### PR TITLE
MGMT-4272 Fixes CIDR validation for IPv6

### DIFF
--- a/src/components/ui/formik/validationSchemas.ts
+++ b/src/components/ui/formik/validationSchemas.ts
@@ -158,7 +158,7 @@ export const ipBlockValidationSchema = Yup.string()
     },
   )
   .test(
-    'valid-cidr',
+    'valid-cidr-base-address',
     ({ value }) => `${value} is not a valid CIDR`,
     (value: string) => {
       const ip = stringToIPAddress(value);
@@ -166,9 +166,11 @@ export const ipBlockValidationSchema = Yup.string()
         return false;
       }
 
-      const startAddress = ip.startAddress().address;
+      const networkAddress = ip.startAddress().parsedAddress;
+      const ipAddress = ip.parsedAddress;
+      const result = ipAddress.every((part, idx) => part === networkAddress[idx]);
 
-      return ip.addressMinusSuffix === startAddress;
+      return result;
     },
   );
 


### PR DESCRIPTION
Fixes a bug related to the validation of the CIDR fields that occurs when the value is expressed in IPv6 short form (e.g. 2002:db8::/53).