### PR TITLE
MGMT-3382: Retrieve OCP versions from API

### DIFF
--- a/src/api/versions.ts
+++ b/src/api/versions.ts
@@ -1,5 +1,8 @@
 import { AxiosPromise } from 'axios';
 import { client } from './axiosClient';
-import { ListVersions } from './types';
+import { ListVersions, OpenshiftVersions } from './types';
 
 export const getVersions = (): AxiosPromise<ListVersions> => client.get('/component_versions');
+
+export const getOpenshiftVersions = (): AxiosPromise<OpenshiftVersions> =>
+  client.get('/openshift_versions');

--- a/src/components/AddBareMetalHosts/BareMetalHostsClusterDetailTab.tsx
+++ b/src/components/AddBareMetalHosts/BareMetalHostsClusterDetailTab.tsx
@@ -1,6 +1,5 @@
 import React, { ReactNode } from 'react';
 import { Button, ButtonVariant, EmptyStateVariant } from '@patternfly/react-core';
-import { normalizeClusterVersion } from '../../config';
 import { OcmClusterType } from './types';
 import { AddHostsClusterCreateParams, Cluster, getCluster, handleApiError } from '../../api';
 import { getOpenshiftClusterId } from './utils';
@@ -9,6 +8,10 @@ import { AssistedUILibVersion, ErrorState, LoadingState } from '../ui';
 import { addHostsClusters } from '../../api/addHostsClusters';
 import { AlertsContextProvider } from '../AlertsContextProvider';
 import { POLLING_INTERVAL } from '../../config';
+import {
+  OpenshiftVersionsContext,
+  OpenshiftVersionsContextProvider,
+} from '../OpenshiftVersionsContextProvider';
 import AddBareMetalHosts from './AddBareMetalHosts';
 import { AddBareMetalHostsContextProvider } from './AddBareMetalHostsContext';
 
@@ -28,6 +31,7 @@ const BareMetalHostsClusterDetailTabContent: React.FC<BareMetalHostsClusterDetai
   const [error, setError] = React.useState<ReactNode>();
   const [day2Cluster, setDay2Cluster] = React.useState<Cluster | null>();
   const pullSecret = usePullSecretFetch();
