### PR TITLE
BZ-1934610 Updates the Configure HTTP Proxy label

### DIFF
--- a/src/components/clusterConfiguration/ProxyFields.tsx
+++ b/src/components/clusterConfiguration/ProxyFields.tsx
@@ -30,7 +30,7 @@ const ProxyFields: React.FC = () => {
   return (
     <>
       <CheckboxField
-        label="Configure HTTP Proxy"
+        label="Configure cluster-wide proxy settings"
         name="enableProxy"
         helperText="If hosts are behind a firewall that requires the use of a proxy, provide additional information about the proxy."
         onChange={(value: boolean) => resetProxy(value)}


### PR DESCRIPTION
Configure HTTP Proxy" string should change to "Configure Proxy"
![ksnip_20210304-163935](https://user-images.githubusercontent.com/77008341/109980136-41146c80-7d08-11eb-93c5-b5c070e9f776.png)
Reported in: assisted-ui-lib version:  0.0.8-wizard

**MUST be merged into `wizard` branch for QE validation.**