### PR TITLE
Add AssistedUILibVersion component

### DIFF
--- a/src/components/AddBareMetalHosts/BareMetalHostsClusterDetailTab.tsx
+++ b/src/components/AddBareMetalHosts/BareMetalHostsClusterDetailTab.tsx
@@ -5,7 +5,7 @@ import { OcmClusterType } from './types';
 import { AddHostsClusterCreateParams, Cluster, getCluster, handleApiError } from '../../api';
 import { getOpenshiftClusterId } from './utils';
 import { usePullSecretFetch } from '../fetching/pullSecret';
-import { ErrorState, LoadingState } from '../ui';
+import { AssistedUILibVersion, ErrorState, LoadingState } from '../ui';
 import { addHostsClusters } from '../../api/addHostsClusters';
 import { AlertsContextProvider } from '../AlertsContextProvider';
 import { POLLING_INTERVAL } from '../../config';
@@ -14,11 +14,17 @@ import { AddBareMetalHostsContextProvider } from './AddBareMetalHostsContext';
 
 type OpenModalType = (modalName: string, cluster?: OcmClusterType) => void;
 
-export const BareMetalHostsClusterDetailTab: React.FC<{
+type BareMetalHostsClusterDetailTabProps = {
   cluster?: OcmClusterType;
   isVisible: boolean;
   openModal?: OpenModalType;
-}> = ({ cluster, isVisible, openModal }) => {
+};
+
+const BareMetalHostsClusterDetailTabContent: React.FC<BareMetalHostsClusterDetailTabProps> = ({
+  cluster,
+  isVisible,
+  openModal,
+}) => {
   const [error, setError] = React.useState<ReactNode>();
   const [day2Cluster, setDay2Cluster] = React.useState<Cluster | null>();
   const pullSecret = usePullSecretFetch();
@@ -222,3 +228,11 @@ export const BareMetalHostsClusterDetailTab: React.FC<{
     </AlertsContextProvider>
   );
 };
+
+export const BareMetalHostsClusterDetailTab: React.FC<BareMetalHostsClusterDetailTabProps> = (
+  props,
+) => (
+  <AssistedUILibVersion>
+    <BareMetalHostsClusterDetailTabContent {...props} />
+  </AssistedUILibVersion>
+);

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -5,6 +5,7 @@ import { Clusters, ClusterPage, NewClusterPage } from './clusters';
 import { store } from '../store';
 import { isSingleClusterMode, routeBasePath } from '../config/constants';
 import SingleCluster from './SingleCluster';
+import { AssistedUILibVersion } from './ui';
 
 export const AssistedUiRouter: React.FC = () => (
   <Provider store={store}>
@@ -12,20 +13,24 @@ export const AssistedUiRouter: React.FC = () => (
   </Provider>
 );
 
-export const Router: React.FC = ({ children }) =>
-  isSingleClusterMode() ? (
-    <Switch>
-      <Route path={`${routeBasePath}/clusters/:clusterId`} component={ClusterPage} />
-      <Route path={`${routeBasePath}/clusters`} component={SingleCluster} />
-      {children}
-      <Redirect to={`${routeBasePath}/clusters`} />
-    </Switch>
-  ) : (
-    <Switch>
-      <Route path={`${routeBasePath}/clusters/~new`} component={NewClusterPage} />
-      <Route path={`${routeBasePath}/clusters/:clusterId`} component={ClusterPage} />
-      <Route path={`${routeBasePath}/clusters`} component={Clusters} />
-      {children}
-      <Redirect to={`${routeBasePath}/clusters`} />
-    </Switch>
-  );
+export const Router: React.FC = ({ children }) => (
+  <>
+    <AssistedUILibVersion />
+    {isSingleClusterMode() ? (
+      <Switch>
+        <Route path={`${routeBasePath}/clusters/:clusterId`} component={ClusterPage} />
+        <Route path={`${routeBasePath}/clusters`} component={SingleCluster} />
+        {children}
+        <Redirect to={`${routeBasePath}/clusters`} />
+      </Switch>
+    ) : (
+      <Switch>
+        <Route path={`${routeBasePath}/clusters/~new`} component={NewClusterPage} />
+        <Route path={`${routeBasePath}/clusters/:clusterId`} component={ClusterPage} />
+        <Route path={`${routeBasePath}/clusters`} component={Clusters} />
+        {children}
+        <Redirect to={`${routeBasePath}/clusters`} />
+      </Switch>
+    )}
+  </>
+);

--- a/src/components/ui/AssistedUILibVersion.tsx
+++ b/src/components/ui/AssistedUILibVersion.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { getAssistedUiLibVersion } from '../../config';
+
+export const AssistedUILibVersion: React.FC = ({ children }) => (
+  <>
+    {children}
+    <div data-test-id="assisted-ui-lib-version" hidden>
+      {getAssistedUiLibVersion()}
+    </div>
+  </>
+);

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -3,6 +3,7 @@ export * from './utils';
 export * from './formik';
 export * from './Toolbar';
 export * from './DetailList';
+export * from './AssistedUILibVersion';
 
 export { default as PageSection } from './PageSection';
 export { default as ExternalLink } from './ExternalLink';


### PR DESCRIPTION
The library version is stored in the DOM:

```
<div data-test-id="assisted-ui-lib-version" hidden="">1.5.2-1</div>
```

Can be used by Cypress CI for better reporting.