### PR TITLE
BZ 1938969: Disable Back button on BareMetalDiscovery

### DIFF
--- a/src/components/clusterConfiguration/ClusterValidationSection.tsx
+++ b/src/components/clusterConfiguration/ClusterValidationSection.tsx
@@ -69,6 +69,15 @@ const ClusterValidationSection: React.FC<ClusterValidationSectionProps> = ({
     <Split>
       <SplitItem isFilled>
         <AlertGroup className="cluster-validation-section">
+          {!cluster.validationsInfo && (
+            <Alert
+              variant={AlertVariant.info}
+              title="Cluster validations are initializing"
+              isInline
+            >
+              Please hold on till backgroud checks are started.
+            </Alert>
+          )}
           {!errorFields.length && dirty && (
             <Alert
               variant={AlertVariant.info}
@@ -106,7 +115,7 @@ const ClusterValidationSection: React.FC<ClusterValidationSectionProps> = ({
               </Flex>
             </Alert>
           )}
-          {!isContentToDisplay && (
+          {!isContentToDisplay && !!cluster.validationsInfo && (
             <Alert variant={AlertVariant.info} title="Host validations are failing" isInline>
               All relevant cluster-level validations are passing, inspect individual hosts.
             </Alert>

--- a/src/components/clusterWizard/BaremetalDiscovery.tsx
+++ b/src/components/clusterWizard/BaremetalDiscovery.tsx
@@ -63,6 +63,7 @@ const BaremetalDiscovery: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
             isSubmitting={isSubmitting}
             isNextDisabled={dirty || !canNextBaremetalDiscovery({ cluster })}
             onNext={() => setCurrentStepId('networking')}
+            isBackDisabled={!cluster.validationsInfo}
             onBack={() => setCurrentStepId('cluster-details')}
           />
         );

--- a/src/components/clusterWizard/ClusterWizardToolbar.tsx
+++ b/src/components/clusterWizard/ClusterWizardToolbar.tsx
@@ -38,6 +38,7 @@ type ClusterWizardToolbarProps = {
   isSubmitting?: boolean;
   onNext?: () => void;
   isNextDisabled?: boolean;
+  isBackDisabled?: boolean;
   onBack?: () => void;
   onCancel?: () => void;
   onInstall?: () => Promise<void>;
@@ -118,7 +119,8 @@ const ClusterWizardToolbar: React.FC<ClusterWizardToolbarProps> = ({
   onCancel,
   onNext,
   onInstall,
-  isNextDisabled,
+  isNextDisabled = false,
+  isBackDisabled = false,
   onBack,
 }) => {
   const [isValidationSectionOpen, setIsValidationSectionOpen] = React.useState(false);
@@ -187,7 +189,7 @@ const ClusterWizardToolbar: React.FC<ClusterWizardToolbarProps> = ({
               variant={ButtonVariant.secondary}
               name="back"
               onClick={onBack}
-              isDisabled={false}
+              isDisabled={isBackDisabled}
             >
               Back
             </ToolbarButton>


### PR DESCRIPTION
when validationsInfo is not available.
That might happen right after cluster's creation.