### PR TITLE
MGMT-3234 Convert NewClusterPage to use wizard

### DIFF
--- a/src/components/clusterWizard/ClusterDetails.tsx
+++ b/src/components/clusterWizard/ClusterDetails.tsx
@@ -2,13 +2,15 @@ import React from 'react';
 import * as Yup from 'yup';
 import _ from 'lodash';
 import { Formik, FormikHelpers } from 'formik';
-import { Cluster, ClusterUpdateParams, ManagedDomain } from '../../api/types';
+import { Cluster, ClusterCreateParams, ClusterUpdateParams, ManagedDomain } from '../../api/types';
 import ClusterWizardStep from './ClusterWizardStep';
 import {
   dnsNameValidationSchema,
   nameValidationSchema,
   validJSONSchema,
 } from '../ui/formik/validationSchemas';
+import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import {
   ButtonVariant,
   Form,
@@ -30,8 +32,7 @@ import { useHistory } from 'react-router-dom';
 import LoadingState from '../ui/uiState/LoadingState';
 import { usePullSecretFetch } from '../fetching/pullSecret';
 import { captureException } from '../../sentry';
-import { ClusterDetailsValues } from '../../types/clusters';
-import { getClusters, patchCluster } from '../../api/clusters';
+import { getClusters, patchCluster, postCluster } from '../../api/clusters';
 import { getErrorMessage, handleApiError } from '../../api/utils';
 import { updateCluster } from '../../features/clusters/currentClusterSlice';
 import { useDispatch } from 'react-redux';
@@ -42,76 +43,95 @@ import CheckboxField from '../ui/formik/CheckboxField';
 import { getManagedDomains } from '../../api/domains';
 import ToolbarText from '../ui/Toolbar/ToolbarText';
 import { canNextClusterDetails } from './wizardTransition';
+import { useOpenshiftVersions } from '../fetching/openshiftVersions';
+import { OpenshiftVersionOptionType } from '../../types/versions';
+import SingleNodeCheckbox from '../ui/formik/SingleNodeCheckbox';
+import { useFeature } from '../../features/featureGate';
 
 type ClusterDetailsFormProps = {
-  cluster: Cluster;
+  cluster?: Cluster;
   pullSecret: string;
   managedDomains: ManagedDomain[];
+  versions: OpenshiftVersionOptionType[];
 };
 
-const ClusterDetailsForm: React.FC<ClusterDetailsFormProps> = ({
-  cluster,
-  pullSecret,
-  managedDomains,
-}) => {
-  const { alerts, addAlert, clearAlerts } = React.useContext(AlertsContext);
-  const { setCurrentStepId } = React.useContext(ClusterWizardContext);
-  const history = useHistory();
-  const dispatch = useDispatch();
-  const nameInputRef = React.useRef<HTMLInputElement>();
-  React.useEffect(() => {
-    nameInputRef.current?.focus();
-  }, []);
-  const { name, openshiftVersion = '', pullSecretSet, baseDnsDomain } = cluster;
+type ClusterDetailsValues = {
+  name: string;
+  highAvailabilityMode: 'Full' | 'None';
+  openshiftVersion: string;
+  pullSecret: string;
+  baseDnsDomain: string;
+  useRedHatDnsService: boolean;
+};
 
-  const initialValues = {
+const getInitialValues = (props: ClusterDetailsFormProps): ClusterDetailsValues => {
+  const { cluster, pullSecret, managedDomains, versions } = props;
+  const {
+    name = '',
+    highAvailabilityMode = 'Full',
+    baseDnsDomain = '',
+    openshiftVersion = versions[0]?.value || '',
+  } = cluster || {};
+  return {
     name,
+    highAvailabilityMode,
     openshiftVersion,
     pullSecret,
     baseDnsDomain,
     useRedHatDnsService:
       !!baseDnsDomain && managedDomains.map((d) => d.domain).includes(baseDnsDomain),
   };
+};
 
-  const validationSchema = React.useCallback(
-    () =>
-      Yup.object({
-        name: nameValidationSchema,
-        openshiftVersion: Yup.string().required('Required'),
-        pullSecret: pullSecretSet
-          ? validJSONSchema
-          : validJSONSchema.required('Pull secret must be provided.'),
-        baseDnsDomain: dnsNameValidationSchema(initialValues.baseDnsDomain),
-      }),
-    [initialValues.baseDnsDomain, pullSecretSet],
-  );
+const getValidationSchema = (cluster?: Cluster) => {
+  if (cluster?.pullSecretSet) {
+    return Yup.object({
+      name: nameValidationSchema,
+      baseDnsDomain: dnsNameValidationSchema.required('Base Domain is required.'),
+    });
+  }
+  return Yup.object({
+    name: nameValidationSchema,
+    pullSecret: validJSONSchema.required('Pull secret must be provided.'),
+    baseDnsDomain: dnsNameValidationSchema.required('Base Domain is required.'),
+  });
+};
 
-  const handleSubmit = async (
-    values: ClusterDetailsValues,
-    formikActions: FormikHelpers<ClusterDetailsValues>,
-  ) => {
-    clearAlerts();
-
-    // async validation for cluster name - run only on submit
-    // TODO(jtomasek): Update this to validate combination of cluster name + dns domain
-    try {
-      const { data: clusters } = await getClusters();
-      const names = clusters.map((c) => c.name).filter((n) => n !== cluster.name);
-      if (names.includes(values.name)) {
-        return formikActions.setFieldError('name', `Name "${values.name}" is already taken.`);
-      }
-    } catch (e) {
-      captureException(e, 'Failed to perform unique cluster name validation.');
+const validateClusterName = async (newName: string, existingClusterName?: string) => {
+  try {
+    const { data: clusters } = await getClusters();
+    const names = clusters.map((c) => c.name).filter((n) => n !== existingClusterName);
+    if (names.includes(newName)) {
+      return `Name "${newName}" is already taken.`;
     }
+  } catch (e) {
+    captureException(e, 'Failed to perform unique cluster name validation.');
+  }
+};
+
+const ClusterDetailsForm: React.FC<ClusterDetailsFormProps> = (props) => {
+  const { cluster, pullSecret, managedDomains, versions } = props;
+  const { alerts, addAlert, clearAlerts } = React.useContext(AlertsContext);
+  const { setCurrentStepId } = React.useContext(ClusterWizardContext);
+  const isSingleNodeOpenshiftEnabled = useFeature('ASSISTED_INSTALLER_SNO_FEATURE');
+  const history = useHistory();
+  const dispatch = useDispatch();
+  const nameInputRef = React.useRef<HTMLInputElement>();
+  React.useEffect(() => {
+    nameInputRef.current?.focus();
+  }, []);
+
+  // TODO(jtomasek): Update this to validate combination of cluster name + dns domain
+  const handleClusterUpdate = async (clusterId: Cluster['id'], values: ClusterDetailsValues) => {
+    const params: ClusterUpdateParams = _.omit(values, [
+      'highAvailabilityMode',
+      'pullSecret',
+      'openshiftVersion',
+      'useRedHatDnsService',
+    ]);
 
     try {
-      const params = _.omit(values, ['useRedHatDnsService']);
-
-      if (pullSecretSet) {
-        delete params.pullSecret;
-      }
-
-      const { data } = await patchCluster(cluster.id, params);
+      const { data } = await patchCluster(clusterId, params);
       dispatch(updateCluster(data));
 
       canNextClusterDetails({ cluster: data }) && setCurrentStepId('baremetal-discovery');
@@ -122,13 +142,50 @@ const ClusterDetailsForm: React.FC<ClusterDetailsFormProps> = ({
     }
   };
 
+  const handleClusterCreate = async (values: ClusterDetailsValues) => {
+    const params: ClusterCreateParams = _.omit(values, ['useRedHatDnsService']);
+
+    try {
+      const { data } = await postCluster(params);
+      history.push(`${routeBasePath}/clusters/${data.id}`);
+    } catch (e) {
+      handleApiError<ClusterCreateParams>(e, () =>
+        addAlert({ title: 'Failed to create new cluster', message: getErrorMessage(e) }),
+      );
+    }
+  };
+
+  const handleSubmit = async (
+    values: ClusterDetailsValues,
+    formikActions: FormikHelpers<ClusterDetailsValues>,
+  ) => {
+    clearAlerts();
+
+    if (cluster) {
+      const clusterNameError = await validateClusterName(values.name, cluster.name);
+      if (clusterNameError) {
+        return formikActions.setFieldError('name', clusterNameError);
+      }
+      await handleClusterUpdate(cluster.id, values);
+    } else {
+      const clusterNameError = await validateClusterName(values.name);
+      if (clusterNameError) {
+        return formikActions.setFieldError('name', clusterNameError);
+      }
+      await handleClusterCreate(values);
+    }
+  };
+
+  const initialValues = getInitialValues(props);
+  const validationSchema = getValidationSchema(cluster);
+
   return (
     <Formik
       initialValues={initialValues}
       validationSchema={validationSchema}
       onSubmit={handleSubmit}
     >
-      {({ submitForm, isSubmitting, isValid, values, setFieldValue }) => {
+      {({ submitForm, isSubmitting, isValid, dirty, values, setFieldValue }) => {
         const { name: clusterName, baseDnsDomain, useRedHatDnsService } = values;
 
         const baseDnsHelperText = (
@@ -144,6 +201,19 @@ const ClusterDetailsForm: React.FC<ClusterDetailsFormProps> = ({
         const toggleRedHatDnsService = (checked: boolean) =>
           setFieldValue('baseDnsDomain', checked ? managedDomains.map((d) => d.domain)[0] : '');
 
+        const getOpenshiftVersionHelperText = (value: string) =>
+          versions.find((version) => version.value === value)?.supportLevel !== 'production' ? (
+            <>
+              <ExclamationTriangleIcon color={warningColor.value} size="sm" />
+              &nbsp;Please note that this version is not production ready.
+            </>
+          ) : null;
+
+        const ocpVersionOptions = versions.map((version) => ({
+          label: version.label,
+          value: version.value,
+        }));
+
         const form = (
           <>
             <Grid hasGutter>
@@ -155,15 +225,18 @@ const ClusterDetailsForm: React.FC<ClusterDetailsFormProps> = ({
               <GridItem span={12} lg={10} xl={9} xl2={7}>
                 <Form id="wizard-cluster-details__form">
                   <InputField ref={nameInputRef} label="Cluster Name" name="name" isRequired />
+                  {!isSingleNodeOpenshiftEnabled && (
+                    <SingleNodeCheckbox name="highAvailabilityMode" isDisabled={!!cluster} />
+                  )}
                   <SelectField
                     label="OpenShift Version"
                     name="openshiftVersion"
-                    options={[{ label: openshiftVersion, value: openshiftVersion }]}
-                    // getHelperText={getOpenshiftVersionHelperText}
-                    isDisabled
+                    options={ocpVersionOptions}
+                    getHelperText={getOpenshiftVersionHelperText}
+                    isDisabled={!!cluster}
                     isRequired
                   />
-                  {(pullSecret || !pullSecretSet) && <PullSecret pullSecret={pullSecret} />}
+                  {!cluster?.pullSecretSet && <PullSecret pullSecret={pullSecret} />}
                   {!!managedDomains.length && (
                     <CheckboxField
                       name="useRedHatDnsService"
@@ -211,7 +284,9 @@ const ClusterDetailsForm: React.FC<ClusterDetailsFormProps> = ({
                 <ToolbarButton
                   name="save"
                   variant={ButtonVariant.primary}
-                  isDisabled={isSubmitting || !isValid}
+                  isDisabled={
+                    cluster ? isSubmitting || !isValid : isSubmitting || !isValid || !dirty
+                  }
                   onClick={submitForm}
                 >
                   Next
@@ -243,7 +318,7 @@ const ClusterDetailsForm: React.FC<ClusterDetailsFormProps> = ({
 };
 
 type ClusterDetailsProps = {
-  cluster: Cluster;
+  cluster?: Cluster;
 };
 
 const ClusterDetails: React.FC<ClusterDetailsProps> = ({ cluster }) => {
@@ -267,7 +342,14 @@ const ClusterDetails: React.FC<ClusterDetailsProps> = ({ cluster }) => {
 
   const pullSecret = usePullSecretFetch();
 
-  if (pullSecret === undefined || !managedDomains) {
+  const { error: errorOCPVersions, loading: loadingOCPVersions, versions } = useOpenshiftVersions();
+
+  React.useEffect(() => errorOCPVersions && addAlert(errorOCPVersions), [
+    errorOCPVersions,
+    addAlert,
+  ]);
+
+  if (pullSecret === undefined || !managedDomains || loadingOCPVersions) {
     return (
       <ClusterWizardStep cluster={cluster}>
         <LoadingState />
@@ -275,7 +357,12 @@ const ClusterDetails: React.FC<ClusterDetailsProps> = ({ cluster }) => {
     );
   }
   return (
-    <ClusterDetailsForm cluster={cluster} pullSecret={pullSecret} managedDomains={managedDomains} />
+    <ClusterDetailsForm
+      cluster={cluster}
+      pullSecret={pullSecret}
+      managedDomains={managedDomains}
+      versions={versions}
+    />
   );
 };
 

--- a/src/components/clusterWizard/ClusterWizardStep.tsx
+++ b/src/components/clusterWizard/ClusterWizardStep.tsx
@@ -14,7 +14,7 @@ import {
 } from './wizardTransition';
 
 type ClusterWizardStepProps = {
-  cluster: Cluster;
+  cluster?: Cluster;
   footer?: React.ReactNode;
 };
 
@@ -57,7 +57,7 @@ const ClusterWizardStep: React.FC<ClusterWizardStepProps> = ({ cluster, footer, 
         key="cluster-details"
         content="Cluster Details"
         isCurrent={currentStepId === 'cluster-details'}
-        isValid={() => canNextClusterDetails({ cluster })}
+        isValid={() => !cluster || canNextClusterDetails({ cluster })}
         isDisabled={false}
         step={0}
         onNavItemClick={() => setCurrentStepId('cluster-details')}
@@ -66,7 +66,7 @@ const ClusterWizardStep: React.FC<ClusterWizardStepProps> = ({ cluster, footer, 
         key="baremetal-discovery"
         content="Bare Metal Discovery"
         isDisabled={!wizardSteps.slice(1).includes(currentStepId)}
-        isValid={() => canNextBaremetalDiscovery({ cluster })}
+        isValid={() => !cluster || canNextBaremetalDiscovery({ cluster })}
         isCurrent={currentStepId === 'baremetal-discovery'}
         step={1}
         onNavItemClick={() => setCurrentStepId('baremetal-discovery')}
@@ -75,7 +75,7 @@ const ClusterWizardStep: React.FC<ClusterWizardStepProps> = ({ cluster, footer, 
         content="Networking"
         step={2}
         isDisabled={!wizardSteps.slice(2).includes(currentStepId)}
-        isValid={() => canNextNetworkBackend({ cluster })}
+        isValid={() => !cluster || canNextNetworkBackend({ cluster })}
         key="networking"
         isCurrent={currentStepId === 'networking'}
         onNavItemClick={() => setCurrentStepId('networking')}

--- a/src/components/clusterWizard/NewClusterWizard.tsx
+++ b/src/components/clusterWizard/NewClusterWizard.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import ClusterWizardContext from './ClusterWizardContext';
+import { ClusterWizardStepsType } from './wizardTransition';
+import ClusterDetails from './ClusterDetails';
+
+const NewClusterWizard: React.FC = () => {
+  const [currentStepId, setCurrentStepId] = React.useState<ClusterWizardStepsType>(
+    'cluster-details',
+  );
+
+  const renderCurrentStep = React.useCallback(() => {
+    switch (currentStepId) {
+      // case 'welcome':
+      //   return <Welcome />;
+      case 'cluster-details':
+      default:
+        return <ClusterDetails />;
+    }
+  }, [currentStepId]);
+
+  return (
+    <>
+      <ClusterWizardContext.Provider value={{ currentStepId, setCurrentStepId }}>
+        <div className="pf-c-wizard">{renderCurrentStep()}</div>
+      </ClusterWizardContext.Provider>
+    </>
+  );
+};
+
+export default NewClusterWizard;

--- a/src/components/clusterWizard/wizardTransition.ts
+++ b/src/components/clusterWizard/wizardTransition.ts
@@ -14,7 +14,7 @@ export type ClusterWizardStepsType =
   | 'networking'
   | 'review';
 
-export const CLUSTER_WIZARD_FIRST_STEP: ClusterWizardStepsType = 'cluster-details';
+export const CLUSTER_WIZARD_FIRST_STEP: ClusterWizardStepsType = 'baremetal-discovery';
 
 type TransitionBackendProps = { cluster: Cluster };
 type TransitionProps = TransitionBackendProps & { isValid?: boolean; isSubmitting?: boolean };

--- a/src/components/clusters/NewClusterPage.tsx
+++ b/src/components/clusters/NewClusterPage.tsx
@@ -1,220 +1,27 @@
 import React from 'react';
-import * as Yup from 'yup';
-import { Formik, FormikHelpers } from 'formik';
-import { useHistory } from 'react-router-dom';
-import {
-  Form,
-  Grid,
-  GridItem,
-  PageSectionVariants,
-  TextContent,
-  Text,
-  ButtonVariant,
-  Stack,
-  StackItem,
-} from '@patternfly/react-core';
+import { PageSectionVariants, TextContent, Text } from '@patternfly/react-core';
 import PageSection from '../ui/PageSection';
-import { ToolbarButton } from '../ui/Toolbar';
-import ClusterToolbar from './ClusterToolbar';
-import { ExclamationTriangleIcon } from '@patternfly/react-icons';
-import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens';
-import Alerts from '../ui/Alerts';
-import { handleApiError, getErrorMessage } from '../../api/utils';
-import { AlertsContext, AlertsContextProvider } from '../AlertsContextProvider';
+import { AlertsContextProvider } from '../AlertsContextProvider';
 import ClusterBreadcrumbs from './ClusterBreadcrumbs';
-import { routeBasePath } from '../../config/constants';
-import { getClusters, postCluster } from '../../api/clusters';
-import { ClusterCreateParams } from '../../api/types';
-import { nameValidationSchema, validJSONSchema } from '../ui/formik/validationSchemas';
-import InputField from '../ui/formik/InputField';
-import SelectField from '../ui/formik/SelectField';
-import LoadingState from '../ui/uiState/LoadingState';
-import { captureException } from '../../sentry';
-import { usePullSecretFetch } from '../fetching/pullSecret';
-import PullSecret from './PullSecret';
-import { useOpenshiftVersions } from '../fetching/openshiftVersions';
-import { OpenshiftVersionOptionType } from '../../types/versions';
-import SingleNodeCheckbox from '../ui/formik/SingleNodeCheckbox';
-import {
-  FeatureGateContextProvider,
-  FeatureListType,
-  useFeature,
-} from '../../features/featureGate';
+import NewClusterWizard from '../clusterWizard/NewClusterWizard';
+import { FeatureGateContextProvider, FeatureListType } from '../../features/featureGate';
 
-type NewClusterFormProps = {
-  pullSecret?: string;
-  versions: OpenshiftVersionOptionType[];
-};
-
-const NewClusterForm: React.FC<NewClusterFormProps> = ({ pullSecret = '', versions }) => {
-  const { addAlert, clearAlerts } = React.useContext(AlertsContext);
-  const isSingleNodeOpenshiftEnabled = useFeature('ASSISTED_INSTALLER_SNO_FEATURE');
-  const history = useHistory();
-
-  const nameInputRef = React.useRef<HTMLInputElement>();
-  React.useEffect(() => {
-    nameInputRef.current?.focus();
-  }, []);
-
-  const validationSchema = React.useCallback(
-    () =>
-      Yup.object({
-        name: nameValidationSchema,
-        openshiftVersion: Yup.string().required('Required'),
-        pullSecret: validJSONSchema.required('Pull secret must be provided.'),
-      }),
-    [],
-  );
-
-  const handleSubmit = async (
-    values: ClusterCreateParams,
-    formikActions: FormikHelpers<ClusterCreateParams>,
-  ) => {
-    clearAlerts();
-
-    // async validation for cluster name - run only on submit
-    try {
-      const { data: clusters } = await getClusters();
-      const names = clusters.map((c) => c.name);
-      if (names.includes(values.name)) {
-        return formikActions.setFieldError('name', `Name "${values.name}" is already taken.`);
-      }
-    } catch (e) {
-      captureException(e, 'Failed to perform unique cluster name validation.');
-    }
-
-    try {
-      const { data } = await postCluster(values);
-      history.push(`${routeBasePath}/clusters/${data.id}`);
-    } catch (e) {
-      handleApiError<ClusterCreateParams>(e, () =>
-        addAlert({ title: 'Failed to create new cluster', message: getErrorMessage(e) }),
-      );
-    }
-  };
-
-  const getOpenshiftVersionHelperText = (value: string) =>
-    versions.find((version) => version.value === value)?.supportLevel !== 'production' ? (
-      <>
-        <ExclamationTriangleIcon color={warningColor.value} size="sm" />
-        &nbsp;Please note that this version is not production ready.
-      </>
-    ) : null;
-
-  const ocpVersionOptions = versions.map((version) => ({
-    label: version.label,
-    value: version.value,
-  }));
-
+const NewClusterPage: React.FC<{ features: FeatureListType }> = ({ features }) => {
   return (
-    <>
-      <Formik
-        initialValues={{
-          name: '',
-          openshiftVersion: versions[0]?.value,
-          pullSecret: pullSecret,
-          highAvailabilityMode: 'Full',
-        }}
-        validationSchema={validationSchema}
-        onSubmit={handleSubmit}
-      >
-        {({ submitForm, isSubmitting, isValid, dirty }) => (
-          <Form
-            className="form-new-cluster"
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                submitForm();
-              }
-            }}
-          >
-            <Grid hasGutter>
-              <GridItem span={12} lg={10} xl={6}>
-                <Stack hasGutter>
-                  <StackItem>
-                    <InputField ref={nameInputRef} label="Cluster Name" name="name" isRequired />
-                  </StackItem>
-                  {!isSingleNodeOpenshiftEnabled && (
-                    <StackItem>
-                      <SingleNodeCheckbox name="highAvailabilityMode" />
-                    </StackItem>
-                  )}
-                  <StackItem>
-                    <SelectField
-                      label="OpenShift Version"
-                      name="openshiftVersion"
-                      options={ocpVersionOptions}
-                      getHelperText={getOpenshiftVersionHelperText}
-                      isDisabled={versions.length === 0}
-                      isRequired
-                    />
-                  </StackItem>
-                  <StackItem>
-                    <PullSecret pullSecret={pullSecret} />
-                  </StackItem>
-                </Stack>
-              </GridItem>
-            </Grid>
-            <Alerts />
-            <ClusterToolbar>
-              <ToolbarButton
-                name="save"
-                variant={ButtonVariant.primary}
-                isDisabled={isSubmitting || !isValid || !dirty}
-                onClick={submitForm}
-                id="new-cluster-page-save"
-              >
-                Save & Continue
-              </ToolbarButton>
-              <ToolbarButton
-                variant={ButtonVariant.link}
-                onClick={() => history.push(`${routeBasePath}/clusters`)}
-                id="new-cluster-page-cancel"
-              >
-                Cancel
-              </ToolbarButton>
-            </ClusterToolbar>
-          </Form>
-        )}
-      </Formik>
-    </>
+    <AlertsContextProvider>
+      <FeatureGateContextProvider features={features}>
+        <ClusterBreadcrumbs clusterName="New cluster" />
+        <PageSection variant={PageSectionVariants.light}>
+          <TextContent>
+            <Text component="h1">Install OpenShift on Bare Metal with the Assisted Installer</Text>
+          </TextContent>
+        </PageSection>
+        <PageSection variant={PageSectionVariants.light} isFilled>
+          <NewClusterWizard />
+        </PageSection>
+      </FeatureGateContextProvider>
+    </AlertsContextProvider>
   );
 };
-
-const NewCluster: React.FC = () => {
-  const { addAlert } = React.useContext(AlertsContext);
-  const pullSecret = usePullSecretFetch();
-  const { error: errorOCPVersions, loading: loadingOCPVersions, versions } = useOpenshiftVersions();
-
-  React.useEffect(() => errorOCPVersions && addAlert(errorOCPVersions), [
-    errorOCPVersions,
-    addAlert,
-  ]);
-
-  return (
-    <>
-      <ClusterBreadcrumbs clusterName="New cluster" />
-      <PageSection variant={PageSectionVariants.light}>
-        <TextContent>
-          <Text component="h1">Install OpenShift on Bare Metal with the Assisted Installer</Text>
-        </TextContent>
-      </PageSection>
-      <PageSection variant={PageSectionVariants.light} isFilled>
-        {pullSecret === undefined || loadingOCPVersions ? (
-          <LoadingState />
-        ) : (
-          <NewClusterForm pullSecret={pullSecret} versions={versions} />
-        )}
-      </PageSection>
-    </>
-  );
-};
-
-const NewClusterPage: React.FC<{ features: FeatureListType }> = ({ features }) => (
-  <AlertsContextProvider>
-    <FeatureGateContextProvider features={features}>
-      <NewCluster />
-    </FeatureGateContextProvider>
-  </AlertsContextProvider>
-);
 
 export default NewClusterPage;

--- a/src/components/ui/formik/validationSchemas.ts
+++ b/src/components/ui/formik/validationSchemas.ts
@@ -133,13 +133,9 @@ export const ipBlockValidationSchema = Yup.string()
     },
   );
 
-export const dnsNameValidationSchema = (initialValue?: string) =>
-  requiredOnceSet(initialValue).concat(
-    Yup.string().matches(DNS_NAME_REGEX, {
-      message: 'Value "${value}" is not valid DNS name. Example: basedomain.example.com', // eslint-disable-line no-template-curly-in-string
-      excludeEmptyString: true,
-    }),
-  );
+export const dnsNameValidationSchema = Yup.string().matches(DNS_NAME_REGEX, {
+  message: 'Value "${value}" is not valid DNS name. Example: basedomain.example.com', // eslint-disable-line no-template-curly-in-string
+});
 
 export const hostPrefixValidationSchema = (values: NetworkConfigurationValues) => {
   const requiredText = 'The host prefix is required.';

--- a/src/types/clusters.ts
+++ b/src/types/clusters.ts
@@ -22,10 +22,6 @@ export type NetworkConfigurationValues = ClusterUpdateParams & {
   shareDiscoverySshKey?: boolean;
 };
 
-export type ClusterDetailsValues = ClusterUpdateParams & {
-  useRedHatDnsService: boolean;
-};
-
 // TODO(mlibra): just name?
 export type BareMetalDiscoveryValues = ClusterUpdateParams;
 


### PR DESCRIPTION
- NewClusterPage now renders NewClusterWizard instead of NewClusterForm
- ClusterDetails wizard step is capable of creating/updating the cluster
- single node, openshift version and pull secret are not allowed to be
  updated

Next steps:
- use ClusterWizardToolbar in ClusterDetails
- validate cluster name + dns domain for uniqueness rather than just cluster name
- explore possibility to edit pull secret?
- align to wireframes