### PR TITLE
MGMT-3487 - Use IPv6 short form in subnet selection dropdown

### DIFF
--- a/src/components/clusterConfiguration/utils.ts
+++ b/src/components/clusterConfiguration/utils.ts
@@ -25,7 +25,7 @@ const getHumanizedSubnet = (subnet: Address6 | Address4 | null) => {
   if (subnet) {
     const subnetStart = subnet.startAddress().correctForm();
     const subnetEnd = subnet.endAddress().correctForm();
-    return `${subnet.address} (${subnetStart}-${subnetEnd})`;
+    return `${subnet.address} (${subnetStart} - ${subnetEnd})`;
   }
 
   return '';

--- a/src/components/clusterConfiguration/utils.ts
+++ b/src/components/clusterConfiguration/utils.ts
@@ -21,10 +21,15 @@ export const getSubnet = (cidr: string): Address6 | Address4 | null => {
   }
 };
 
-const getHumanizedSubnet = (subnet: Address6 | Address4 | null) =>
-  subnet
-    ? `${subnet.address} (${subnet.startAddress().address}-${subnet.endAddress().address})`
-    : '';
+const getHumanizedSubnet = (subnet: Address6 | Address4 | null) => {
+  if (subnet) {
+    const subnetStart = subnet.startAddress().correctForm();
+    const subnetEnd = subnet.endAddress().correctForm();
+    return `${subnet.address} (${subnetStart}-${subnetEnd})`;
+  }
+
+  return '';
+};
 
 export const getHostSubnets = (cluster: Cluster): HostSubnets => {
   const hostnameMap: { [id: string]: string } =


### PR DESCRIPTION
This is just a suggestion, feel free to close the PR / make changes.

Instead of:
![image](https://user-images.githubusercontent.com/10882062/103485811-bf848900-4e01-11eb-9025-815d65465acc.png)

Show `fe70::/64 (fe80::-fe80::ffff:ffff:ffff:ffff)`

The subnet, along with the full start and end address, look rather awkward inside the dropdown because they form a very long string.
