### PR TITLE
Min height 200 pull secret text area

### DIFF
--- a/src/components/clusters/NewClusterPage.css
+++ b/src/components/clusters/NewClusterPage.css
@@ -1,5 +1,6 @@
 .form-new-cluster .form-group-pull-secret {
   height: calc(100vh - 650px);
+  min-height: 200px;
 }
 
 .form-new-cluster .form-group-pull-secret .pf-c-form__group-control {


### PR DESCRIPTION
When the window height is too small the pull secret text area gets squished down to height 0 and it's impossible/hard to interact with it.

Not sure if this is the correct way to fix it (and also not sure how to test it, it worked locally in my browser dev window). 

Feel free to modify the PR / fix it / close it / recreate it however you see fit 