### PR TITLE
BZ-1936360 Advanced networking checkbox is enabled when creating new cluster

### DIFF
--- a/src/components/clusterConfiguration/ClusterConfiguration.tsx
+++ b/src/components/clusterConfiguration/ClusterConfiguration.tsx
@@ -16,18 +16,23 @@ const ClusterConfiguration: React.FC<ClusterConfigurationProps> = ({ cluster }) 
   const { addAlert } = React.useContext(AlertsContext);
 
   React.useEffect(() => {
+    let mounted = true;
     const fetchManagedDomains = async () => {
       try {
         const { data } = await getManagedDomains();
-        setDomains(data);
+        if (mounted) setDomains(data);
       } catch (e) {
-        setDomains([]);
+        if (mounted) setDomains([]);
         handleApiError(e, () =>
           addAlert({ title: 'Failed to retrieve managed domains', message: getErrorMessage(e) }),
         );
       }
     };
     fetchManagedDomains();
+
+    return () => {
+      mounted = false;
+    };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   if (domains) {

--- a/src/components/clusterConfiguration/ClusterDefaultConfigurationContext.tsx
+++ b/src/components/clusterConfiguration/ClusterDefaultConfigurationContext.tsx
@@ -1,31 +1,52 @@
 import _ from 'lodash';
-import React, { useContext, useEffect, useState } from 'react';
-import { handleApiError, getErrorMessage } from '../../api';
+import React, { PropsWithChildren, useContext, useEffect } from 'react';
 import { getClustersDefaultConfiguration } from '../../api/clusters';
 import { ClusterDefaultConfig } from '../../api/types';
-import { AlertsContext } from '../AlertsContextProvider';
+
+type State<T> = { status: 'idle' | 'loading' | 'succeeded' | 'failed'; data: T };
+type Actions<T> = { type: 'request' } | { type: 'failure' | 'success'; data: T };
+
+const reducer: React.Reducer<State<ClusterDefaultConfig>, Actions<ClusterDefaultConfig>> = (
+  state,
+  action,
+) => {
+  let newState: State<ClusterDefaultConfig>;
+  switch (action.type) {
+    case 'request':
+      newState = { status: 'loading', data: {} };
+      break;
+    case 'success':
+      newState = { status: 'succeeded', data: action.data };
+      break;
+    case 'failure':
+      newState = { status: 'failed', data: action.data };
+      break;
+    default:
+      newState = state;
+      break;
+  }
+
+  return newState;
+};
 
 export const ClusterDefaultConfigurationContext = React.createContext<ClusterDefaultConfig>({});
 
-export const ClusterDefaultConfigurationProvider: React.FC = ({ children }) => {
-  const [defaultConfiguration, setDefaultConfiguration] = useState<ClusterDefaultConfig>({});
-  const { addAlert } = React.useContext(AlertsContext);
+export const ClusterDefaultConfigurationProvider = ({
+  children,
+  errorUI,
+  loadingUI,
+}: PropsWithChildren<{ errorUI: React.ReactNode; loadingUI: React.ReactNode }>) => {
+  const [state, dispatch] = React.useReducer(reducer, { status: 'idle', data: {} });
 
   useEffect(() => {
     let mounted = true;
     const fetchAndSetDefaultConfiguration = async () => {
       try {
+        if (mounted) dispatch({ type: 'request' });
         const { data } = await getClustersDefaultConfiguration();
-        if (mounted) {
-          setDefaultConfiguration(data);
-        }
-      } catch (e) {
-        handleApiError(e, () =>
-          addAlert({
-            title: 'Failed to retrieve the default configuration',
-            message: getErrorMessage(e),
-          }),
-        );
+        if (mounted) dispatch({ type: 'success', data });
+      } catch {
+        if (mounted) dispatch({ type: 'failure', data: {} });
       }
     };
     fetchAndSetDefaultConfiguration();
@@ -35,9 +56,32 @@ export const ClusterDefaultConfigurationProvider: React.FC = ({ children }) => {
     };
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
+  const render = (state: State<ClusterDefaultConfig>) => {
+    let result: {
+      ui: React.ReactNode;
+      value: ClusterDefaultConfig;
+    } = { ui: loadingUI, value: state.data };
+
+    switch (state.status) {
+      case 'idle':
+      case 'loading':
+        break;
+      case 'failed':
+        result = { ...result, ui: errorUI };
+        break;
+      case 'succeeded':
+        result = { ...result, ui: children };
+        break;
+    }
+
+    return result;
+  };
+
+  const { ui, value } = render(state);
+
   return (
-    <ClusterDefaultConfigurationContext.Provider value={defaultConfiguration}>
-      {children}
+    <ClusterDefaultConfigurationContext.Provider value={value}>
+      {ui}
     </ClusterDefaultConfigurationContext.Provider>
   );
 };

--- a/src/components/clusters/ClusterPage.tsx
+++ b/src/components/clusters/ClusterPage.tsx
@@ -108,12 +108,14 @@ const ClusterPage: React.FC<RouteComponentProps<MatchParams>> = ({ match }) => {
     }
   };
 
+  const loadingUI = (
+    <PageSection variant={PageSectionVariants.light} isMain>
+      <LoadingState />
+    </PageSection>
+  );
+
   if (uiState === ResourceUIState.LOADING) {
-    return (
-      <PageSection variant={PageSectionVariants.light} isMain>
-        <LoadingState />
-      </PageSection>
-    );
+    return loadingUI;
   }
 
   if (uiState === ResourceUIState.ERROR) {
@@ -132,10 +134,19 @@ const ClusterPage: React.FC<RouteComponentProps<MatchParams>> = ({ match }) => {
     );
   }
 
+  const errorUI = (
+    <PageSection variant={PageSectionVariants.light} isMain>
+      <ErrorState
+        title="Failed to retrieve the default configuration"
+        actions={errorStateActions}
+      />
+    </PageSection>
+  );
+
   if (cluster) {
     return (
       <AlertsContextProvider>
-        <ClusterDefaultConfigurationProvider>
+        <ClusterDefaultConfigurationProvider loadingUI={loadingUI} errorUI={errorUI}>
           {getContent(cluster)}
           <CancelInstallationModal
             isOpen={cancelInstallationModalOpen}

--- a/src/components/clusters/NewClusterPage.tsx
+++ b/src/components/clusters/NewClusterPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import * as Yup from 'yup';
 import { Formik, FormikHelpers } from 'formik';
-import { useHistory } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import {
   Form,
   Grid,
@@ -10,6 +10,7 @@ import {
   TextContent,
   Text,
   ButtonVariant,
+  Button,
 } from '@patternfly/react-core';
 import PageSection from '../ui/PageSection';
 import { ToolbarButton } from '../ui/Toolbar';
@@ -32,6 +33,7 @@ import { OpenshiftVersionOptionType } from '../../types/versions';
 import SingleNodeCheckbox from '../ui/formik/SingleNodeCheckbox';
 import OpenShiftVersionSelect from '../clusterConfiguration/OpenShiftVersionSelect';
 import { ClusterDefaultConfigurationProvider } from '../clusterConfiguration/ClusterDefaultConfigurationContext';
+import { ErrorState } from '../ui/uiState';
 
 import './NewClusterPage.css';
 
@@ -157,6 +159,12 @@ const NewClusterForm: React.FC<NewClusterFormProps> = ({ pullSecret = '', versio
   );
 };
 
+const loadingUI = (
+  <PageSection variant={PageSectionVariants.light} isMain>
+    <LoadingState />
+  </PageSection>
+);
+
 const NewCluster: React.FC = () => {
   const { addAlert } = React.useContext(AlertsContext);
   const pullSecret = usePullSecretFetch();
@@ -169,19 +177,32 @@ const NewCluster: React.FC = () => {
   ]);
 
   if (pullSecret === undefined || loadingOCPVersions) {
-    return (
-      <PageSection variant={PageSectionVariants.light} isMain>
-        <LoadingState />
-      </PageSection>
-    );
+    return loadingUI;
   }
 
   return <NewClusterForm pullSecret={pullSecret} versions={versions} />;
 };
 
+const errorUI = (
+  <PageSection variant={PageSectionVariants.light} isMain>
+    <ErrorState
+      title="Failed to retrieve the default configuration"
+      actions={[
+        <Button
+          key="cancel"
+          variant={ButtonVariant.secondary}
+          component={(props) => <Link to={`${routeBasePath}/clusters`} {...props} />}
+        >
+          Back
+        </Button>,
+      ]}
+    />
+  </PageSection>
+);
+
 const NewClusterPage: React.FC = () => (
   <AlertsContextProvider>
-    <ClusterDefaultConfigurationProvider>
+    <ClusterDefaultConfigurationProvider loadingUI={loadingUI} errorUI={errorUI}>
       <NewCluster />
     </ClusterDefaultConfigurationProvider>
   </AlertsContextProvider>


### PR DESCRIPTION
If the `clusters/default-config` API endpoint is not available the provider will render an "error" UI and a "loading" UI while it is fetching data.
The end goal is to prevent the form to be initially filled with empty data and then updated with default values coming from the API; that is what is enabling the checkbox.