### PR TITLE
Disable Next button and show 'Saving changes' when creating cluster

### DIFF
--- a/src/components/clusterWizard/ClusterDetails.tsx
+++ b/src/components/clusterWizard/ClusterDetails.tsx
@@ -257,7 +257,11 @@ const ClusterDetailsForm: React.FC<ClusterDetailsFormProps> = (props) => {
             dirty={dirty}
             isSubmitting={isSubmitting}
             isNextDisabled={
-              !(isValid && (dirty || (cluster && canNextClusterDetails({ cluster }))))
+              !(
+                !isSubmitting &&
+                isValid &&
+                (dirty || (cluster && canNextClusterDetails({ cluster })))
+              )
             }
             onNext={submitForm}
           />

--- a/src/components/clusterWizard/ClusterWizardToolbar.tsx
+++ b/src/components/clusterWizard/ClusterWizardToolbar.tsx
@@ -23,7 +23,7 @@ import { getWizardStepClusterStatus } from './wizardTransition';
 import ClusterWizardContext from './ClusterWizardContext';
 
 type ValidationSectionToggleProps = {
-  cluster: Cluster;
+  cluster?: Cluster;
   formErrors: FormikErrors<ClusterUpdateParams>;
   isSubmitting?: boolean;
   isStartingInstallation?: boolean;
@@ -79,7 +79,7 @@ const ValidationSectionToggle: React.FC<ValidationSectionToggleProps> = ({
     );
   }
 
-  if (getWizardStepClusterStatus(cluster, currentStepId) !== 'ready') {
+  if (cluster && getWizardStepClusterStatus(cluster, currentStepId) !== 'ready') {
     return (
       <Button variant={ButtonVariant.link} onClick={toggleValidationSection} isInline>
         <WarningTriangleIcon color={warningColor.value} />
@@ -88,7 +88,7 @@ const ValidationSectionToggle: React.FC<ValidationSectionToggleProps> = ({
     );
   }
 
-  if (onInstall) {
+  if (cluster && onInstall) {
     if (cluster.status === 'ready') {
       return (
         <>
@@ -202,17 +202,14 @@ const ClusterWizardToolbar: React.FC<ClusterWizardToolbarProps> = ({
           >
             Cancel
           </ToolbarButton>
-
-          {cluster && (
-            <ValidationSectionToggle
-              cluster={cluster}
-              formErrors={formErrors}
-              isSubmitting={isSubmitting}
-              isStartingInstallation={isStartingInstallation}
-              onInstall={onInstall}
-              toggleValidationSection={() => setIsValidationSectionOpen(!isValidationSectionOpen)}
-            />
-          )}
+          <ValidationSectionToggle
+            cluster={cluster}
+            formErrors={formErrors}
+            isSubmitting={isSubmitting}
+            isStartingInstallation={isStartingInstallation}
+            onInstall={onInstall}
+            toggleValidationSection={() => setIsValidationSectionOpen(!isValidationSectionOpen)}
+          />
         </ClusterToolbar>
       </StackItem>
     </Stack>


### PR DESCRIPTION
The `ClusterWizardToolbar` has gotten too complex which is completely unnecessary. The toolbar should be a simple presentational component (or a set of components for buttons for example) and the individual step components should define its behaviour for each step separately.