### PR TITLE
BZ 1910402:  missing "Hardware Type" value in physical hosts

### DIFF
--- a/src/components/hosts/HostRowDetail.tsx
+++ b/src/components/hosts/HostRowDetail.tsx
@@ -165,7 +165,7 @@ export const HostDetail: React.FC<HostDetailProps> = ({
   }
   bmcAddress = bmcAddress || DASH;
 
-  const virtualText = getHardwareTypeText(inventory);
+  const hardwareType = getHardwareTypeText(inventory);
 
   return (
     <Grid hasGutter>
@@ -183,7 +183,7 @@ export const HostDetail: React.FC<HostDetailProps> = ({
         <DetailItem title="CPU architecture" value={inventory.cpu?.architecture || DASH} />
       </SectionColumn>
       <SectionColumn>
-        <DetailItem title="Hardware type" value={virtualText} />
+        <DetailItem title="Hardware type" value={hardwareType} />
         <DetailItem title="BMC address" value={bmcAddress} />
         <DetailItem title="Boot mode" value={inventory.boot?.currentBootMode || DASH} />
         {inventory.boot?.pxeInterface && (

--- a/src/components/hosts/HostRowDetail.tsx
+++ b/src/components/hosts/HostRowDetail.tsx
@@ -11,7 +11,7 @@ import { ValidationsInfo } from '../../types/hosts';
 import NtpValidationStatus from './NtpValidationStatus';
 import DiskLimitations from './DiskLimitations';
 import DiskRole from './DiskRole';
-import { canEditDisks } from './utils';
+import { canEditDisks, getHardwareTypeText } from './utils';
 
 type HostDetailProps = {
   cluster: Cluster;
@@ -165,12 +165,7 @@ export const HostDetail: React.FC<HostDetailProps> = ({
   }
   bmcAddress = bmcAddress || DASH;
 
-  let virtualText = DASH;
-  if (inventory.systemVendor?.virtual) {
-    virtualText = 'Virtual machine';
-  } else if (inventory.systemVendor?.virtual !== undefined) {
-    virtualText = 'Bare metal';
-  }
+  const virtualText = getHardwareTypeText(inventory);
 
   return (
     <Grid hasGutter>

--- a/src/components/hosts/utils.ts
+++ b/src/components/hosts/utils.ts
@@ -9,6 +9,7 @@ import {
   getPresignedFileUrl,
 } from '../../api';
 import { AlertsContextType } from '../AlertsContextProvider';
+import { DASH } from '../constants';
 
 export const canEnable = (clusterStatus: Cluster['status'], status: Host['status']) =>
   ['pending-for-input', 'insufficient', 'ready', 'adding-hosts'].includes(clusterStatus) &&
@@ -118,3 +119,18 @@ export const hasKnownHost = (cluster: Cluster) =>
 
 export const getHostname = (host: Host, inventory: Inventory) =>
   host.requestedHostname || inventory.hostname;
+
+export const getHardwareTypeText = (inventory: Inventory) => {
+  let hardwareTypeText = DASH;
+  const { systemVendor } = inventory;
+
+  if (systemVendor !== undefined) {
+    if (systemVendor.virtual) {
+      hardwareTypeText = 'Virtual machine';
+    } else {
+      hardwareTypeText = 'Bare metal';
+    }
+  }
+
+  return hardwareTypeText;
+};


### PR DESCRIPTION
Addresses an issue where the "Hardware Type" value in physical hosts was missing.
