### PR TITLE
Show host progress on installed host

### DIFF
--- a/src/components/hosts/HostStatus.tsx
+++ b/src/components/hosts/HostStatus.tsx
@@ -22,10 +22,10 @@ import { ValidationsInfo } from '../../types/hosts';
 import HostProgress from './HostProgress';
 import { HOST_STATUS_LABELS, HOST_STATUS_DETAILS } from '../../config/constants';
 import { getHumanizedDateTime } from '../ui/utils';
-import { toSentence } from '../ui/table/utils';
 import { getHostProgressStageNumber, getHostProgressStages } from './utils';
 import HostValidationGroups, { ValidationInfoActionProps } from './HostValidationGroups';
 import OcpConsoleNodesSectionLink from './OcpConsoleNodesSectionLink';
+import { toSentence } from '../ui/table/utils';
 
 const getStatusIcon = (status: Host['status']): React.ReactElement => {
   switch (status) {
@@ -92,13 +92,19 @@ const HostStatusPopoverContent: React.FC<HostStatusPopoverContentProps> = (props
     return (
       <TextContent>
         <Text>
-          {statusDetails && (
-            <>
-              {statusDetails} <br />
-            </>
-          )}
+          {statusDetails}
+          <br />
           {toSentence(statusInfo)}
         </Text>
+        <HostProgress host={host} />
+      </TextContent>
+    );
+  }
+
+  if (['installed'].includes(status)) {
+    return (
+      <TextContent>
+        <Text>{statusDetails}</Text>
         <HostProgress host={host} />
       </TextContent>
     );


### PR DESCRIPTION
Installed hosts should show progress in the status popover rather than
validations info

![Screenshot from 2021-03-10 08-46-53](https://user-images.githubusercontent.com/1121740/110600955-c5da0d00-8184-11eb-8317-842d4ce9ce2c.png)
