### PR TITLE
OCPBUGSM-25836 Disable version select if cluster exists

### DIFF
--- a/src/components/clusterConfiguration/OpenShiftVersionSelect.tsx
+++ b/src/components/clusterConfiguration/OpenShiftVersionSelect.tsx
@@ -8,9 +8,13 @@ import { ClusterCreateParams } from '../../api/types';
 import { SNO_SUPPORT_MIN_VERSION } from '../../config/constants';
 
 type OpenShiftVersionSelectProps = {
+  isDisabled: boolean;
   versions: OpenshiftVersionOptionType[];
 };
-const OpenShiftVersionSelect: React.FC<OpenShiftVersionSelectProps> = ({ versions }) => {
+const OpenShiftVersionSelect: React.FC<OpenShiftVersionSelectProps> = ({
+  versions,
+  isDisabled,
+}) => {
   const {
     values: { highAvailabilityMode },
     setFieldValue,
@@ -53,7 +57,7 @@ const OpenShiftVersionSelect: React.FC<OpenShiftVersionSelectProps> = ({ version
       name="openshiftVersion"
       options={selectOptions}
       getHelperText={getOpenshiftVersionHelperText}
-      isDisabled={versions.length === 0}
+      isDisabled={isDisabled || versions.length === 0}
       isRequired
     />
   );

--- a/src/components/clusterWizard/ClusterDetails.tsx
+++ b/src/components/clusterWizard/ClusterDetails.tsx
@@ -243,7 +243,7 @@ const ClusterDetailsForm: React.FC<ClusterDetailsFormProps> = (props) => {
                     versions={versions}
                     isDisabled={!!cluster}
                   />
-                  <OpenShiftVersionSelect versions={versions} />
+                  <OpenShiftVersionSelect versions={versions} isDisabled={!!cluster} />
                   {!cluster?.pullSecretSet && <PullSecret pullSecret={pullSecret} />}
                 </Form>
               </GridItem>


### PR DESCRIPTION
It is not possible to update openshiftVersion once the cluster has been created.
This change disables the version select field if cluster exists