### PR TITLE
OCPBUGSM-21366 Support comma-separated NTP sources list

### DIFF
--- a/src/components/clusterConfiguration/AdvancedNetworkFields.tsx
+++ b/src/components/clusterConfiguration/AdvancedNetworkFields.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { TextInputTypes } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
-import { InputField } from '../ui/formik';
+import { InputField, TextAreaField } from '../ui/formik';
 import { ClusterConfigurationValues } from '../../types/clusters';
 import { Address6 } from 'ip-address';
 import { PREFIX_MAX_RESTRICTION } from '../../config/constants';
+import { trimCommaSeparatedList } from '../ui/formik/utils';
 
 const AdvancedNetworkFields: React.FC = () => {
   const { setFieldValue, values } = useFormikContext<ClusterConfigurationValues>();
@@ -13,6 +14,12 @@ const AdvancedNetworkFields: React.FC = () => {
   const formatClusterNetworkHostPrefix = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (isNaN(parseInt(e.target.value))) {
       setFieldValue('clusterNetworkHostPrefix', clusterNetworkCidrPrefix);
+    }
+  };
+
+  const formatAdditionalNtpSource = () => {
+    if (values.additionalNtpSource) {
+      setFieldValue('additionalNtpSource', trimCommaSeparatedList(values.additionalNtpSource));
     }
   };
 
@@ -46,10 +53,12 @@ const AdvancedNetworkFields: React.FC = () => {
         helperText="The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic."
         isRequired
       />
-      <InputField
+      <TextAreaField
         name="additionalNtpSource"
-        label="Additional NTP Source"
-        helperText="IP or domain name of the NTP pool or server. Additional NTP source is added to all hosts to ensure all hosts clocks are synchronized with a valid NTP server."
+        label="Additional NTP Sources"
+        helperText="A comma separated list of IP or domain names of the NTP pools or servers. Additional NTP sources are added to all hosts to ensure all hosts clocks are synchronized with a valid NTP server."
+        onBlur={formatAdditionalNtpSource}
+        spellCheck={false}
       />
     </>
   );

--- a/src/components/ui/formik/types.ts
+++ b/src/components/ui/formik/types.ts
@@ -48,6 +48,7 @@ export interface TextAreaFieldProps extends FieldProps {
   placeholder?: string;
   onChange?: (event: React.FormEvent<HTMLTextAreaElement>) => void;
   onBlur?: () => void;
+  spellCheck?: boolean;
 }
 
 export interface UploadFieldProps extends FieldProps {

--- a/src/components/ui/formik/validationSchemas.ts
+++ b/src/components/ui/formik/validationSchemas.ts
@@ -259,17 +259,21 @@ export const noProxyValidationSchema = Yup.string().test(
 
 export const ntpSourceValidationSchema = Yup.string().test(
   'ntp-source-validation',
-  'Provide a valid DNS or IP address.',
+  'Provide a comma separated list of valid DNS names or IP addresses.',
   (value: string) => {
     if (!value) {
       return true;
     }
-    if (value.match(DNS_NAME_REGEX)) {
-      return true;
-    }
-    if (value.match(IP_ADDRESS_REGEX)) {
-      return true;
-    }
-    return false;
+    return trimCommaSeparatedList(value)
+      .split(',')
+      .every((item) => {
+        if (item.match(DNS_NAME_REGEX)) {
+          return true;
+        }
+        if (item.match(IP_ADDRESS_REGEX)) {
+          return true;
+        }
+        return false;
+      });
   },
 );

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -186,7 +186,7 @@ export const HOST_VALIDATION_FAILURE_HINTS: { [key in HostValidationId]: string 
 };
 
 export const CLUSTER_DEFAULTS = {
-  additionalNtpSource: '0.rhel.pool.ntp.org',
+  additionalNtpSource: undefined,
 };
 
 export const CLUSTER_DEFAULT_NETWORK_SETTINGS_IPV4 = {


### PR DESCRIPTION
Depends on https://github.com/openshift/assisted-service/pull/801

- Add spellCheck prop to TextareaField
- Set additionalNtpSource default to undefined to match the backend