### PR TITLE
MGMT-2632 Adds missing warning

### DIFF
--- a/src/components/clusterDetail/ClusterDetail.tsx
+++ b/src/components/clusterDetail/ClusterDetail.tsx
@@ -88,9 +88,9 @@ const ClusterDetail: React.FC<ClusterDetailProps> = ({
           <GridItem>
             <ClusterProgress cluster={cluster} />
           </GridItem>
-          {['installed', 'installing', 'finalizing'].includes(cluster.status) && (
-            <FailedHostsWarning cluster={cluster} />
-          )}
+          {['installed', 'installing', 'installing-pending-user-action', 'finalizing'].includes(
+            cluster.status,
+          ) && <FailedHostsWarning cluster={cluster} />}
           {cluster.status === 'error' && (
             <ClusterInstallationError
               cluster={cluster}


### PR DESCRIPTION
- Adds a missing warning when the cluster is in `installing-pending-user-action` (e. g. wrong boot order).
