### PR TITLE
Introduce wizard step validation mapping

### DIFF
--- a/src/components/clusterConfiguration/ClusterValidationSection.tsx
+++ b/src/components/clusterConfiguration/ClusterValidationSection.tsx
@@ -16,10 +16,12 @@ import {
 } from '@patternfly/react-core';
 import { TimesIcon } from '@patternfly/react-icons';
 import { Cluster } from '../../api/types';
-import { NetworkConfigurationValues, ValidationsInfo } from '../../types/clusters';
+import { NetworkConfigurationValues, Validation, ValidationsInfo } from '../../types/clusters';
 import { CLUSTER_FIELD_LABELS } from '../../config/constants';
 import { stringToJSON } from '../../api/utils';
 import './ClusterValidationSection.css';
+import { getWizardStepClusterValidationsInfo } from '../clusterWizard/wizardTransition';
+import ClusterWizardContext from '../clusterWizard/ClusterWizardContext';
 
 type ClusterValidationSectionProps = {
   cluster: Cluster;
@@ -37,18 +39,20 @@ const ClusterValidationSection: React.FC<ClusterValidationSectionProps> = ({
   const prevReadyRef = React.useRef<boolean>();
   const errorFields = Object.keys(formErrors);
   const ready = cluster.status === 'ready' && !errorFields.length && !dirty;
+  const { currentStepId } = React.useContext(ClusterWizardContext);
 
   const { failedValidations } = React.useMemo(() => {
-    const validationsInfo = stringToJSON<ValidationsInfo>(cluster.validationsInfo) || {
-      hostsData: [],
-      network: [],
-    };
-    const flattenedValues = _.values(validationsInfo).flat();
+    const validationsInfo = stringToJSON<ValidationsInfo>(cluster.validationsInfo) || {};
+    const reducedValidationsInfo = getWizardStepClusterValidationsInfo(
+      validationsInfo,
+      currentStepId,
+    );
+    const flattenedValues = _.values(reducedValidationsInfo).flat() as Validation[];
     return {
       pendingValidations: flattenedValues.filter((validation) => validation.status === 'pending'),
       failedValidations: flattenedValues.filter((validation) => validation.status === 'failure'),
     };
-  }, [cluster.validationsInfo]);
+  }, [cluster.validationsInfo, currentStepId]);
 
   // When cluster becomes ready, close this section
   React.useEffect(() => {

--- a/src/components/clusterConfiguration/NetworkConfigurationForm.tsx
+++ b/src/components/clusterConfiguration/NetworkConfigurationForm.tsx
@@ -25,7 +25,7 @@ import ClusterWizardStep from '../clusterWizard/ClusterWizardStep';
 import { HostSubnets, NetworkConfigurationValues } from '../../types/clusters';
 import { updateCluster } from '../../features/clusters/currentClusterSlice';
 import ClusterWizardToolbar from '../clusterWizard/ClusterWizardToolbar';
-import { canNextNetwork, canNextNetworkBackend } from '../clusterWizard/wizardTransition';
+import { canNextNetwork } from '../clusterWizard/wizardTransition';
 import ClusterWizardContext from '../clusterWizard/ClusterWizardContext';
 import NetworkConfiguration from './NetworkConfiguration';
 import ClusterSshKeyField from './ClusterSshKeyField';
@@ -88,7 +88,7 @@ const NetworkConfigurationForm: React.FC<{
       });
       dispatch(updateCluster(data));
 
-      canNextNetworkBackend({ cluster }) && setCurrentStepId('review');
+      canNextNetwork({ cluster }) && setCurrentStepId('review');
     } catch (e) {
       handleApiError<ClusterUpdateParams>(e, () =>
         addAlert({ title: 'Failed to update the cluster', message: getErrorMessage(e) }),
@@ -164,10 +164,10 @@ const NetworkConfigurationForm: React.FC<{
             <StackItem>
               <ClusterWizardToolbar
                 cluster={cluster}
-                errors={errors}
+                formErrors={errors}
                 dirty={dirty}
                 isSubmitting={isSubmitting}
-                isNextDisabled={!canNextNetwork({ isValid, isSubmitting, cluster })}
+                isNextDisabled={!(isValid && (dirty || canNextNetwork({ cluster })))}
                 onNext={submitForm}
                 onBack={() => setCurrentStepId('baremetal-discovery')}
               />

--- a/src/components/clusterWizard/BaremetalDiscovery.tsx
+++ b/src/components/clusterWizard/BaremetalDiscovery.tsx
@@ -12,7 +12,6 @@ const BaremetalDiscovery: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
   const footer = (
     <ClusterWizardToolbar
       cluster={cluster}
-      errors={{}}
       dirty={false}
       isSubmitting={false}
       isNextDisabled={!canNextBaremetalDiscovery({ cluster })}

--- a/src/components/clusterWizard/ClusterWizardStep.tsx
+++ b/src/components/clusterWizard/ClusterWizardStep.tsx
@@ -9,7 +9,7 @@ import ClusterWizardContext from './ClusterWizardContext';
 import {
   canNextBaremetalDiscovery,
   canNextClusterDetails,
-  canNextNetworkBackend,
+  canNextNetwork,
   ClusterWizardStepsType,
 } from './wizardTransition';
 
@@ -75,7 +75,7 @@ const ClusterWizardStep: React.FC<ClusterWizardStepProps> = ({ cluster, footer, 
         content="Networking"
         step={2}
         isDisabled={!wizardSteps.slice(2).includes(currentStepId)}
-        isValid={() => !cluster || canNextNetworkBackend({ cluster })}
+        isValid={() => !cluster || canNextNetwork({ cluster })}
         key="networking"
         isCurrent={currentStepId === 'networking'}
         onNavItemClick={() => setCurrentStepId('networking')}

--- a/src/components/clusterWizard/wizardTransition.ts
+++ b/src/components/clusterWizard/wizardTransition.ts
@@ -1,12 +1,13 @@
 import _ from 'lodash';
-import { Cluster, ClusterValidationId, HostValidationId, stringToJSON } from '../../api';
-import { ValidationsInfo as ClusterValidationsInfo } from '../../types/clusters';
-import { ValidationsInfo as HostValidationsInfo } from '../../types/hosts';
-
-/*
-We are colocating all these canNext* functions for easier maintenance.
-However they should be independent on each other anyway.
-*/
+import { Cluster, ClusterValidationId, Host, HostValidationId, stringToJSON } from '../../api';
+import {
+  ValidationGroup as ClusterValidationGroup,
+  ValidationsInfo as ClusterValidationsInfo,
+} from '../../types/clusters';
+import {
+  ValidationGroup as HostValidationGroup,
+  ValidationsInfo as HostValidationsInfo,
+} from '../../types/hosts';
 
 export type ClusterWizardStepsType =
   | 'cluster-details'
@@ -23,8 +24,74 @@ export const getClusterWizardFirstStep = (
 ): ClusterWizardStepsType =>
   props?.wizardFlow === 'new' ? 'baremetal-discovery' : 'cluster-details';
 
-type TransitionBackendProps = { cluster: Cluster };
-type TransitionProps = TransitionBackendProps & { isValid?: boolean; isSubmitting?: boolean };
+type TransitionProps = { cluster: Cluster };
+
+type WizardStepValidationMap = {
+  cluster: {
+    groups: ClusterValidationGroup[];
+    validationIds: ClusterValidationId[];
+  };
+  host: {
+    groups: HostValidationGroup[];
+    validationIds: HostValidationId[];
+  };
+};
+
+type WizardStepsValidationMap = {
+  [key in ClusterWizardStepsType]: WizardStepValidationMap;
+};
+
+const clusterDetailsStepValidationsMap: WizardStepValidationMap = {
+  cluster: {
+    groups: [],
+    validationIds: ['pull-secret-set', 'dns-domain-defined'],
+  },
+  host: {
+    groups: [],
+    validationIds: [],
+  },
+};
+
+const baremetalDiscoveryStepValidationsMap: WizardStepValidationMap = {
+  cluster: {
+    groups: [],
+    // TODO(jtomasek): enable sufficient-masters-count once https://bugzilla.redhat.com/show_bug.cgi?id=1928086 is fixed
+    validationIds: [/*'sufficient-masters-count',*/ 'ocs-requirements-satisfied'],
+  },
+  host: {
+    groups: ['hardware'],
+    validationIds: ['connected', 'container-images-available'],
+  },
+};
+
+const networkingStepValidationsMap: WizardStepValidationMap = {
+  cluster: {
+    groups: ['network'],
+    validationIds: [],
+  },
+  host: {
+    groups: ['network'],
+    validationIds: [],
+  },
+};
+
+const reviewStepValidationsMap: WizardStepValidationMap = {
+  cluster: {
+    groups: [],
+    validationIds: ['all-hosts-are-ready-to-install'],
+  },
+  host: {
+    groups: [],
+    validationIds: [],
+  },
+};
+
+const wizardStepsValidationsMap: WizardStepsValidationMap = {
+  'cluster-details': clusterDetailsStepValidationsMap,
+  'baremetal-discovery': baremetalDiscoveryStepValidationsMap,
+  networking: networkingStepValidationsMap,
+  review: reviewStepValidationsMap,
+};
 
 const checkClusterValidations = (
   clusterValidationsInfo: ClusterValidationsInfo,
@@ -38,15 +105,16 @@ const checkClusterValidations = (
     requiredValidations.every((v) => v?.status === 'success')
   );
 };
+
 const checkClusterValidationGroups = (
   clusterValidationsInfo: ClusterValidationsInfo,
-  groups: ('hostsData' | 'network' | 'configuration')[],
+  groups: ClusterValidationGroup[],
 ) =>
   groups.every((group) =>
     clusterValidationsInfo[group]?.every((validation) => validation.status === 'success'),
   );
 
-const checkHostValidations = (
+export const checkHostValidations = (
   hostValidationsInfo: HostValidationsInfo,
   requiredIds: HostValidationId[],
 ): boolean => {
@@ -60,86 +128,111 @@ const checkHostValidations = (
   );
 };
 
-const checkHostValidationGroups = (
+export const checkHostValidationGroups = (
   hostValidationsInfo: HostValidationsInfo,
-  groups: ('hardware' | 'network')[],
+  groups: HostValidationGroup[],
 ) =>
   groups.every((group) =>
     hostValidationsInfo[group]?.every((validation) => validation.status === 'success'),
   );
 
-export const canNextClusterDetails = ({ cluster }: TransitionBackendProps): boolean => {
-  const clusterValidationsInfo = stringToJSON<ClusterValidationsInfo>(cluster.validationsInfo);
-  return !!(
-    clusterValidationsInfo && checkClusterValidations(clusterValidationsInfo, ['pull-secret-set'])
+export const getWizardStepHostValidationsInfo = (
+  validationsInfo: HostValidationsInfo,
+  wizardStepId: ClusterWizardStepsType,
+): HostValidationsInfo => {
+  const { groups, validationIds } = wizardStepsValidationsMap[wizardStepId].host;
+  return _.reduce(
+    validationsInfo,
+    (result, groupValidations, groupName) => {
+      if (groups.includes(groupName as HostValidationGroup)) {
+        result[groupName] = groupValidations;
+        return result;
+      }
+      const selectedValidations = (groupValidations || []).filter((validation) =>
+        validationIds.includes(validation.id),
+      );
+      if (selectedValidations.length) {
+        result[groupName] = selectedValidations;
+        return result;
+      }
+      return result;
+    },
+    {},
   );
 };
 
-// Check backend validations relevant for the networking step.
-// Since BaremetalDiscovery step is is not a UI form, we do not need frontend validation checks.
-export const canNextBaremetalDiscovery = ({ cluster }: TransitionProps): boolean => {
-  const clusterValidationsInfo = stringToJSON<ClusterValidationsInfo>(cluster.validationsInfo);
-  if (!clusterValidationsInfo?.hostsData || !clusterValidationsInfo?.network) {
-    return false;
+export const getWizardStepHostStatus = (
+  host: Host,
+  wizardStepId: ClusterWizardStepsType,
+): Host['status'] => {
+  const { status } = host;
+  if (['insufficient', 'pending-for-input'].includes(host.status)) {
+    const validationsInfo = stringToJSON<HostValidationsInfo>(host.validationsInfo) || {};
+    const { groups, validationIds } = wizardStepsValidationsMap[wizardStepId].host;
+
+    // TODO(jtomasek): alternatively we could getWizardStepValidationsInfo and ensure that all validations are passing
+    return checkHostValidationGroups(validationsInfo, groups) &&
+      checkHostValidations(validationsInfo, validationIds)
+      ? 'known'
+      : host.status;
   }
-
-  // Cluster level: Selected hostsData and network validations must be passing
-  if (
-    !checkClusterValidations(clusterValidationsInfo, [
-      'sufficient-masters-count',
-      'ntp-server-configured',
-    ])
-  ) {
-    return false;
-  }
-
-  // For every host
-  return !!cluster.hosts?.every((host) => {
-    const hostValidationsInfo = stringToJSON<HostValidationsInfo>(host.validationsInfo);
-    if (!hostValidationsInfo?.hardware || !hostValidationsInfo.network) {
-      return false;
-    }
-
-    // Selected network validations for every host must be passing
-    if (
-      !checkHostValidations(hostValidationsInfo, [
-        'connected',
-        'belongs-to-majority-group',
-        'ntp-synced',
-      ])
-    ) {
-      return false;
-    }
-
-    // All hardware validations for every host must be passing
-    return checkHostValidationGroups(hostValidationsInfo, ['hardware']);
-  });
+  return status;
 };
 
-// Check backend validations relevant for the networking step.
-export const canNextNetworkBackend = ({ cluster }: TransitionBackendProps): boolean => {
-  const clusterValidationsInfo = stringToJSON<ClusterValidationsInfo>(cluster.validationsInfo);
-  if (!clusterValidationsInfo?.network) {
-    return false;
-  }
-
-  // All network cluster validations must be passing
-  if (!checkClusterValidationGroups(clusterValidationsInfo, ['network'])) {
-    return false;
-  }
-
-  // All network validations for every host must be passing
-  return !!cluster.hosts?.every((host) => {
-    const hostValidationsInfo = stringToJSON<HostValidationsInfo>(host.validationsInfo);
-    return hostValidationsInfo && checkHostValidationGroups(hostValidationsInfo, ['network']);
-  });
+export const getWizardStepClusterValidationsInfo = (
+  validationsInfo: ClusterValidationsInfo,
+  wizardStepId: ClusterWizardStepsType,
+): ClusterValidationsInfo => {
+  const { groups, validationIds } = wizardStepsValidationsMap[wizardStepId].cluster;
+  return _.reduce(
+    validationsInfo,
+    (result, groupValidations, groupName) => {
+      if (groups.includes(groupName as ClusterValidationGroup)) {
+        result[groupName] = groupValidations;
+        return result;
+      }
+      const selectedValidations = (groupValidations || []).filter((validation) =>
+        validationIds.includes(validation.id),
+      );
+      if (selectedValidations.length) {
+        result[groupName] = selectedValidations;
+        return result;
+      }
+      return result;
+    },
+    {},
+  );
 };
 
-export const canNextNetwork = ({ isValid, isSubmitting, cluster }: TransitionProps): boolean => {
-  let uiValidation = true;
-  if (isValid !== undefined) {
-    uiValidation = isValid && !isSubmitting;
+export const getWizardStepClusterStatus = (
+  cluster: Cluster,
+  wizardStepId: ClusterWizardStepsType,
+): Cluster['status'] => {
+  const { status } = cluster;
+  if (['insufficient', 'pending-for-input'].includes(cluster.status)) {
+    const validationsInfo = stringToJSON<ClusterValidationsInfo>(cluster.validationsInfo) || {};
+    const { groups, validationIds } = wizardStepsValidationsMap[wizardStepId].cluster;
+    const allHostsReady = (cluster?.hosts || []).every(
+      (host) => getWizardStepHostStatus(host, wizardStepId) === 'known',
+    );
+    return allHostsReady &&
+      checkClusterValidationGroups(validationsInfo, groups) &&
+      checkClusterValidations(validationsInfo, validationIds)
+      ? 'ready'
+      : cluster.status;
   }
-
-  return uiValidation && canNextNetworkBackend({ cluster });
+  return status;
 };
+
+/*
+We are colocating all these canNext* functions for easier maintenance.
+However they should be independent on each other anyway.
+*/
+export const canNextClusterDetails = ({ cluster }: TransitionProps): boolean =>
+  getWizardStepClusterStatus(cluster, 'cluster-details') === 'ready';
+
+export const canNextBaremetalDiscovery = ({ cluster }: TransitionProps): boolean =>
+  getWizardStepClusterStatus(cluster, 'baremetal-discovery') === 'ready';
+
+export const canNextNetwork = ({ cluster }: TransitionProps): boolean =>
+  getWizardStepClusterStatus(cluster, 'networking') === 'ready';

--- a/src/components/clusterWizard/wizardTransitions.test.ts
+++ b/src/components/clusterWizard/wizardTransitions.test.ts
@@ -1,0 +1,14 @@
+import { checkHostValidationGroups, checkHostValidations } from './wizardTransition';
+
+describe('wizardTransitions module tests', () => {
+  describe('checkHostValidationGroups', () => {
+    it('should return false when validationsInfo parameter is empty object', () => {
+      expect(checkHostValidationGroups({}, ['hardware'])).toBeFalsy();
+    });
+  });
+  describe('checkHostValidations', () => {
+    it('should return false when validationsInfo parameter is empty object', () => {
+      expect(checkHostValidations({}, ['connected'])).toBeFalsy();
+    });
+  });
+});

--- a/src/components/hosts/HardwareStatus.tsx
+++ b/src/components/hosts/HardwareStatus.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Cluster, Host } from '../../api/types';
+import { ValidationsInfo } from '../../types/hosts';
+import HostStatus from './HostStatus';
+import {
+  getWizardStepHostStatus,
+  getWizardStepHostValidationsInfo,
+} from '../clusterWizard/wizardTransition';
+
+type HardwareStatusProps = {
+  host: Host;
+  validationsInfo: ValidationsInfo;
+  cluster: Cluster;
+};
+
+const HardwareStatus: React.FC<HardwareStatusProps> = (props) => {
+  const hardwareStatus = getWizardStepHostStatus(props.host, 'baremetal-discovery');
+  const validationsInfo = getWizardStepHostValidationsInfo(
+    props.validationsInfo,
+    'baremetal-discovery',
+  );
+  return (
+    <HostStatus {...props} statusOverride={hardwareStatus} validationsInfo={validationsInfo} />
+  );
+};
+
+export default HardwareStatus;

--- a/src/components/hosts/HostStatus.tsx
+++ b/src/components/hosts/HostStatus.tsx
@@ -120,6 +120,7 @@ type HostStatusProps = {
   host: Host;
   validationsInfo: ValidationsInfo;
   cluster: Cluster;
+  statusOverride?: Host['status'];
 };
 
 const HostStatusPopoverFooter: React.FC<{ host: Host }> = ({ host }) => {
@@ -151,9 +152,14 @@ const HostStatusPopoverFooter: React.FC<{ host: Host }> = ({ host }) => {
   return <small>{footerText}</small>;
 };
 
-const HostStatus: React.FC<HostStatusProps> = ({ host, cluster, validationsInfo }) => {
+const HostStatus: React.FC<HostStatusProps> = ({
+  host,
+  cluster,
+  validationsInfo,
+  statusOverride,
+}) => {
   const [keepOnOutsideClick, onValidationActionToggle] = React.useState(false);
-  const { status } = host;
+  const status = statusOverride || host.status;
   const title = HOST_STATUS_LABELS[status] || status;
   const icon = getStatusIcon(status) || null;
   const hostProgressStages = getHostProgressStages(host);

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -70,7 +70,7 @@ export const CLUSTER_STATUS_LABELS: { [key in Cluster['status']]: string } = {
 export const HOST_STATUS_LABELS: { [key in Host['status']]: string } = {
   discovering: 'Discovering',
   'pending-for-input': 'Pending input',
-  known: 'Ready to install',
+  known: 'Ready',
   disconnected: 'Disconnected',
   insufficient: 'Insufficient',
   disabled: 'Disabled',

--- a/src/types/clusters.ts
+++ b/src/types/clusters.ts
@@ -6,6 +6,12 @@ export type Validation = HostValidation & {
   id: ClusterValidationId;
 };
 
+export type ValidationGroup = 'configuration' | 'hostsData' | 'network' | 'operators';
+
+export type ValidationsInfo = {
+  [key in ValidationGroup]?: Validation[];
+};
+
 export type ClusterTableRows = IRow[];
 
 export type HostSubnet = {
@@ -28,9 +34,3 @@ export type ClusterDetailsValues = ClusterUpdateParams & {
 };
 
 export type BareMetalDiscoveryValues = ClusterUpdateParams;
-
-export type ValidationsInfo = {
-  hostsData: Validation[];
-  network: Validation[];
-  configuration: Validation[];
-};

--- a/src/types/hosts.ts
+++ b/src/types/hosts.ts
@@ -6,10 +6,10 @@ export type Validation = {
   message: string;
 };
 
+export type ValidationGroup = 'hardware' | 'network' | 'role';
+
 export type ValidationsInfo = {
-  hardware?: Validation[];
-  network?: Validation[];
-  role?: Validation[];
+  [key in ValidationGroup]?: Validation[];
 };
 
 export type HostRole = {


### PR DESCRIPTION
- Use validation map to calculate cluster/host validationInfo and
  status
- Use calculated status to determine transition to next step
- Adjust ClusterWizardToolbar to display validations toggle properly
- Simplify 'canNext' functions
- Enable 'Next' button in case when form is dirty and valid to allow
  user saving the changes regardless of backend validations