### PR TITLE
BZ-1917423 Table elements should be identifiable by ID

### DIFF
--- a/src/components/clusters/ClusterStatus.tsx
+++ b/src/components/clusters/ClusterStatus.tsx
@@ -19,6 +19,7 @@ import { getHumanizedDateTime } from '../ui/utils';
 
 type ClusterStatusProps = {
   cluster: Cluster;
+  testId?: string;
 };
 
 const getStatusIcon = (status: Cluster['status']): React.ReactElement => {
@@ -46,7 +47,7 @@ const getStatusIcon = (status: Cluster['status']): React.ReactElement => {
 export const getClusterStatusText = (cluster: Cluster) =>
   CLUSTER_STATUS_LABELS[cluster.status] || cluster.status;
 
-const ClusterStatus: React.FC<ClusterStatusProps> = ({ cluster }) => {
+const ClusterStatus: React.FC<ClusterStatusProps> = ({ cluster, testId }) => {
   const { status, statusInfo, statusUpdatedAt } = cluster;
   const title = getClusterStatusText(cluster);
   const icon = getStatusIcon(status) || null;
@@ -59,7 +60,12 @@ const ClusterStatus: React.FC<ClusterStatusProps> = ({ cluster }) => {
         minWidth="30rem"
         maxWidth="50rem"
       >
-        <Button variant={ButtonVariant.link} isInline id={`button-cluster-status-${cluster.name}`}>
+        <Button
+          variant={ButtonVariant.link}
+          isInline
+          data-testid={testId}
+          id={`button-cluster-status-${cluster.name}`}
+        >
           {icon} {title}
         </Button>
       </Popover>

--- a/src/components/clusters/ClustersTable.tsx
+++ b/src/components/clusters/ClustersTable.tsx
@@ -172,7 +172,7 @@ const ClustersTable: React.FC<ClustersTableProps> = ({ rows, deleteCluster }) =>
         sortBy={sortBy}
         onSort={onSort}
         rowWrapper={ClusterRowWrapper}
-        data-testid={'ClustersTable'}
+        data-testid={'clusters-table'}
       >
         <TableHeader />
         <TableBody rowKey={rowKey} />

--- a/src/components/clusters/ClustersTable.tsx
+++ b/src/components/clusters/ClustersTable.tsx
@@ -50,9 +50,17 @@ const columns = [
 const getStatusCell = (row: IRow) => row.cells?.[3] as HumanizedSortable | undefined;
 
 const ClusterRowWrapper = (props: RowWrapperProps) => {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-  // @ts-ignore
-  return <RowWrapper {...props} id={`cluster-row-${props.row?.props?.name}`} />;
+  /* eslint-disable @typescript-eslint/ban-ts-ignore */
+  return (
+    <RowWrapper
+      {...props}
+      // @ts-ignore
+      data-testid={`cluster-row-${props.row?.props?.name}`}
+      // @ts-ignore
+      id={`cluster-row-${props.row?.props?.name}`}
+    />
+  );
+  /* eslint-enable @typescript-eslint/ban-ts-ignore */
 };
 
 const ClustersTable: React.FC<ClustersTableProps> = ({ rows, deleteCluster }) => {
@@ -164,6 +172,7 @@ const ClustersTable: React.FC<ClustersTableProps> = ({ rows, deleteCluster }) =>
         sortBy={sortBy}
         onSort={onSort}
         rowWrapper={ClusterRowWrapper}
+        data-testid={'ClustersTable'}
       >
         <TableHeader />
         <TableBody rowKey={rowKey} />

--- a/src/components/hosts/BaremetalDiscoveryHostsTable.tsx
+++ b/src/components/hosts/BaremetalDiscoveryHostsTable.tsx
@@ -10,7 +10,6 @@ import { getHostRowHardwareInfo } from './hardwareInfo';
 import { ValidationsInfo } from '../../types/hosts';
 import { canEditRole, getHostname, getHostRole } from './utils';
 import Hostname from './Hostname';
-import { DASH } from '../constants';
 import RoleCell from './RoleCell';
 import HardwareStatus from './HardwareStatus';
 import { getDateTimeCell } from '../ui/table/utils';

--- a/src/components/hosts/BaremetalDiscoveryHostsTable.tsx
+++ b/src/components/hosts/BaremetalDiscoveryHostsTable.tsx
@@ -40,6 +40,7 @@ const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host
   );
   const computedHostname = getHostname(host, inventory);
   const hostRole = getHostRole(host);
+  const dateTimeCell = getDateTimeCell(createdAt);
 
   return [
     {
@@ -47,28 +48,50 @@ const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host
       isOpen: !!openRows[id],
       cells: [
         {
-          title: computedHostname ? (
-            <Hostname host={host} inventory={inventory} cluster={cluster} />
-          ) : (
-            DASH
+          title: (
+            <Hostname
+              testId={`host-name-${computedHostname}`}
+              host={host}
+              inventory={inventory}
+              cluster={cluster}
+            />
           ),
           sortableValue: computedHostname || '',
         },
         {
           title: (
-            <RoleCell host={host} readonly={!canEditRole(cluster, host.status)} role={hostRole} />
+            <RoleCell
+              testId={`host-role-${computedHostname}`}
+              host={host}
+              readonly={!canEditRole(cluster, host.status)}
+              role={hostRole}
+            />
           ),
           sortableValue: hostRole,
         },
         {
-          title: <HardwareStatus host={host} cluster={cluster} validationsInfo={validationsInfo} />,
+          title: (
+            <HardwareStatus
+              testId={`host-hw-status-${computedHostname}`}
+              host={host}
+              cluster={cluster}
+              validationsInfo={validationsInfo}
+            />
+          ),
           sortableValue: status,
         },
-        getDateTimeCell(createdAt),
+        {
+          title: (
+            <span data-testid={`host-discovered-time-${computedHostname}`}>
+              {dateTimeCell.title}
+            </span>
+          ),
+          sortableValue: dateTimeCell.sortableValue,
+        },
         {
           title: (
             <HostPropertyValidationPopover validation={cpuCoresValidation}>
-              {cores.title}
+              <span data-testid={`host-cpu-cores-${computedHostname}`}>{cores.title}</span>
             </HostPropertyValidationPopover>
           ),
           sortableValue: cores.sortableValue,
@@ -76,7 +99,7 @@ const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host
         {
           title: (
             <HostPropertyValidationPopover validation={memoryValidation}>
-              {memory.title}
+              <span data-testid={`host-memory-${computedHostname}`}>{memory.title}</span>
             </HostPropertyValidationPopover>
           ),
           sortableValue: memory.sortableValue,
@@ -84,7 +107,7 @@ const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host
         {
           title: (
             <HostPropertyValidationPopover validation={diskValidation}>
-              {disk.title}
+              <span data-testid={`host-disk-${computedHostname}`}>{disk.title}</span>
             </HostPropertyValidationPopover>
           ),
           sortableValue: disk.sortableValue,
@@ -125,7 +148,14 @@ type BaremetalDiscoveryHostsTableProps = {
 };
 
 const BaremetalDiscoveryHostsTable: React.FC<BaremetalDiscoveryHostsTableProps> = (props) => {
-  return <HostsTable {...props} getColumns={getColumns} hostToHostTableRow={hostToHostTableRow} />;
+  return (
+    <HostsTable
+      {...props}
+      testId={'bare-metal-discovery-hosts-table'}
+      getColumns={getColumns}
+      hostToHostTableRow={hostToHostTableRow}
+    />
+  );
 };
 
 export default BaremetalDiscoveryHostsTable;

--- a/src/components/hosts/BaremetalDiscoveryHostsTable.tsx
+++ b/src/components/hosts/BaremetalDiscoveryHostsTable.tsx
@@ -48,19 +48,14 @@ const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host
       cells: [
         {
           title: (
-            <Hostname
-              testId={`host-name-${computedHostname}`}
-              host={host}
-              inventory={inventory}
-              cluster={cluster}
-            />
+            <Hostname testId={`host-name`} host={host} inventory={inventory} cluster={cluster} />
           ),
           sortableValue: computedHostname || '',
         },
         {
           title: (
             <RoleCell
-              testId={`host-role-${computedHostname}`}
+              testId={`host-role`}
               host={host}
               readonly={!canEditRole(cluster, host.status)}
               role={hostRole}
@@ -71,7 +66,7 @@ const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host
         {
           title: (
             <HardwareStatus
-              testId={`host-hw-status-${computedHostname}`}
+              testId={`host-hw-status`}
               host={host}
               cluster={cluster}
               validationsInfo={validationsInfo}
@@ -80,17 +75,13 @@ const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host
           sortableValue: status,
         },
         {
-          title: (
-            <span data-testid={`host-discovered-time-${computedHostname}`}>
-              {dateTimeCell.title}
-            </span>
-          ),
+          title: <span data-testid={`host-discovered-time`}>{dateTimeCell.title}</span>,
           sortableValue: dateTimeCell.sortableValue,
         },
         {
           title: (
             <HostPropertyValidationPopover validation={cpuCoresValidation}>
-              <span data-testid={`host-cpu-cores-${computedHostname}`}>{cores.title}</span>
+              <span data-testid={`host-cpu-cores`}>{cores.title}</span>
             </HostPropertyValidationPopover>
           ),
           sortableValue: cores.sortableValue,
@@ -98,7 +89,7 @@ const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host
         {
           title: (
             <HostPropertyValidationPopover validation={memoryValidation}>
-              <span data-testid={`host-memory-${computedHostname}`}>{memory.title}</span>
+              <span data-testid={`host-memory`}>{memory.title}</span>
             </HostPropertyValidationPopover>
           ),
           sortableValue: memory.sortableValue,
@@ -106,7 +97,7 @@ const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host
         {
           title: (
             <HostPropertyValidationPopover validation={diskValidation}>
-              <span data-testid={`host-disk-${computedHostname}`}>{disk.title}</span>
+              <span data-testid={`host-disk`}>{disk.title}</span>
             </HostPropertyValidationPopover>
           ),
           sortableValue: disk.sortableValue,

--- a/src/components/hosts/HardwareStatus.tsx
+++ b/src/components/hosts/HardwareStatus.tsx
@@ -12,6 +12,7 @@ type HardwareStatusProps = {
   host: Host;
   validationsInfo: ValidationsInfo;
   cluster: Cluster;
+  testId?: string;
 };
 
 const HardwareStatus: React.FC<HardwareStatusProps> = (props) => {

--- a/src/components/hosts/HostStatus.tsx
+++ b/src/components/hosts/HostStatus.tsx
@@ -129,6 +129,7 @@ type HostStatusProps = {
   cluster: Cluster;
   statusOverride?: Host['status'];
   sublabel?: string;
+  testId?: string;
 };
 
 const HostStatusPopoverFooter: React.FC<{ host: Host }> = ({ host }) => {
@@ -166,6 +167,7 @@ const HostStatus: React.FC<HostStatusProps> = ({
   validationsInfo,
   statusOverride,
   sublabel,
+  testId = 'host-status',
 }) => {
   const [keepOnOutsideClick, onValidationActionToggle] = React.useState(false);
   const status = statusOverride || host.status;
@@ -197,7 +199,7 @@ const HostStatus: React.FC<HostStatusProps> = ({
         hideOnOutsideClick={!keepOnOutsideClick}
         zIndex={300}
       >
-        <Button variant={ButtonVariant.link} isInline>
+        <Button data-testid={testId} variant={ButtonVariant.link} isInline>
           {icon} {title}{' '}
           {['installing', 'installing-in-progress', 'error', 'cancelled'].includes(status) && (
             <>

--- a/src/components/hosts/Hostname.tsx
+++ b/src/components/hosts/Hostname.tsx
@@ -3,6 +3,7 @@ import { Button, ButtonVariant } from '@patternfly/react-core';
 import EditHostModal from './EditHostModal';
 import { Host, Inventory, Cluster } from '../../api/types';
 import { getHostname } from './utils';
+import { DASH } from '../constants';
 
 type HostnameProps = {
   host: Host;
@@ -12,6 +13,7 @@ type HostnameProps = {
   // Provide either inventory or title
   inventory?: Inventory;
   title?: string;
+  testId?: string;
 };
 
 const Hostname: React.FC<HostnameProps> = ({
@@ -21,6 +23,7 @@ const Hostname: React.FC<HostnameProps> = ({
   title,
   className,
   onToggle,
+  testId = 'host-name',
 }) => {
   const [isOpen, _setOpen] = React.useState(false);
 
@@ -29,12 +32,13 @@ const Hostname: React.FC<HostnameProps> = ({
     _setOpen(isOpen);
   };
 
-  const hostname = title || getHostname(host, inventory);
+  const hostname = title || getHostname(host, inventory) || DASH;
   const isHostnameChangeRequested = !title && host.requestedHostname !== inventory.hostname;
 
   return (
     <>
       <Button
+        data-testid={testId}
         variant={ButtonVariant.link}
         isInline
         onClick={() => setOpen(true)}

--- a/src/components/hosts/HostsCount.tsx
+++ b/src/components/hosts/HostsCount.tsx
@@ -6,6 +6,7 @@ type HostsCountProps = {
   hosts?: Host[];
   inParenthesis?: boolean;
   valueId?: string;
+  testId?: string;
 };
 
 export const getEnabledHostsCount = (hosts?: Host[]) =>
@@ -18,6 +19,7 @@ const HostsCount: React.FC<HostsCountProps> = ({
   hosts,
   inParenthesis = false,
   valueId = 'hosts-count',
+  testId,
 }) => {
   const hostsDiscovered = hosts?.length || 0;
   const hostsIncluded = getEnabledHostsCount(hosts);
@@ -42,7 +44,7 @@ const HostsCount: React.FC<HostsCountProps> = ({
 
   return (
     <Popover headerContent="Hosts in the cluster" bodyContent={body}>
-      <a id={valueId}>
+      <a id={valueId} data-testid={testId}>
         {inParenthesis && '('}
         {hostsIncluded}
         {inParenthesis && ')'}

--- a/src/components/hosts/HostsTable.tsx
+++ b/src/components/hosts/HostsTable.tsx
@@ -13,6 +13,8 @@ import {
   ISortBy,
   OnSort,
   ICell,
+  RowWrapperProps,
+  RowWrapper,
 } from '@patternfly/react-table';
 import { ConnectedIcon } from '@patternfly/react-icons';
 import { ExtraParamsType } from '@patternfly/react-table/dist/js/components/Table/base';
@@ -97,6 +99,7 @@ const defaultHostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (hos
   );
   const computedHostname = getHostname(host, inventory);
   const hostRole = getHostRole(host);
+  const dateTimeCell = getDateTimeCell(createdAt);
 
   return [
     {
@@ -104,28 +107,50 @@ const defaultHostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (hos
       isOpen: !!openRows[id],
       cells: [
         {
-          title: computedHostname ? (
-            <Hostname host={host} inventory={inventory} cluster={cluster} />
-          ) : (
-            DASH
+          title: (
+            <Hostname
+              testId={`host-name-${computedHostname}`}
+              host={host}
+              inventory={inventory}
+              cluster={cluster}
+            />
           ),
           sortableValue: computedHostname || '',
         },
         {
           title: (
-            <RoleCell host={host} readonly={!canEditRole(cluster, host.status)} role={hostRole} />
+            <RoleCell
+              testId={`host-role-${computedHostname}`}
+              host={host}
+              readonly={!canEditRole(cluster, host.status)}
+              role={hostRole}
+            />
           ),
           sortableValue: hostRole,
         },
         {
-          title: <HostStatus host={host} cluster={cluster} validationsInfo={validationsInfo} />,
+          title: (
+            <HostStatus
+              testId={`host-status-${computedHostname}`}
+              host={host}
+              cluster={cluster}
+              validationsInfo={validationsInfo}
+            />
+          ),
           sortableValue: status,
         },
-        getDateTimeCell(createdAt),
+        {
+          title: (
+            <span data-testid={`host-discovered-time-${computedHostname}`}>
+              {dateTimeCell.title}
+            </span>
+          ),
+          sortableValue: dateTimeCell.sortableValue,
+        },
         {
           title: (
             <HostPropertyValidationPopover validation={cpuCoresValidation}>
-              {cores.title}
+              <span data-testid={`host-cpu-cores-${computedHostname}`}>{cores.title}</span>
             </HostPropertyValidationPopover>
           ),
           sortableValue: cores.sortableValue,
@@ -133,7 +158,7 @@ const defaultHostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (hos
         {
           title: (
             <HostPropertyValidationPopover validation={memoryValidation}>
-              {memory.title}
+              <span data-testid={`host-memory-${computedHostname}`}>{memory.title + 'foo'}</span>
             </HostPropertyValidationPopover>
           ),
           sortableValue: memory.sortableValue,
@@ -141,7 +166,7 @@ const defaultHostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (hos
         {
           title: (
             <HostPropertyValidationPopover validation={diskValidation}>
-              {disk.title}
+              <span data-testid={`host-disks-${computedHostname}`}>{disk.title}</span>
             </HostPropertyValidationPopover>
           ),
           sortableValue: disk.sortableValue,
@@ -199,12 +224,17 @@ const rowKey = ({ rowData }: ExtraParamsType) => rowData?.key;
 const isHostShown = (skipDisabled: boolean) => (host: Host) =>
   !skipDisabled || host.status != 'disabled';
 
+const HostsTableRowWrapper = (props: RowWrapperProps) => (
+  <RowWrapper {...props} data-testid={`host-row-${props.rowProps?.rowIndex}`} />
+);
+
 type HostsTableProps = {
   cluster: Cluster;
   getColumns?: (hosts?: Host[]) => (string | ICell)[];
   hostToHostTableRow?: (openRows: OpenRows, cluster: Cluster) => (host: Host) => IRow;
   skipDisabled?: boolean;
   setDiscoveryHintModalOpen?: HostsNotShowingLinkProps['setDiscoveryHintModalOpen'];
+  testId?: string;
 };
 
 const HostsTable: React.FC<HostsTableProps> = ({
@@ -213,6 +243,7 @@ const HostsTable: React.FC<HostsTableProps> = ({
   getColumns = defaultGetColumns,
   skipDisabled = false,
   setDiscoveryHintModalOpen,
+  testId = 'hosts-table',
 }) => {
   const { addAlert } = React.useContext(AlertsContext);
   const {
@@ -476,6 +507,8 @@ const HostsTable: React.FC<HostsTableProps> = ({
         className="hosts-table"
         sortBy={sortBy}
         onSort={onSort}
+        rowWrapper={HostsTableRowWrapper}
+        data-testid={testId}
       >
         <TableHeader />
         <TableBody rowKey={rowKey} />

--- a/src/components/hosts/HostsTable.tsx
+++ b/src/components/hosts/HostsTable.tsx
@@ -38,7 +38,6 @@ import {
 } from '../../features/clusters/currentClusterSlice';
 import { handleApiError, stringToJSON, getErrorMessage } from '../../api/utils';
 import sortable from '../ui/table/sortable';
-import { DASH } from '../constants';
 import { AlertsContext } from '../AlertsContextProvider';
 import {
   HostsNotShowingLink,

--- a/src/components/hosts/HostsTable.tsx
+++ b/src/components/hosts/HostsTable.tsx
@@ -107,19 +107,14 @@ const defaultHostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (hos
       cells: [
         {
           title: (
-            <Hostname
-              testId={`host-name-${computedHostname}`}
-              host={host}
-              inventory={inventory}
-              cluster={cluster}
-            />
+            <Hostname testId={`host-name`} host={host} inventory={inventory} cluster={cluster} />
           ),
           sortableValue: computedHostname || '',
         },
         {
           title: (
             <RoleCell
-              testId={`host-role-${computedHostname}`}
+              testId={`host-role`}
               host={host}
               readonly={!canEditRole(cluster, host.status)}
               role={hostRole}
@@ -130,7 +125,7 @@ const defaultHostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (hos
         {
           title: (
             <HostStatus
-              testId={`host-status-${computedHostname}`}
+              testId={`host-status`}
               host={host}
               cluster={cluster}
               validationsInfo={validationsInfo}
@@ -139,17 +134,13 @@ const defaultHostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (hos
           sortableValue: status,
         },
         {
-          title: (
-            <span data-testid={`host-discovered-time-${computedHostname}`}>
-              {dateTimeCell.title}
-            </span>
-          ),
+          title: <span data-testid={`host-discovered-time`}>{dateTimeCell.title}</span>,
           sortableValue: dateTimeCell.sortableValue,
         },
         {
           title: (
             <HostPropertyValidationPopover validation={cpuCoresValidation}>
-              <span data-testid={`host-cpu-cores-${computedHostname}`}>{cores.title}</span>
+              <span data-testid={`host-cpu-cores`}>{cores.title}</span>
             </HostPropertyValidationPopover>
           ),
           sortableValue: cores.sortableValue,
@@ -157,7 +148,7 @@ const defaultHostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (hos
         {
           title: (
             <HostPropertyValidationPopover validation={memoryValidation}>
-              <span data-testid={`host-memory-${computedHostname}`}>{memory.title + 'foo'}</span>
+              <span data-testid={`host-memory`}>{memory.title}</span>
             </HostPropertyValidationPopover>
           ),
           sortableValue: memory.sortableValue,
@@ -165,7 +156,7 @@ const defaultHostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (hos
         {
           title: (
             <HostPropertyValidationPopover validation={diskValidation}>
-              <span data-testid={`host-disks-${computedHostname}`}>{disk.title}</span>
+              <span data-testid={`host-disks`}>{disk.title}</span>
             </HostPropertyValidationPopover>
           ),
           sortableValue: disk.sortableValue,

--- a/src/components/hosts/NetworkingHostsTable.tsx
+++ b/src/components/hosts/NetworkingHostsTable.tsx
@@ -14,6 +14,7 @@ import HostsCount from './HostsCount';
 import NetworkingStatus from './NetworkingStatus';
 import { getSubnet } from '../clusterConfiguration/utils';
 import { Address4, Address6 } from 'ip-address';
+import RoleCell from './RoleCell';
 
 const getSelectedNic = (nics: Interface[], currentSubnet: Address4 | Address6) => {
   return nics.find((nic) => {
@@ -68,38 +69,67 @@ const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host
       isOpen: !!openRows[id],
       cells: [
         {
-          title: computedHostname ? (
-            <Hostname host={host} inventory={inventory} cluster={cluster} />
-          ) : (
-            DASH
+          title: (
+            <Hostname
+              testId={`host-name-${computedHostname}`}
+              host={host}
+              inventory={inventory}
+              cluster={cluster}
+            />
           ),
           sortableValue: computedHostname || '',
         },
         {
-          title: hostRole,
+          title: (
+            <RoleCell
+              testId={`host-role-${computedHostname}`}
+              host={host}
+              readonly
+              role={hostRole}
+            />
+          ),
           sortableValue: hostRole,
         },
         {
           title: (
-            <NetworkingStatus host={host} cluster={cluster} validationsInfo={validationsInfo} />
+            <NetworkingStatus
+              testId={`nic-status-${computedHostname}`}
+              host={host}
+              cluster={cluster}
+              validationsInfo={validationsInfo}
+            />
           ),
           sortableValue: status,
         },
         {
-          title: selectedNic ? selectedNic.name : DASH,
-          sortableValue: selectedNic ? selectedNic.name : DASH,
+          title: (
+            <span data-testid={`nic-name-${computedHostname}`}>{selectedNic?.name || DASH}</span>
+          ),
+          sortableValue: selectedNic?.name || DASH,
         },
         {
-          title: selectedNic ? (selectedNic.ipv4Addresses || []).join(', ') : DASH,
-          sortableValue: selectedNic ? (selectedNic.ipv4Addresses || []).join(', ') : DASH,
+          title: (
+            <span data-testid={`nic-ipv4-addresses-${computedHostname}`}>
+              {(selectedNic?.ipv4Addresses || []).join(', ') || DASH}
+            </span>
+          ),
+          sortableValue: (selectedNic?.ipv4Addresses || []).join(', ') || DASH,
         },
         {
-          title: selectedNic ? (selectedNic.ipv6Addresses || []).join(', ') : DASH,
-          sortableValueitle: selectedNic ? (selectedNic.ipv6Addresses || []).join(', ') : DASH,
+          title: (
+            <span data-testid={`nic-ipv6-addresses-${computedHostname}`}>
+              {(selectedNic?.ipv6Addresses || []).join(', ') || DASH}
+            </span>
+          ),
+          sortableValue: (selectedNic?.ipv6Addresses || []).join(', ') || DASH,
         },
         {
-          title: selectedNic ? selectedNic.macAddress : DASH,
-          sortableValueitle: selectedNic ? selectedNic.macAddress : DASH,
+          title: (
+            <span data-testid={`nic-mac-address-${computedHostname}`}>
+              {selectedNic?.macAddress || DASH}
+            </span>
+          ),
+          sortableValue: selectedNic?.macAddress || DASH,
         },
       ],
       host,

--- a/src/components/hosts/NetworkingHostsTable.tsx
+++ b/src/components/hosts/NetworkingHostsTable.tsx
@@ -70,30 +70,18 @@ const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host
       cells: [
         {
           title: (
-            <Hostname
-              testId={`host-name-${computedHostname}`}
-              host={host}
-              inventory={inventory}
-              cluster={cluster}
-            />
+            <Hostname testId={`host-name`} host={host} inventory={inventory} cluster={cluster} />
           ),
           sortableValue: computedHostname || '',
         },
         {
-          title: (
-            <RoleCell
-              testId={`host-role-${computedHostname}`}
-              host={host}
-              readonly
-              role={hostRole}
-            />
-          ),
+          title: <RoleCell testId={`host-role`} host={host} readonly role={hostRole} />,
           sortableValue: hostRole,
         },
         {
           title: (
             <NetworkingStatus
-              testId={`nic-status-${computedHostname}`}
+              testId={`nic-status`}
               host={host}
               cluster={cluster}
               validationsInfo={validationsInfo}
@@ -102,14 +90,12 @@ const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host
           sortableValue: status,
         },
         {
-          title: (
-            <span data-testid={`nic-name-${computedHostname}`}>{selectedNic?.name || DASH}</span>
-          ),
+          title: <span data-testid={`nic-name`}>{selectedNic?.name || DASH}</span>,
           sortableValue: selectedNic?.name || DASH,
         },
         {
           title: (
-            <span data-testid={`nic-ipv4-addresses-${computedHostname}`}>
+            <span data-testid={`nic-ipv4-addresses`}>
               {(selectedNic?.ipv4Addresses || []).join(', ') || DASH}
             </span>
           ),
@@ -117,18 +103,14 @@ const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host
         },
         {
           title: (
-            <span data-testid={`nic-ipv6-addresses-${computedHostname}`}>
+            <span data-testid={`nic-ipv6-addresses`}>
               {(selectedNic?.ipv6Addresses || []).join(', ') || DASH}
             </span>
           ),
           sortableValue: (selectedNic?.ipv6Addresses || []).join(', ') || DASH,
         },
         {
-          title: (
-            <span data-testid={`nic-mac-address-${computedHostname}`}>
-              {selectedNic?.macAddress || DASH}
-            </span>
-          ),
+          title: <span data-testid={`nic-mac-address`}>{selectedNic?.macAddress || DASH}</span>,
           sortableValue: selectedNic?.macAddress || DASH,
         },
       ],

--- a/src/components/hosts/NetworkingStatus.tsx
+++ b/src/components/hosts/NetworkingStatus.tsx
@@ -12,6 +12,7 @@ type NetworkingStatusProps = {
   host: Host;
   validationsInfo: ValidationsInfo;
   cluster: Cluster;
+  testId?: string;
 };
 
 const NetworkingStatus: React.FC<NetworkingStatusProps> = (props) => {

--- a/src/components/hosts/RoleCell.tsx
+++ b/src/components/hosts/RoleCell.tsx
@@ -6,10 +6,20 @@ type RoleCellProps = {
   host: Host;
   role: string;
   readonly?: boolean;
+  testId?: string;
 };
 
-const RoleCell: React.FC<RoleCellProps> = ({ host, role, readonly = false }) => {
-  return !readonly ? <RoleDropdown host={host} /> : <>{role}</>;
+const RoleCell: React.FC<RoleCellProps> = ({
+  host,
+  role,
+  readonly = false,
+  testId = 'host-role',
+}) => {
+  return !readonly ? (
+    <RoleDropdown testId={testId} host={host} />
+  ) : (
+    <span data-testid={testId}>{role}</span>
+  );
 };
 
 export default RoleCell;

--- a/src/components/hosts/RoleDropdown.tsx
+++ b/src/components/hosts/RoleDropdown.tsx
@@ -11,9 +11,10 @@ import { getHostRole } from './utils';
 
 type RoleDropdownProps = {
   host: Host;
+  testId?: string;
 };
 
-export const RoleDropdown: React.FC<RoleDropdownProps> = ({ host }) => {
+export const RoleDropdown: React.FC<RoleDropdownProps> = ({ host, testId }) => {
   const { id, clusterId } = host;
   const [isDisabled, setDisabled] = React.useState(false);
   const dispatch = useDispatch();
@@ -42,6 +43,7 @@ export const RoleDropdown: React.FC<RoleDropdownProps> = ({ host }) => {
       setValue={setRole}
       isDisabled={isDisabled}
       idPrefix={`role-${host.requestedHostname}`}
+      testId={testId}
     />
   );
 };

--- a/src/components/ui/SimpleDropdown.tsx
+++ b/src/components/ui/SimpleDropdown.tsx
@@ -10,6 +10,7 @@ type SimpleDropdownProps = {
   setValue: (value?: string) => void;
   isDisabled: boolean;
   idPrefix?: string;
+  testId?: string;
 };
 
 export const SimpleDropdown: React.FC<SimpleDropdownProps> = ({
@@ -19,6 +20,7 @@ export const SimpleDropdown: React.FC<SimpleDropdownProps> = ({
   setValue,
   isDisabled,
   idPrefix,
+  testId = 'SimpleDropdown',
 }) => {
   const [isOpen, setOpen] = React.useState(false);
   const dropdownItems = items.map(({ value, label, description }) => (
@@ -57,6 +59,7 @@ export const SimpleDropdown: React.FC<SimpleDropdownProps> = ({
       isOpen={isOpen}
       isPlain
       id={idPrefix ? `${idPrefix}-dropdown-toggle` : undefined}
+      data-testid={testId}
     />
   );
 };

--- a/src/selectors/clusters.tsx
+++ b/src/selectors/clusters.tsx
@@ -27,27 +27,43 @@ export const selectClustersUIState = createSelector(
 
 const clusterToClusterTableRow = (cluster: Cluster): IRow => {
   const { id, name, hosts, openshiftVersion, baseDnsDomain, createdAt } = cluster;
+  const dateTimeCell = getDateTimeCell(createdAt);
+
   return {
     cells: [
       {
         title: (
-          <Link key={name} to={`${routeBasePath}/clusters/${id}`} id={`cluster-link-${name}`}>
+          <Link
+            key={name}
+            to={`${routeBasePath}/clusters/${id}`}
+            data-testid={`cluster-name-${name}`}
+            id={`cluster-link-${name}`}
+          >
             {name}
           </Link>
         ),
         sortableValue: name,
       } as HumanizedSortable,
-      baseDnsDomain || DASH,
-      openshiftVersion,
       {
-        title: <ClusterStatus cluster={cluster} />,
+        title: <span data-testid={`cluster-base-domain-${name}`}>{baseDnsDomain || DASH}</span>,
+        sortableValue: baseDnsDomain,
+      },
+      {
+        title: <span data-testid={`cluster-version-${name}`}>{openshiftVersion}</span>,
+        sortableValue: openshiftVersion,
+      },
+      {
+        title: <ClusterStatus cluster={cluster} testId={`cluster-status-${name}`} />,
         sortableValue: getClusterStatusText(cluster),
       } as HumanizedSortable,
       {
-        title: <HostsCount hosts={hosts} valueId={`hosts-count-${cluster.name}`} />,
+        title: <HostsCount hosts={hosts} testId={`cluster-hosts-count-${name}`} />,
         sortableValue: getEnabledHostsCount(hosts),
       } as HumanizedSortable,
-      getDateTimeCell(createdAt),
+      {
+        title: <span data-testid={`cluster-created-time-${name}`}>{dateTimeCell.title}</span>,
+        sortableValue: dateTimeCell.sortableValue,
+      } as HumanizedSortable,
     ],
     props: {
       name,


### PR DESCRIPTION
This PR adds `data-testid` attributes to the ClustersTable:
![image](https://user-images.githubusercontent.com/77008341/112458829-e64dbe00-8d65-11eb-8464-9bcbf546fa8a.png)

and the *HostsTable:
![image](https://user-images.githubusercontent.com/77008341/112462969-5eb67e00-8d6a-11eb-8592-fc964983eb99.png)

### Remarks:
1. As can be seen in the screenshot, each row in the host table has appended its row number (obeying the table's sort value), so the first row will always have `data-testid="host-row-0"` and the second will have `data-testid="host-row-2"` (why? because the rows with odd numbers correspond to the host details. BTW haven't deal with it as part of this PR) no matter the sorting value of the table. Unfortunately, these test-id's cannot be based on the hosts' names because after being discovered they're all called the same (localhost) and only after changing them their names' uniqueness is enforced. 
2. I haven't removed any `id`s, intentionally, to prevent breaking the existing automated tests. We can encourage now QE to start using the `.findByTestId` API from the `cypress/testing-library` or `cy.get('data-testid="foo-bar"')` API.


