### PR TITLE
Bug 1919626 - [Assisted-4.7] [UI] NTP should not be included in Advanced Networking description

### DIFF
--- a/src/components/clusterConfiguration/NetworkConfiguration.tsx
+++ b/src/components/clusterConfiguration/NetworkConfiguration.tsx
@@ -87,7 +87,7 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
       <Checkbox
         id="useAdvancedNetworking"
         label="Use Advanced Networking"
-        description="Configure advanced networking properties (CIDR ranges, NTP)."
+        description="Configure advanced networking properties (e.g. CIDR ranges)."
         isChecked={isAdvanced}
         onChange={toggleAdvConfiguration}
       />


### PR DESCRIPTION
- Removes NTP mention from Advanced Networking section
