### PR TITLE
BZ-1877838 CIDR fields display wrong validation message

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
   "dependencies": {
     "axios-case-converter": "^0.6.0",
     "ip-address": "^7.1.0",
+    "is-cidr": "^4.0.2",
     "is-in-subnet": "^3.1.0",
     "unique-names-generator": "^4.2.0"
   }


### PR DESCRIPTION
Previously the message bellow couldn't be displayed because we were validating the input is a valid IP address (v4 or v6) but not a valid CIDR string.

![image](https://user-images.githubusercontent.com/77008341/107685056-38ea8380-6cac-11eb-92dc-814be657fd45.png)
