### PR TITLE
[WIP] MGMT-3651 Remove host names from event messages

### DIFF
--- a/src/components/hosts/utils.ts
+++ b/src/components/hosts/utils.ts
@@ -137,6 +137,12 @@ export const getEnabledHosts = (hosts: Host[] = []) =>
 export const getHostname = (host: Host, inventory: Inventory) =>
   host.requestedHostname || inventory.hostname;
 
+export const findHostname = (hostId: string, hosts: Host[] = []): string => {
+  const host = hosts.find(({ id }) => id === hostId);
+
+  return host?.requestedHostname || hostId;
+};
+
 export const getHardwareTypeText = (inventory: Inventory) => {
   let hardwareTypeText = DASH;
   const { systemVendor } = inventory;

--- a/src/components/ui/ClusterEventsList.test.tsx
+++ b/src/components/ui/ClusterEventsList.test.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
-import { render, screen, within } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
+import { renderWithRedux } from '../../testUtils';
 import ClusterEventsList, { ClusterEventsListProps } from './ClusterEventsList';
+import { RootState } from '../../store/rootReducer';
+import { ResourceUIState } from '../../types';
 
 // TODO: this fixture needs a warm place where to live in the project.
 const props = Object.freeze<ClusterEventsListProps>({
@@ -173,14 +176,25 @@ const props = Object.freeze<ClusterEventsListProps>({
 
 describe('<ClusterEventsList />', () => {
   it('Renders without crashing', () => {
-    render(<ClusterEventsList {...props} />);
+    const preloadedState: RootState = {
+      clusters: {
+        data: [],
+        uiState: ResourceUIState.LOADED,
+      },
+      currentCluster: {
+        data: { ...props.cluster },
+        uiState: ResourceUIState.LOADED,
+        isReloadScheduled: 0,
+      },
+    };
+    renderWithRedux(<ClusterEventsList {...props} />, { preloadedState });
     const element = screen.queryByPlaceholderText(/Filter by text/i);
     expect(element).toBeTruthy();
   });
 
   describe('Severity filter', () => {
     it("Given that more than one filter is selected, unchecking one item doesn't uncheck the rest", () => {
-      render(<ClusterEventsList {...props} />);
+      renderWithRedux(<ClusterEventsList {...props} />);
 
       // open the severity filter menu
       const severityFilter = screen.getByText(/Severity/i);
@@ -218,7 +232,7 @@ describe('<ClusterEventsList />', () => {
 
   describe('Hosts filter', () => {
     it("Given that 'cluster-level' events and 'deleted hosts' options are selected exclusively; selecting one of the hosts won't activate the 'select all' checkbox", () => {
-      render(<ClusterEventsList {...props} />);
+      renderWithRedux(<ClusterEventsList {...props} />);
 
       // open the hosts filter menu
       const hostsFilter = screen.getByRole('button', { name: /hosts/i });

--- a/src/testUtils.tsx
+++ b/src/testUtils.tsx
@@ -1,0 +1,23 @@
+import React, { PropsWithChildren } from 'react';
+import { render, RenderOptions } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import rootReducer, { RootState } from './store/rootReducer';
+
+type RenderWithReduxOptions = RenderOptions & { preloadedState?: RootState };
+
+export const renderWithRedux = (
+  ui: React.ReactElement,
+  { preloadedState, ...options }: RenderWithReduxOptions = {},
+) => {
+  const WithRedux = ({ children }: PropsWithChildren<unknown>) => {
+    const store = configureStore({
+      reducer: rootReducer,
+      preloadedState,
+    });
+
+    return <Provider store={store}>{children}</Provider>;
+  };
+
+  return render(ui, { wrapper: WithRedux, ...options });
+};


### PR DESCRIPTION
Before this PR The UI attempts to resolve the hostname in every event message if it is available, otherwise, it shows the host's UUID. The idea is to perform this logic on the server.

- DO NOT MERGE YET! (waiting for [this task](https://issues.redhat.com/browse/MGMT-4131) to be finished on BE side)