### PR TITLE
BZ-1917423 - Table elements should be identifiable by ID

### DIFF
--- a/src/components/clusters/ClusterStatus.tsx
+++ b/src/components/clusters/ClusterStatus.tsx
@@ -17,7 +17,6 @@ import { Cluster } from '../../api/types';
 import { CLUSTER_STATUS_LABELS } from '../../config/constants';
 
 type ClusterStatusProps = {
-  testId?: string;
   status: Cluster['status'];
 };
 
@@ -57,7 +56,7 @@ export const ClusterStatusIcon: React.FC<ClusterStatusIconProps> = ({ status, ..
 export const getClusterStatusText = (status: Cluster['status']) =>
   CLUSTER_STATUS_LABELS[status] || status;
 
-const ClusterStatus: React.FC<ClusterStatusProps> = ({ status, testId }) => {
+const ClusterStatus: React.FC<ClusterStatusProps & WithTestID> = ({ status, testId }) => {
   const title = getClusterStatusText(status);
 
   return (

--- a/src/components/hosts/HardwareStatus.tsx
+++ b/src/components/hosts/HardwareStatus.tsx
@@ -12,10 +12,9 @@ type HardwareStatusProps = {
   host: Host;
   validationsInfo: ValidationsInfo;
   cluster: Cluster;
-  testId?: string;
 };
 
-const HardwareStatus: React.FC<HardwareStatusProps> = (props) => {
+const HardwareStatus: React.FC<HardwareStatusProps & WithTestID> = (props) => {
   const hardwareStatus = getWizardStepHostStatus(props.host, 'host-discovery');
   const validationsInfo = getWizardStepHostValidationsInfo(props.validationsInfo, 'host-discovery');
   const sublabel = getFailingClusterWizardSoftValidationIds(validationsInfo, 'host-discovery')

--- a/src/components/hosts/HardwareStatus.tsx
+++ b/src/components/hosts/HardwareStatus.tsx
@@ -14,7 +14,7 @@ type HardwareStatusProps = {
   cluster: Cluster;
 };
 
-const HardwareStatus: React.FC<HardwareStatusProps & WithTestID> = (props) => {
+const HardwareStatus: React.FC<HardwareStatusProps> = (props) => {
   const hardwareStatus = getWizardStepHostStatus(props.host, 'host-discovery');
   const validationsInfo = getWizardStepHostValidationsInfo(props.validationsInfo, 'host-discovery');
   const sublabel = getFailingClusterWizardSoftValidationIds(validationsInfo, 'host-discovery')

--- a/src/components/hosts/HostStatus.tsx
+++ b/src/components/hosts/HostStatus.tsx
@@ -160,13 +160,12 @@ const HostStatusPopoverFooter: React.FC<{ host: Host }> = ({ host }) => {
   return <small>{footerText}</small>;
 };
 
-const HostStatus: React.FC<HostStatusProps & WithTestID> = ({
+const HostStatus: React.FC<HostStatusProps> = ({
   host,
   cluster,
   validationsInfo,
   statusOverride,
   sublabel,
-  testId = 'host-status',
 }) => {
   const [keepOnOutsideClick, onValidationActionToggle] = React.useState(false);
   const status = statusOverride || host.status;
@@ -198,7 +197,7 @@ const HostStatus: React.FC<HostStatusProps & WithTestID> = ({
         hideOnOutsideClick={!keepOnOutsideClick}
         zIndex={300}
       >
-        <Button data-testid={testId} variant={ButtonVariant.link} isInline>
+        <Button variant={ButtonVariant.link} isInline>
           {icon} {title}{' '}
           {['installing', 'installing-in-progress', 'error', 'cancelled'].includes(status) && (
             <>

--- a/src/components/hosts/HostStatus.tsx
+++ b/src/components/hosts/HostStatus.tsx
@@ -129,7 +129,6 @@ type HostStatusProps = {
   cluster: Cluster;
   statusOverride?: Host['status'];
   sublabel?: string;
-  testId?: string;
 };
 
 const HostStatusPopoverFooter: React.FC<{ host: Host }> = ({ host }) => {
@@ -161,7 +160,7 @@ const HostStatusPopoverFooter: React.FC<{ host: Host }> = ({ host }) => {
   return <small>{footerText}</small>;
 };
 
-const HostStatus: React.FC<HostStatusProps> = ({
+const HostStatus: React.FC<HostStatusProps & WithTestID> = ({
   host,
   cluster,
   validationsInfo,

--- a/src/components/hosts/Hostname.tsx
+++ b/src/components/hosts/Hostname.tsx
@@ -15,14 +15,13 @@ type HostnameProps = {
   title?: string;
 };
 
-const Hostname: React.FC<HostnameProps & WithTestID> = ({
+const Hostname: React.FC<HostnameProps> = ({
   host,
   inventory = {},
   cluster,
   title,
   className,
   onToggle,
-  testId = 'host-name',
 }) => {
   const [isOpen, _setOpen] = React.useState(false);
 
@@ -37,7 +36,6 @@ const Hostname: React.FC<HostnameProps & WithTestID> = ({
   return (
     <>
       <Button
-        data-testid={testId}
         variant={ButtonVariant.link}
         isInline
         onClick={() => setOpen(true)}

--- a/src/components/hosts/Hostname.tsx
+++ b/src/components/hosts/Hostname.tsx
@@ -13,10 +13,9 @@ type HostnameProps = {
   // Provide either inventory or title
   inventory?: Inventory;
   title?: string;
-  testId?: string;
 };
 
-const Hostname: React.FC<HostnameProps> = ({
+const Hostname: React.FC<HostnameProps & WithTestID> = ({
   host,
   inventory = {},
   cluster,

--- a/src/components/hosts/HostsCount.tsx
+++ b/src/components/hosts/HostsCount.tsx
@@ -6,7 +6,6 @@ type HostsCountProps = {
   hosts?: Host[];
   inParenthesis?: boolean;
   valueId?: string;
-  testId?: string;
 };
 
 export const getEnabledHostsCount = (hosts?: Host[]) =>
@@ -15,7 +14,7 @@ export const getEnabledHostsCount = (hosts?: Host[]) =>
 const getReadyHostsCount = (hosts?: Host[]) =>
   (hosts || []).filter((h) => h.status === 'known').length;
 
-const HostsCount: React.FC<HostsCountProps> = ({
+const HostsCount: React.FC<HostsCountProps & WithTestID> = ({
   hosts,
   inParenthesis = false,
   valueId = 'hosts-count',

--- a/src/components/hosts/HostsCount.tsx
+++ b/src/components/hosts/HostsCount.tsx
@@ -14,11 +14,10 @@ export const getEnabledHostsCount = (hosts?: Host[]) =>
 const getReadyHostsCount = (hosts?: Host[]) =>
   (hosts || []).filter((h) => h.status === 'known').length;
 
-const HostsCount: React.FC<HostsCountProps & WithTestID> = ({
+const HostsCount: React.FC<HostsCountProps> = ({
   hosts,
   inParenthesis = false,
   valueId = 'hosts-count',
-  testId,
 }) => {
   const hostsDiscovered = hosts?.length || 0;
   const hostsIncluded = getEnabledHostsCount(hosts);
@@ -43,7 +42,7 @@ const HostsCount: React.FC<HostsCountProps & WithTestID> = ({
 
   return (
     <Popover headerContent="Hosts in the cluster" bodyContent={body}>
-      <a id={valueId} data-testid={testId}>
+      <a id={valueId}>
         {inParenthesis && '('}
         {hostsIncluded}
         {inParenthesis && ')'}

--- a/src/components/hosts/HostsDiscoveryTable.tsx
+++ b/src/components/hosts/HostsDiscoveryTable.tsx
@@ -27,7 +27,7 @@ const getColumns = (hosts?: Host[]) => [
   { title: <HostsCount hosts={hosts} inParenthesis /> },
 ];
 
-const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host): IRow => {
+const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host): IRow[] => {
   const { id, status, createdAt, inventory: inventoryString = '' } = host;
   const inventory = stringToJSON<Inventory>(inventoryString) || {};
   const { cores, memory, disk } = getHostRowHardwareInfo(inventory);
@@ -47,59 +47,52 @@ const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host
       isOpen: !!openRows[id],
       cells: [
         {
-          title: (
-            <Hostname testId={`host-name`} host={host} inventory={inventory} cluster={cluster} />
-          ),
+          title: <Hostname host={host} inventory={inventory} cluster={cluster} />,
+          props: { 'data-testid': 'host-name' },
           sortableValue: computedHostname || '',
         },
         {
           title: (
-            <RoleCell
-              testId={`host-role`}
-              host={host}
-              readonly={!canEditRole(cluster, host.status)}
-              role={hostRole}
-            />
+            <RoleCell host={host} readonly={!canEditRole(cluster, host.status)} role={hostRole} />
           ),
+          props: { 'data-testid': 'host-role' },
           sortableValue: hostRole,
         },
         {
-          title: (
-            <HardwareStatus
-              testId={`host-hw-status`}
-              host={host}
-              cluster={cluster}
-              validationsInfo={validationsInfo}
-            />
-          ),
+          title: <HardwareStatus host={host} cluster={cluster} validationsInfo={validationsInfo} />,
+          props: { 'data-testid': 'host-hw-status' },
           sortableValue: status,
         },
         {
-          title: <span data-testid={`host-discovered-time`}>{dateTimeCell.title}</span>,
+          title: dateTimeCell.title,
+          props: { 'data-testid': 'host-discovered-time' },
           sortableValue: dateTimeCell.sortableValue,
         },
         {
           title: (
             <HostPropertyValidationPopover validation={cpuCoresValidation}>
-              <span data-testid={`host-cpu-cores`}>{cores.title}</span>
+              {cores.title}
             </HostPropertyValidationPopover>
           ),
+          props: { 'data-testid': 'host-cpu-cores' },
           sortableValue: cores.sortableValue,
         },
         {
           title: (
             <HostPropertyValidationPopover validation={memoryValidation}>
-              <span data-testid={`host-memory`}>{memory.title}</span>
+              {memory.title}
             </HostPropertyValidationPopover>
           ),
+          props: { 'data-testid': 'host-memory' },
           sortableValue: memory.sortableValue,
         },
         {
           title: (
             <HostPropertyValidationPopover validation={diskValidation}>
-              <span data-testid={`host-disk`}>{disk.title}</span>
+              {disk.title}
             </HostPropertyValidationPopover>
           ),
+          props: { 'data-testid': 'host-disk' },
           sortableValue: disk.sortableValue,
         },
       ],

--- a/src/components/hosts/HostsTable.tsx
+++ b/src/components/hosts/HostsTable.tsx
@@ -106,59 +106,52 @@ const defaultHostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (hos
       isOpen: !!openRows[id],
       cells: [
         {
-          title: (
-            <Hostname testId={`host-name`} host={host} inventory={inventory} cluster={cluster} />
-          ),
+          title: <Hostname host={host} inventory={inventory} cluster={cluster} />,
+          props: { 'data-testid': 'host-name' },
           sortableValue: computedHostname || '',
         },
         {
           title: (
-            <RoleCell
-              testId={`host-role`}
-              host={host}
-              readonly={!canEditRole(cluster, host.status)}
-              role={hostRole}
-            />
+            <RoleCell host={host} readonly={!canEditRole(cluster, host.status)} role={hostRole} />
           ),
+          props: { 'data-testid': 'host-role' },
           sortableValue: hostRole,
         },
         {
-          title: (
-            <HostStatus
-              testId={`host-status`}
-              host={host}
-              cluster={cluster}
-              validationsInfo={validationsInfo}
-            />
-          ),
+          title: <HostStatus host={host} cluster={cluster} validationsInfo={validationsInfo} />,
+          props: { 'data-testid': 'host-status' },
           sortableValue: status,
         },
         {
-          title: <span data-testid={`host-discovered-time`}>{dateTimeCell.title}</span>,
+          title: dateTimeCell.title,
+          props: { 'data-testid': 'host-discovered-time' },
           sortableValue: dateTimeCell.sortableValue,
         },
         {
           title: (
             <HostPropertyValidationPopover validation={cpuCoresValidation}>
-              <span data-testid={`host-cpu-cores`}>{cores.title}</span>
+              {cores.title}
             </HostPropertyValidationPopover>
           ),
+          props: { 'data-testid': 'host-cpu-cores' },
           sortableValue: cores.sortableValue,
         },
         {
           title: (
             <HostPropertyValidationPopover validation={memoryValidation}>
-              <span data-testid={`host-memory`}>{memory.title}</span>
+              {memory.title}
             </HostPropertyValidationPopover>
           ),
+          props: { 'data-testid': 'host-memory' },
           sortableValue: memory.sortableValue,
         },
         {
           title: (
             <HostPropertyValidationPopover validation={diskValidation}>
-              <span data-testid={`host-disks`}>{disk.title}</span>
+              {disk.title}
             </HostPropertyValidationPopover>
           ),
+          props: { 'data-testid': 'host-disks' },
           sortableValue: disk.sortableValue,
         },
       ],

--- a/src/components/hosts/HostsTable.tsx
+++ b/src/components/hosts/HostsTable.tsx
@@ -224,10 +224,9 @@ type HostsTableProps = {
   hostToHostTableRow?: (openRows: OpenRows, cluster: Cluster) => (host: Host) => IRow;
   skipDisabled?: boolean;
   setDiscoveryHintModalOpen?: HostsNotShowingLinkProps['setDiscoveryHintModalOpen'];
-  testId?: string;
 };
 
-const HostsTable: React.FC<HostsTableProps> = ({
+const HostsTable: React.FC<HostsTableProps & WithTestID> = ({
   cluster,
   hostToHostTableRow = defaultHostToHostTableRow,
   getColumns = defaultGetColumns,

--- a/src/components/hosts/NetworkingHostsTable.tsx
+++ b/src/components/hosts/NetworkingHostsTable.tsx
@@ -149,7 +149,14 @@ type NetworkingHostsTableProps = {
 };
 
 const NetworkingHostsTable: React.FC<NetworkingHostsTableProps> = (props) => {
-  return <HostsTable {...props} getColumns={getColumns} hostToHostTableRow={hostToHostTableRow} />;
+  return (
+    <HostsTable
+      {...props}
+      testId={'networking-hosts-table'}
+      getColumns={getColumns}
+      hostToHostTableRow={hostToHostTableRow}
+    />
+  );
 };
 
 export default NetworkingHostsTable;

--- a/src/components/hosts/NetworkingHostsTable.tsx
+++ b/src/components/hosts/NetworkingHostsTable.tsx
@@ -51,7 +51,7 @@ const getColumns = (hosts?: Host[]) => [
   { title: <HostsCount hosts={hosts} inParenthesis /> },
 ];
 
-const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host): IRow => {
+const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host): IRow[] => {
   const { id, status, inventory: inventoryString = '' } = host;
   const inventory = stringToJSON<Inventory>(inventoryString) || {};
   const validationsInfo = stringToJSON<ValidationsInfo>(host.validationsInfo) || {};
@@ -69,48 +69,40 @@ const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host
       isOpen: !!openRows[id],
       cells: [
         {
-          title: (
-            <Hostname testId={`host-name`} host={host} inventory={inventory} cluster={cluster} />
-          ),
+          title: <Hostname host={host} inventory={inventory} cluster={cluster} />,
+          props: { 'data-testid': 'host-name' },
           sortableValue: computedHostname || '',
         },
         {
-          title: <RoleCell testId={`host-role`} host={host} readonly role={hostRole} />,
+          title: <RoleCell host={host} readonly role={hostRole} />,
+          props: { 'data-testid': 'host-role' },
           sortableValue: hostRole,
         },
         {
           title: (
-            <NetworkingStatus
-              testId={`nic-status`}
-              host={host}
-              cluster={cluster}
-              validationsInfo={validationsInfo}
-            />
+            <NetworkingStatus host={host} cluster={cluster} validationsInfo={validationsInfo} />
           ),
+          props: { 'data-testid': 'nic-status' },
           sortableValue: status,
         },
         {
-          title: <span data-testid={`nic-name`}>{selectedNic?.name || DASH}</span>,
+          title: selectedNic?.name || DASH,
+          props: { 'data-testid': 'nic-name' },
           sortableValue: selectedNic?.name || DASH,
         },
         {
-          title: (
-            <span data-testid={`nic-ipv4-addresses`}>
-              {(selectedNic?.ipv4Addresses || []).join(', ') || DASH}
-            </span>
-          ),
+          title: (selectedNic?.ipv4Addresses || []).join(', ') || DASH,
+          props: { 'data-testid': 'nic-ipv4' },
           sortableValue: (selectedNic?.ipv4Addresses || []).join(', ') || DASH,
         },
         {
-          title: (
-            <span data-testid={`nic-ipv6-addresses`}>
-              {(selectedNic?.ipv6Addresses || []).join(', ') || DASH}
-            </span>
-          ),
+          title: (selectedNic?.ipv6Addresses || []).join(', ') || DASH,
+          props: { 'data-testid': 'nic-ipv6' },
           sortableValue: (selectedNic?.ipv6Addresses || []).join(', ') || DASH,
         },
         {
-          title: <span data-testid={`nic-mac-address`}>{selectedNic?.macAddress || DASH}</span>,
+          title: selectedNic?.macAddress || DASH,
+          props: { 'data-testid': 'nic-mac-address' },
           sortableValue: selectedNic?.macAddress || DASH,
         },
       ],
@@ -152,7 +144,7 @@ const NetworkingHostsTable: React.FC<NetworkingHostsTableProps> = (props) => {
   return (
     <HostsTable
       {...props}
-      testId={'networking-hosts-table'}
+      testId={'networking-host-table'}
       getColumns={getColumns}
       hostToHostTableRow={hostToHostTableRow}
     />

--- a/src/components/hosts/NetworkingStatus.tsx
+++ b/src/components/hosts/NetworkingStatus.tsx
@@ -12,10 +12,9 @@ type NetworkingStatusProps = {
   host: Host;
   validationsInfo: ValidationsInfo;
   cluster: Cluster;
-  testId?: string;
 };
 
-const NetworkingStatus: React.FC<NetworkingStatusProps> = (props) => {
+const NetworkingStatus: React.FC<NetworkingStatusProps & WithTestID> = (props) => {
   const networkingStatus = getWizardStepHostStatus(props.host, 'networking');
   const validationsInfo = getWizardStepHostValidationsInfo(props.validationsInfo, 'networking');
   const sublabel = getFailingClusterWizardSoftValidationIds(validationsInfo, 'networking').length

--- a/src/components/hosts/NetworkingStatus.tsx
+++ b/src/components/hosts/NetworkingStatus.tsx
@@ -14,7 +14,7 @@ type NetworkingStatusProps = {
   cluster: Cluster;
 };
 
-const NetworkingStatus: React.FC<NetworkingStatusProps & WithTestID> = (props) => {
+const NetworkingStatus: React.FC<NetworkingStatusProps> = (props) => {
   const networkingStatus = getWizardStepHostStatus(props.host, 'networking');
   const validationsInfo = getWizardStepHostValidationsInfo(props.validationsInfo, 'networking');
   const sublabel = getFailingClusterWizardSoftValidationIds(validationsInfo, 'networking').length

--- a/src/components/hosts/RoleCell.tsx
+++ b/src/components/hosts/RoleCell.tsx
@@ -6,10 +6,9 @@ type RoleCellProps = {
   host: Host;
   role: string;
   readonly?: boolean;
-  testId?: string;
 };
 
-const RoleCell: React.FC<RoleCellProps> = ({
+const RoleCell: React.FC<RoleCellProps & WithTestID> = ({
   host,
   role,
   readonly = false,

--- a/src/components/hosts/RoleCell.tsx
+++ b/src/components/hosts/RoleCell.tsx
@@ -8,17 +8,7 @@ type RoleCellProps = {
   readonly?: boolean;
 };
 
-const RoleCell: React.FC<RoleCellProps & WithTestID> = ({
-  host,
-  role,
-  readonly = false,
-  testId = 'host-role',
-}) => {
-  return !readonly ? (
-    <RoleDropdown testId={testId} host={host} />
-  ) : (
-    <span data-testid={testId}>{role}</span>
-  );
-};
+const RoleCell: React.FC<RoleCellProps> = ({ host, role, readonly = false }) =>
+  !readonly ? <RoleDropdown host={host} /> : <>{role}</>;
 
 export default RoleCell;

--- a/src/components/hosts/RoleDropdown.tsx
+++ b/src/components/hosts/RoleDropdown.tsx
@@ -11,10 +11,9 @@ import { getHostRole } from './utils';
 
 type RoleDropdownProps = {
   host: Host;
-  testId?: string;
 };
 
-export const RoleDropdown: React.FC<RoleDropdownProps> = ({ host, testId }) => {
+export const RoleDropdown: React.FC<RoleDropdownProps & WithTestID> = ({ host, testId }) => {
   const { id, clusterId } = host;
   const [isDisabled, setDisabled] = React.useState(false);
   const dispatch = useDispatch();

--- a/src/components/hosts/RoleDropdown.tsx
+++ b/src/components/hosts/RoleDropdown.tsx
@@ -13,7 +13,7 @@ type RoleDropdownProps = {
   host: Host;
 };
 
-export const RoleDropdown: React.FC<RoleDropdownProps & WithTestID> = ({ host, testId }) => {
+export const RoleDropdown: React.FC<RoleDropdownProps> = ({ host }) => {
   const { id, clusterId } = host;
   const [isDisabled, setDisabled] = React.useState(false);
   const dispatch = useDispatch();
@@ -42,7 +42,6 @@ export const RoleDropdown: React.FC<RoleDropdownProps & WithTestID> = ({ host, t
       setValue={setRole}
       isDisabled={isDisabled}
       idPrefix={`role-${host.requestedHostname}`}
-      testId={testId}
     />
   );
 };

--- a/src/components/ui/DetailList.tsx
+++ b/src/components/ui/DetailList.tsx
@@ -43,10 +43,11 @@ export const DetailList: React.FC<DetailListProps> = ({
   </TextContent>
 );
 
-export const DetailItem: React.FC<DetailItemProps> = ({
+export const DetailItem: React.FC<DetailItemProps & WithTestID> = ({
   title,
   value = '',
   idPrefix,
+  testId,
   isHidden = false,
   classNameValue,
 }) =>
@@ -55,21 +56,31 @@ export const DetailItem: React.FC<DetailItemProps> = ({
       <TextListItem
         component={TextListItemVariants.dt}
         id={idPrefix ? `${idPrefix}-title` : undefined}
+        data-testid={testId ? `${testId}-title` : undefined}
       >
         {title}
       </TextListItem>
       <TextListItem
         component={TextListItemVariants.dd}
         id={idPrefix ? `${idPrefix}-value` : undefined}
+        data-testid={testId ? `${testId}-value` : undefined}
         className={classNameValue}
       >
         {Array.isArray(value) ? (
           <TextList component={TextListVariants.dl}>
-            {value.map((item) => [
-              <TextListItem key={item.title} component={TextListItemVariants.dt}>
+            {value.map((item, idx) => [
+              <TextListItem
+                data-testid={testId ? `${testId}-title-${idx}` : undefined}
+                key={item.title}
+                component={TextListItemVariants.dt}
+              >
                 {item.title}
               </TextListItem>,
-              <TextListItem key={`dd-${item.title}`} component={TextListItemVariants.dd}>
+              <TextListItem
+                data-testid={testId ? `${testId}-value-${idx}` : undefined}
+                key={`dd-${item.title}`}
+                component={TextListItemVariants.dd}
+              >
                 {item.value}
               </TextListItem>,
             ])}

--- a/src/components/ui/SimpleDropdown.tsx
+++ b/src/components/ui/SimpleDropdown.tsx
@@ -12,14 +12,13 @@ type SimpleDropdownProps = {
   idPrefix?: string;
 };
 
-export const SimpleDropdown: React.FC<SimpleDropdownProps & WithTestID> = ({
+export const SimpleDropdown: React.FC<SimpleDropdownProps> = ({
   current,
   defaultValue,
   items,
   setValue,
   isDisabled,
   idPrefix,
-  testId = 'SimpleDropdown',
 }) => {
   const [isOpen, setOpen] = React.useState(false);
   const dropdownItems = items.map(({ value, label, description }) => (
@@ -58,7 +57,6 @@ export const SimpleDropdown: React.FC<SimpleDropdownProps & WithTestID> = ({
       isOpen={isOpen}
       isPlain
       id={idPrefix ? `${idPrefix}-dropdown-toggle` : undefined}
-      data-testid={testId}
     />
   );
 };

--- a/src/components/ui/SimpleDropdown.tsx
+++ b/src/components/ui/SimpleDropdown.tsx
@@ -10,10 +10,9 @@ type SimpleDropdownProps = {
   setValue: (value?: string) => void;
   isDisabled: boolean;
   idPrefix?: string;
-  testId?: string;
 };
 
-export const SimpleDropdown: React.FC<SimpleDropdownProps> = ({
+export const SimpleDropdown: React.FC<SimpleDropdownProps & WithTestID> = ({
   current,
   defaultValue,
   items,

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -7,3 +7,7 @@ declare module '*.jpg' {
   const content: string;
   export default content;
 }
+
+interface WithTestID {
+  testId?: string;
+}

--- a/src/selectors/clusters.tsx
+++ b/src/selectors/clusters.tsx
@@ -33,35 +33,36 @@ const clusterToClusterTableRow = (cluster: Cluster): IRow => {
     cells: [
       {
         title: (
-          <Link
-            key={name}
-            to={`${routeBasePath}/clusters/${id}`}
-            data-testid={`cluster-name-${name}`}
-            id={`cluster-link-${name}`}
-          >
+          <Link key={name} to={`${routeBasePath}/clusters/${id}`} id={`cluster-link-${name}`}>
             {name}
           </Link>
         ),
+        props: { 'data-testid': `cluster-name-${name}` },
         sortableValue: name,
       } as HumanizedSortable,
       {
-        title: <span data-testid={`cluster-base-domain-${name}`}>{baseDnsDomain || DASH}</span>,
+        title: baseDnsDomain || DASH,
+        props: { 'data-testid': `cluster-base-domain-${name}` },
         sortableValue: baseDnsDomain,
       },
       {
-        title: <span data-testid={`cluster-version-${name}`}>{openshiftVersion}</span>,
+        title: openshiftVersion,
+        props: { 'data-testid': `cluster-version-${name}` },
         sortableValue: openshiftVersion,
       },
       {
-        title: <ClusterStatus status={cluster.status} testId={`cluster-status-${name}`} />,
+        title: <ClusterStatus status={cluster.status} />,
+        props: { 'data-testid': `cluster-status-${name}` },
         sortableValue: getClusterStatusText(cluster.status),
       } as HumanizedSortable,
       {
-        title: <HostsCount hosts={hosts} testId={`cluster-hosts-count-${name}`} />,
+        title: <HostsCount hosts={hosts} />,
+        props: { 'data-testid': `cluster-hosts-count-${name}` },
         sortableValue: getEnabledHostsCount(hosts),
       } as HumanizedSortable,
       {
-        title: <span data-testid={`cluster-created-time-${name}`}>{dateTimeCell.title}</span>,
+        title: dateTimeCell.title,
+        props: { 'data-testid': `cluster-created-time-${name}` },
         sortableValue: dateTimeCell.sortableValue,
       } as HumanizedSortable,
     ],


### PR DESCRIPTION
Adds `data-testid` attrs to missing elements in the host detail subtable.