### PR TITLE
MGMT-4110 SNO is only available in selected OCP versions

### DIFF
--- a/src/components/clusterConfiguration/OpenShiftVersionSelect.tsx
+++ b/src/components/clusterConfiguration/OpenShiftVersionSelect.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { useFormikContext } from 'formik';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens';
+import { OpenshiftVersionOptionType } from '../../types/versions';
+import SelectField from '../ui/formik/SelectField';
+import { ClusterCreateParams } from '../../api/types';
+import { SNO_SUPPORT_MIN_VERSION } from '../../config/constants';
+
+type OpenShiftVersionSelectProps = {
+  versions: OpenshiftVersionOptionType[];
+};
+const OpenShiftVersionSelect: React.FC<OpenShiftVersionSelectProps> = ({ versions }) => {
+  const {
+    values: { highAvailabilityMode },
+    setFieldValue,
+  } = useFormikContext<ClusterCreateParams>();
+  React.useEffect(() => {
+    if (highAvailabilityMode === 'None') {
+      const firstSupportedVersionValue = versions.find(
+        (version) => parseFloat(version.value) >= SNO_SUPPORT_MIN_VERSION,
+      )?.value;
+      setFieldValue('openshiftVersion', firstSupportedVersionValue);
+    }
+  }, [highAvailabilityMode, setFieldValue, versions]);
+
+  const getOpenshiftVersionHelperText = (value: string) =>
+    versions.find((version) => version.value === value)?.supportLevel !== 'production' ? (
+      <>
+        <ExclamationTriangleIcon color={warningColor.value} size="sm" />
+        &nbsp;Please note that this version is not production ready.
+      </>
+    ) : null;
+
+  const selectOptions = React.useMemo(
+    () =>
+      versions
+        .map((version) => ({
+          label: version.label,
+          value: version.value,
+        }))
+        .filter((version) =>
+          highAvailabilityMode === 'None'
+            ? parseFloat(version.value) >= SNO_SUPPORT_MIN_VERSION
+            : true,
+        ),
+    [versions, highAvailabilityMode],
+  );
+
+  return (
+    <SelectField
+      label="OpenShift Version"
+      name="openshiftVersion"
+      options={selectOptions}
+      getHelperText={getOpenshiftVersionHelperText}
+      isDisabled={versions.length === 0}
+      isRequired
+    />
+  );
+};
+
+export default OpenShiftVersionSelect;

