### PR TITLE
OCPBUGSM-25659 Rename Hardware and Network status column to 'Status'

### DIFF
--- a/src/components/hosts/BaremetalDiscoveryHostsTable.tsx
+++ b/src/components/hosts/BaremetalDiscoveryHostsTable.tsx
@@ -20,7 +20,7 @@ import HostsCount from './HostsCount';
 const getColumns = (hosts?: Host[]) => [
   { title: 'Hostname', transforms: [sortable], cellFormatters: [expandable] },
   { title: 'Role', transforms: [sortable] },
-  { title: 'Hardware Status', transforms: [sortable] },
+  { title: 'Status', transforms: [sortable] },
   { title: 'Discovered At', transforms: [sortable] },
   { title: 'CPU Cores', transforms: [sortable] }, // cores per machine (sockets x cores)
   { title: 'Memory', transforms: [sortable] },

--- a/src/components/hosts/NetworkingHostsTable.tsx
+++ b/src/components/hosts/NetworkingHostsTable.tsx
@@ -42,7 +42,7 @@ const getSelectedNic = (nics: Interface[], currentSubnet: Address4 | Address6) =
 const getColumns = (hosts?: Host[]) => [
   { title: 'Hostname', transforms: [sortable], cellFormatters: [expandable] },
   { title: 'Role', transforms: [sortable] },
-  { title: 'Network Status', transforms: [sortable] },
+  { title: 'Status', transforms: [sortable] },
   { title: 'Active NIC', transforms: [sortable] }, // cores per machine (sockets x cores)
   { title: 'IPv4 address', transforms: [sortable] },
   { title: 'Ipv6 address', transforms: [sortable] },


### PR DESCRIPTION
Since host tables can show validations from several validation groups (Hardware, Network, ...), labeling the status column as 'Hardware Status' and 'Network Status' is misleading. This rolls back to 'Status' label on all tables.