### PR TITLE
BZ1938969: Do not disable back button if validationsInfo is missing

### DIFF
--- a/src/components/clusterWizard/BaremetalDiscovery.tsx
+++ b/src/components/clusterWizard/BaremetalDiscovery.tsx
@@ -55,7 +55,6 @@ const BaremetalDiscovery: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
             isSubmitting={isSubmitting}
             isNextDisabled={dirty || !canNextBaremetalDiscovery({ cluster })}
             onNext={() => setCurrentStepId('networking')}
-            isBackDisabled={!cluster.validationsInfo}
             onBack={() => setCurrentStepId('cluster-details')}
           />
         );


### PR DESCRIPTION
Just the Next button is disabled in that case.
A descriptive info message is rendered.

Follow-up for: #512 