--- a/src/components/clusters/NewClusterPage.tsx
+++ b/src/components/clusters/NewClusterPage.tsx
@@ -14,8 +14,6 @@ import {
 import PageSection from '../ui/PageSection';
 import { ToolbarButton } from '../ui/Toolbar';
 import ClusterToolbar from './ClusterToolbar';
-import { ExclamationTriangleIcon } from '@patternfly/react-icons';
-import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens';
 import AlertsSection from '../ui/AlertsSection';
 import { handleApiError, getErrorMessage } from '../../api/utils';
 import { AlertsContext, AlertsContextProvider } from '../AlertsContextProvider';
@@ -25,7 +23,6 @@ import { getClusters, postCluster } from '../../api/clusters';
 import { ClusterCreateParams } from '../../api/types';
 import { nameValidationSchema, validJSONSchema } from '../ui/formik/validationSchemas';
 import InputField from '../ui/formik/InputField';
-import SelectField from '../ui/formik/SelectField';
 import LoadingState from '../ui/uiState/LoadingState';
 import { captureException } from '../../sentry';
 import { usePullSecretFetch } from '../fetching/pullSecret';
@@ -33,7 +30,7 @@ import PullSecret from './PullSecret';
 import { useOpenshiftVersions } from '../fetching/openshiftVersions';
 import { OpenshiftVersionOptionType } from '../../types/versions';
 import SingleNodeCheckbox from '../ui/formik/SingleNodeCheckbox';
-import { useFeature } from '../../features/featureGate';
+import OpenShiftVersionSelect from '../clusterConfiguration/OpenShiftVersionSelect';
 
 import './NewClusterPage.css';
 
@@ -44,7 +41,6 @@ type NewClusterFormProps = {
 
 const NewClusterForm: React.FC<NewClusterFormProps> = ({ pullSecret = '', versions }) => {
   const { addAlert, clearAlerts } = React.useContext(AlertsContext);
-  const isSingleNodeOpenshiftEnabled = useFeature('ASSISTED_INSTALLER_SNO_FEATURE');
   const history = useHistory();
 
   const nameInputRef = React.useRef<HTMLInputElement>();
@@ -89,19 +85,6 @@ const NewClusterForm: React.FC<NewClusterFormProps> = ({ pullSecret = '', versio
     }
   };
 
-  const getOpenshiftVersionHelperText = (value: string) =>
-    versions.find((version) => version.value === value)?.supportLevel !== 'production' ? (
-      <>
-        <ExclamationTriangleIcon color={warningColor.value} size="sm" />
-        &nbsp;Please note that this version is not production ready.
-      </>
-    ) : null;
-
-  const ocpVersionOptions = versions.map((version) => ({
-    label: version.label,
-    value: version.value,
-  }));
-
   return (
     <>
       <ClusterBreadcrumbs clusterName="New cluster" />
@@ -134,17 +117,8 @@ const NewClusterForm: React.FC<NewClusterFormProps> = ({ pullSecret = '', versio
                       </Text>
                     </TextContent>
                     <InputField ref={nameInputRef} label="Cluster Name" name="name" isRequired />
-                    {isSingleNodeOpenshiftEnabled && (
-                      <SingleNodeCheckbox name="highAvailabilityMode" />
-                    )}
-                    <SelectField
-                      label="OpenShift Version"
-                      name="openshiftVersion"
-                      options={ocpVersionOptions}
-                      getHelperText={getOpenshiftVersionHelperText}
-                      isDisabled={versions.length === 0}
-                      isRequired
-                    />
+                    <SingleNodeCheckbox name="highAvailabilityMode" versions={versions} />
+                    <OpenShiftVersionSelect versions={versions} />
                     <PullSecret pullSecret={pullSecret} />
                   </Form>
                 </GridItem>

--- a/src/components/ui/formik/SingleNodeCheckbox.tsx
+++ b/src/components/ui/formik/SingleNodeCheckbox.tsx
@@ -4,30 +4,48 @@ import { Checkbox } from '@patternfly/react-core';
 import { CheckboxFieldProps } from './types';
 import { getFieldId } from './utils';
 import HelperText from './HelperText';
+import { useFeature } from '../../../features/featureGate';
+import { OpenshiftVersionOptionType } from '../../../types/versions';
+import { SNO_SUPPORT_MIN_VERSION } from '../../../config/constants';
 
-const SingleNodeCheckbox: React.FC<CheckboxFieldProps> = ({ validate, idPostfix, ...props }) => {
+type SingleNodeCheckboxProps = CheckboxFieldProps & { versions: OpenshiftVersionOptionType[] };
+
+const SingleNodeCheckbox: React.FC<SingleNodeCheckboxProps> = ({
+  versions,
+  validate,
+  idPostfix,
+  ...props
+}) => {
+  const isSingleNodeOpenshiftEnabled = useFeature('ASSISTED_INSTALLER_SNO_FEATURE');
   const [field, meta, helpers] = useField<'None' | 'Full'>({ name: props.name, validate });
   const fieldId = getFieldId(props.name, 'input', idPostfix);
 
   const { value } = meta;
   const { setValue } = helpers;
 
-  return (
-    <Checkbox
-      {...field}
-      {...props}
-      id={fieldId}
-      label="I want to install single node OpenShift (SNO)"
-      aria-describedby={`${fieldId}-helper`}
-      description={
-        <HelperText fieldId={fieldId}>
-          {'This enables you to install OpenShift using only 1 host.'}
-        </HelperText>
-      }
-      isChecked={value === 'None'}
-      onChange={(checked) => setValue(checked ? 'None' : 'Full')}
-    />
+  const isSupportedVersionAvailable = !!versions.find(
+    (version) => parseFloat(version.value) >= SNO_SUPPORT_MIN_VERSION,
   );
+
+  if (isSingleNodeOpenshiftEnabled && isSupportedVersionAvailable) {
+    return (
+      <Checkbox
+        {...field}
+        {...props}
+        id={fieldId}
+        label="I want to install single node OpenShift (SNO)"
+        aria-describedby={`${fieldId}-helper`}
+        description={
+          <HelperText fieldId={fieldId}>
+            {'This enables you to install OpenShift using only 1 host.'}
+          </HelperText>
+        }
+        isChecked={value === 'None'}
+        onChange={(checked) => setValue(checked ? 'None' : 'Full')}
+      />
+    );
+  }
+  return null;
 };
 
 export default SingleNodeCheckbox;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -199,3 +199,5 @@ export const DISK_ROLE_LABELS: { [key in DiskRole]: string } = {
   none: 'None',
   install: 'Installation disk',
 };
+
+export const SNO_SUPPORT_MIN_VERSION = 4.8;


### PR DESCRIPTION
- If user enables SNO, the list of available OCP versions is reduced to 4.8 and higher
- SNO option will be hidden if there is no version which supports it available