### PR TITLE
Fix HTTP Proxy URL validation

### DIFF
--- a/src/components/ui/formik/validationSchemas.ts
+++ b/src/components/ui/formik/validationSchemas.ts
@@ -196,7 +196,6 @@ export const httpProxyValidationSchema = (
   pairValueName: 'httpProxy' | 'httpsProxy',
 ) =>
   Yup.string()
-    .url(httpProxyValidationMessage)
     .test(
       'http-proxy-no-empty-validation',
       'At least one of the HTTP or HTTPS proxy URLs is required.',


### PR DESCRIPTION
Yup.url() does not allow ipv6 based URLs

Before:
![image](https://user-images.githubusercontent.com/1121740/106878485-4d41e580-66da-11eb-9cfa-3480a965a165.png)

After:
![Screenshot from 2021-02-04 11-13-56](https://user-images.githubusercontent.com/1121740/106878544-5fbc1f00-66da-11eb-9da2-38ac93da89ad.png)