+  const { normalizeClusterVersion } = React.useContext(OpenshiftVersionsContext);
 
   const TryAgain = React.useCallback(
     () => (
@@ -180,7 +184,7 @@ const BareMetalHostsClusterDetailTabContent: React.FC<BareMetalHostsClusterDetai
 
       doItAsync();
     }
-  }, [cluster, openModal, pullSecret, day2Cluster, isVisible]);
+  }, [cluster, openModal, pullSecret, day2Cluster, isVisible, normalizeClusterVersion]);
 
   React.useEffect(() => {
     if (day2Cluster) {
@@ -221,18 +225,21 @@ const BareMetalHostsClusterDetailTabContent: React.FC<BareMetalHostsClusterDetai
   }
 
   return (
-    <AlertsContextProvider>
-      <AddBareMetalHostsContextProvider cluster={day2Cluster} ocpConsoleUrl={cluster?.console?.url}>
-        <AddBareMetalHosts />
-      </AddBareMetalHostsContextProvider>
-    </AlertsContextProvider>
+    <AddBareMetalHostsContextProvider cluster={day2Cluster} ocpConsoleUrl={cluster?.console?.url}>
+      <AddBareMetalHosts />
+    </AddBareMetalHostsContextProvider>
   );
 };
 
 export const BareMetalHostsClusterDetailTab: React.FC<BareMetalHostsClusterDetailTabProps> = (
   props,
 ) => (
-  <AssistedUILibVersion>
-    <BareMetalHostsClusterDetailTabContent {...props} />
-  </AssistedUILibVersion>
+  <>
+    <AssistedUILibVersion />
+    <AlertsContextProvider>
+      <OpenshiftVersionsContextProvider>
+        <BareMetalHostsClusterDetailTabContent {...props} />
+      </OpenshiftVersionsContextProvider>
+    </AlertsContextProvider>
+  </>
 );

--- a/src/components/OpenshiftVersionsContextProvider.tsx
+++ b/src/components/OpenshiftVersionsContextProvider.tsx
@@ -36,8 +36,7 @@ export const OpenshiftVersionsContextProvider: React.FC = ({ children }) => {
           .sort()
           .map((key) => ({
             label: `OpenShift ${data[key].displayName || key}`,
-            // TODO(mlibra): Nasty hotfix to workaround bug on backend. Expected value: '4.6', received value: '4_6'
-            value: key.replace('_', '.'),
+            value: key,
             supportLevel: data[key].supportLevel,
           }));
         setVersions(versions);

--- a/src/components/OpenshiftVersionsContextProvider.tsx
+++ b/src/components/OpenshiftVersionsContextProvider.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { AddHostsClusterCreateParams, getOpenshiftVersions, handleApiError } from '../api';
+import { DEFAULT_OPENSHIFT_VERSION } from '../config';
+import { OpenshiftVersionOptionType } from '../types/versions';
+
+const generateBugzillaLink = (version: string) =>
+  `https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform&Component=OpenShift%20Container%20Platform&component=assisted-installer&version=${version}`;
+
+export type OpenshiftVersionsContextType = {
+  versions: OpenshiftVersionOptionType[];
+
+  // Assumption: AddHostsClusterCreateParams['openshiftVersion'] is a subset of OpenshiftVersionOptionType['value'] and contains the latest supported versions
+  // In case this assumption is wrong, let's pass the "wrong" value to the Day 2 API and let it fail on server validation.
+  getDefaultVersion: () => AddHostsClusterCreateParams['openshiftVersion'];
+  normalizeClusterVersion: (version?: string) => AddHostsClusterCreateParams['openshiftVersion'];
+  getBugzillaLink: (version?: OpenshiftVersionOptionType['value']) => string;
+};
+
+export const OpenshiftVersionsContext = React.createContext<OpenshiftVersionsContextType>({
+  versions: [],
+  getDefaultVersion: () => '',
+  normalizeClusterVersion: () => '',
+  getBugzillaLink: () => generateBugzillaLink(DEFAULT_OPENSHIFT_VERSION.value),
+});
+
+export const OpenshiftVersionsContextProvider: React.FC = ({ children }) => {
+  const [versions, setVersions] = React.useState<OpenshiftVersionOptionType[]>([
+    // TODO(mlibra): provide empty array when /openshift_version API endpoint is deployed to production
+    DEFAULT_OPENSHIFT_VERSION,
+  ]);
+  React.useEffect(() => {
+    const doAsync = async () => {
+      try {
+        const { data } = await getOpenshiftVersions();
+        const versions: OpenshiftVersionOptionType[] = Object.getOwnPropertyNames(data)
+          .sort()
+          .map((key) => ({
+            label: `OpenShift ${data[key].displayName || key}`,
+            // TODO(mlibra): Nasty hotfix to workaround bug on backend. Expected value: '4.6', received value: '4_6'
+            value: key.replace('_', '.'),
+            supportLevel: data[key].supportLevel,
+          }));
+        setVersions(versions);
+      } catch (e) {
+        return handleApiError(e);
+        // keep using the default hardcoded versions
+      }
+    };
+    doAsync();
+  }, [setVersions]);
+
+  const normalizeClusterVersion = React.useCallback(
+    (version = ''): string =>
+      versions.map((obj) => obj.value).find((normalized) => version.startsWith(normalized)) ||
+      version,
+    [versions],
+  );
+
+  const getDefaultVersion = React.useCallback(
+    () => versions[0]?.value || DEFAULT_OPENSHIFT_VERSION.value,
+    [versions],
+  );
+
+  const getBugzillaLink = React.useCallback(
+    (version: OpenshiftVersionOptionType['value'] = getDefaultVersion()) =>
+      generateBugzillaLink(version),
+    [getDefaultVersion],
+  );
+
+  return (
+    <OpenshiftVersionsContext.Provider
+      value={{ versions, normalizeClusterVersion, getBugzillaLink, getDefaultVersion }}
+    >
+      {children}
+    </OpenshiftVersionsContext.Provider>
+  );
+};

--- a/src/components/OpenshiftVersionsContextProvider.tsx
+++ b/src/components/OpenshiftVersionsContextProvider.tsx
@@ -3,9 +3,6 @@ import { AddHostsClusterCreateParams, getOpenshiftVersions, handleApiError } fro
 import { DEFAULT_OPENSHIFT_VERSION } from '../config';
 import { OpenshiftVersionOptionType } from '../types/versions';
 
-const generateBugzillaLink = (version: string) =>
-  `https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform&Component=OpenShift%20Container%20Platform&component=assisted-installer&version=${version}`;
-
 export type OpenshiftVersionsContextType = {
   versions: OpenshiftVersionOptionType[];
 
@@ -13,14 +10,12 @@ export type OpenshiftVersionsContextType = {
   // In case this assumption is wrong, let's pass the "wrong" value to the Day 2 API and let it fail on server validation.
   getDefaultVersion: () => AddHostsClusterCreateParams['openshiftVersion'];
   normalizeClusterVersion: (version?: string) => AddHostsClusterCreateParams['openshiftVersion'];
-  getBugzillaLink: (version?: OpenshiftVersionOptionType['value']) => string;
 };
 
 export const OpenshiftVersionsContext = React.createContext<OpenshiftVersionsContextType>({
   versions: [],
   getDefaultVersion: () => '',
   normalizeClusterVersion: () => '',
-  getBugzillaLink: () => generateBugzillaLink(DEFAULT_OPENSHIFT_VERSION.value),
 });
 
 export const OpenshiftVersionsContextProvider: React.FC = ({ children }) => {
@@ -32,7 +27,7 @@ export const OpenshiftVersionsContextProvider: React.FC = ({ children }) => {
     const doAsync = async () => {
       try {
         const { data } = await getOpenshiftVersions();
-        const versions: OpenshiftVersionOptionType[] = Object.getOwnPropertyNames(data)
+        const versions: OpenshiftVersionOptionType[] = Object.keys(data)
           .sort()
           .map((key) => ({
             label: `OpenShift ${data[key].displayName || key}`,
@@ -60,15 +55,9 @@ export const OpenshiftVersionsContextProvider: React.FC = ({ children }) => {
     [versions],
   );
 
-  const getBugzillaLink = React.useCallback(
-    (version: OpenshiftVersionOptionType['value'] = getDefaultVersion()) =>
-      generateBugzillaLink(version),
-    [getDefaultVersion],
-  );
-
   return (
     <OpenshiftVersionsContext.Provider
-      value={{ versions, normalizeClusterVersion, getBugzillaLink, getDefaultVersion }}
+      value={{ versions, normalizeClusterVersion, getDefaultVersion }}
     >
       {children}
     </OpenshiftVersionsContext.Provider>

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -6,6 +6,7 @@ import { store } from '../store';
 import { isSingleClusterMode, routeBasePath } from '../config/constants';
 import SingleCluster from './SingleCluster';
 import { AssistedUILibVersion } from './ui';
+import { OpenshiftVersionsContextProvider } from './OpenshiftVersionsContextProvider';
 
 export const AssistedUiRouter: React.FC = () => (
   <Provider store={store}>
@@ -16,21 +17,23 @@ export const AssistedUiRouter: React.FC = () => (
 export const Router: React.FC = ({ children }) => (
   <>
     <AssistedUILibVersion />
-    {isSingleClusterMode() ? (
-      <Switch>
-        <Route path={`${routeBasePath}/clusters/:clusterId`} component={ClusterPage} />
-        <Route path={`${routeBasePath}/clusters`} component={SingleCluster} />
-        {children}
-        <Redirect to={`${routeBasePath}/clusters`} />
-      </Switch>
-    ) : (
-      <Switch>
-        <Route path={`${routeBasePath}/clusters/~new`} component={NewClusterPage} />
-        <Route path={`${routeBasePath}/clusters/:clusterId`} component={ClusterPage} />
-        <Route path={`${routeBasePath}/clusters`} component={Clusters} />
-        {children}
-        <Redirect to={`${routeBasePath}/clusters`} />
-      </Switch>
-    )}
+    <OpenshiftVersionsContextProvider>
+      {isSingleClusterMode() ? (
+        <Switch>
+          <Route path={`${routeBasePath}/clusters/:clusterId`} component={ClusterPage} />
+          <Route path={`${routeBasePath}/clusters`} component={SingleCluster} />
+          {children}
+          <Redirect to={`${routeBasePath}/clusters`} />
+        </Switch>
+      ) : (
+        <Switch>
+          <Route path={`${routeBasePath}/clusters/~new`} component={NewClusterPage} />
+          <Route path={`${routeBasePath}/clusters/:clusterId`} component={ClusterPage} />
+          <Route path={`${routeBasePath}/clusters`} component={Clusters} />
+          {children}
+          <Redirect to={`${routeBasePath}/clusters`} />
+        </Switch>
+      )}
+    </OpenshiftVersionsContextProvider>
   </>
 );

--- a/src/components/clusterDetail/ClusterInstallationError.tsx
+++ b/src/components/clusterDetail/ClusterInstallationError.tsx
@@ -11,7 +11,7 @@ import { Cluster } from '../../api/types';
 import { toSentence } from '../ui/table/utils';
 import { AlertsContext } from '../AlertsContextProvider';
 import { canDownloadClusterLogs } from '../hosts/utils';
-import { OpenshiftVersionsContext } from '../OpenshiftVersionsContextProvider';
+import { getBugzillaLink } from '../../config';
 import { downloadClusterInstallationLogs } from './utils';
 
 type ClusterInstallationErrorProps = {
@@ -28,7 +28,6 @@ const ClusterInstallationError: React.FC<ClusterInstallationErrorProps> = ({
   setResetClusterModalOpen,
 }) => {
   const { addAlert } = React.useContext(AlertsContext);
-  const { getBugzillaLink } = React.useContext(OpenshiftVersionsContext);
 
   return (
     <GridItem>

--- a/src/components/clusterDetail/ClusterInstallationError.tsx
+++ b/src/components/clusterDetail/ClusterInstallationError.tsx
@@ -9,10 +9,10 @@ import {
 } from '@patternfly/react-core';
 import { Cluster } from '../../api/types';
 import { toSentence } from '../ui/table/utils';
-import { getBugzillaLink } from '../../config';
 import { AlertsContext } from '../AlertsContextProvider';
-import { downloadClusterInstallationLogs } from './utils';
 import { canDownloadClusterLogs } from '../hosts/utils';
+import { OpenshiftVersionsContext } from '../OpenshiftVersionsContextProvider';
+import { downloadClusterInstallationLogs } from './utils';
 
 type ClusterInstallationErrorProps = {
   cluster: Cluster;
@@ -28,6 +28,7 @@ const ClusterInstallationError: React.FC<ClusterInstallationErrorProps> = ({
   setResetClusterModalOpen,
 }) => {
   const { addAlert } = React.useContext(AlertsContext);
+  const { getBugzillaLink } = React.useContext(OpenshiftVersionsContext);
 
   return (
     <GridItem>

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -18,6 +18,9 @@ export const DEFAULT_OPENSHIFT_VERSION: OpenshiftVersionOptionType = {
   supportLevel: 'production',
 };
 
+export const getBugzillaLink = (version: string = DEFAULT_OPENSHIFT_VERSION.value) =>
+  `https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform&Component=OpenShift%20Container%20Platform&component=assisted-installer&version=${version}`;
+
 export const FEEDBACK_FORM_LINK =
   'https://docs.google.com/forms/d/e/1FAIpQLSfg9M8wRW4m_HkWeAl6KpB5dTcMu8iI3iJ29GlLfZpF2hnjng/viewform';
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,44 +1,25 @@
 import * as packageJson from '../../package.json';
-import {
-  ClusterCreateParams,
-  Cluster,
-  Host,
-  Event,
-  AddHostsClusterCreateParams,
-  HostValidationId,
-} from '../api/types';
+import { Cluster, Host, Event, HostValidationId } from '../api/types';
 import { ValidationsInfo, HostRole } from '../types/hosts';
+import { OpenshiftVersionOptionType } from '../types/versions';
 
 export let routeBasePath = '';
 export const setRouteBasePath = (basePath: string) => {
   routeBasePath = basePath;
 };
 
-type OpenshiftVersionOptionType = {
-  label: string;
-  value: ClusterCreateParams['openshiftVersion'];
-};
-
-const OPENSHIFT_VERSIONS_ADDHOST: AddHostsClusterCreateParams['openshiftVersion'][] = ['4.6'];
-export const OPENSHIFT_VERSION_OPTIONS: OpenshiftVersionOptionType[] = [
-  { label: 'OpenShift 4.6', value: '4.6' },
-];
-export const DEFAULT_OPENSHIFT_VERSION: OpenshiftVersionOptionType['value'] =
-  OPENSHIFT_VERSION_OPTIONS[0].value;
-
-export const normalizeClusterVersion = (version?: string) =>
-  version && OPENSHIFT_VERSIONS_ADDHOST.find((normalized) => version.startsWith(normalized));
-
 export const CLUSTER_MANAGER_SITE_LINK = 'https://cloud.redhat.com/openshift/install/pull-secret';
 export const PULL_SECRET_INFO_LINK = CLUSTER_MANAGER_SITE_LINK;
 
+// Used as a default before effective values are retrieved from the API
+export const DEFAULT_OPENSHIFT_VERSION: OpenshiftVersionOptionType = {
+  label: 'OpenShift 4.6',
+  value: '4.6',
+  supportLevel: 'production',
+};
+
 export const FEEDBACK_FORM_LINK =
   'https://docs.google.com/forms/d/e/1FAIpQLSfg9M8wRW4m_HkWeAl6KpB5dTcMu8iI3iJ29GlLfZpF2hnjng/viewform';
-
-export const getBugzillaLink = (
-  version: OpenshiftVersionOptionType['value'] = DEFAULT_OPENSHIFT_VERSION,
-) =>
-  `https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform&Component=OpenShift%20Container%20Platform&component=assisted-installer&version=${version}`;
 
 export const getOcpConsoleNodesPage = (ocpConsoleUrl: string) =>
   `${ocpConsoleUrl}/k8s/cluster/nodes`;

--- a/src/types/versions.ts
+++ b/src/types/versions.ts
@@ -1,0 +1,10 @@
+import { ClusterCreateParams, OpenshiftVersion } from '../api';
+
+export type OpenshiftVersionOptionType = {
+  label: string;
+
+  // effectively OpenshiftVersions key (means :string)
+  value: ClusterCreateParams['openshiftVersion'];
+
+  supportLevel: OpenshiftVersion['supportLevel'];
+};


### PR DESCRIPTION
Depends on:
- [x] https://github.com/openshift/assisted-service/pull/869
- [x] https://github.com/openshift-assisted/assisted-ui-lib/pull/398 Api update for `/openshift_versions` endpoint