### PR TITLE
MGMT-4659: Use Cluster.*host_count

### DIFF
--- a/src/components/AddHosts/AddHosts.tsx
+++ b/src/components/AddHosts/AddHosts.tsx
@@ -13,7 +13,7 @@ import { getErrorMessage, handleApiError, installHosts } from '../../api';
 import { addAlert } from '../../features/alerts/alertsSlice';
 import { updateCluster } from '../../features/clusters/currentClusterSlice';
 import { ClusterPreflightRequirementsContextProvider } from '../clusterConfiguration/ClusterPreflightRequirementsContext';
-import { hasKnownHost } from '../hosts/utils';
+import { getReadyHostCount } from '../hosts/utils';
 import { ToolbarButton, ToolbarSecondaryGroup } from '../ui';
 import Alerts from '../ui/Alerts';
 import { EventsModalButton } from '../ui/eventsModal';
@@ -59,7 +59,7 @@ const AddHosts: React.FC = () => {
                 variant={ButtonVariant.primary}
                 name="install"
                 onClick={handleHostsInstall}
-                isDisabled={!hasKnownHost(cluster)}
+                isDisabled={getReadyHostCount(cluster) <= 0}
               >
                 Install ready hosts
               </ToolbarButton>

--- a/src/components/hosts/HostsCount.tsx
+++ b/src/components/hosts/HostsCount.tsx
@@ -1,41 +1,32 @@
 import React from 'react';
 import { Popover, Level, LevelItem } from '@patternfly/react-core';
-import { Host } from '../../api/types';
-import { getEnabledHosts } from './utils';
+import { Cluster } from '../../api/types';
+import { getEnabledHostCount, getReadyHostCount, getTotalHostCount } from './utils';
 
 type HostsCountProps = {
-  hosts?: Host[];
+  cluster: Cluster;
   inParenthesis?: boolean;
   valueId?: string;
 };
 
-export const getEnabledHostsCount = (hosts?: Host[]) => getEnabledHosts(hosts).length;
-
-const getReadyHostsCount = (hosts?: Host[]) =>
-  (hosts || []).filter((h) => h.status === 'known').length;
-
 const HostsCount: React.FC<HostsCountProps> = ({
-  hosts,
+  cluster,
   inParenthesis = false,
   valueId = 'hosts-count',
 }) => {
-  const hostsDiscovered = hosts?.length || 0;
-  const hostsIncluded = getEnabledHostsCount(hosts);
-  const hostsReady = getReadyHostsCount(hosts);
-
   const body = (
     <>
       <Level>
         <LevelItem>Ready for the installation</LevelItem>
-        <LevelItem>{hostsReady}</LevelItem>
+        <LevelItem>{getReadyHostCount(cluster)}</LevelItem>
       </Level>
       <Level>
         <LevelItem>Enabled for the installation</LevelItem>
-        <LevelItem>{hostsIncluded}</LevelItem>
+        <LevelItem>{getEnabledHostCount(cluster)}</LevelItem>
       </Level>
       <Level>
         <LevelItem>All discovered</LevelItem>
-        <LevelItem>{hostsDiscovered}</LevelItem>
+        <LevelItem>{getTotalHostCount(cluster)}</LevelItem>
       </Level>
     </>
   );
@@ -44,7 +35,7 @@ const HostsCount: React.FC<HostsCountProps> = ({
     <Popover headerContent="Hosts in the cluster" bodyContent={body}>
       <a id={valueId}>
         {inParenthesis && '('}
-        {hostsIncluded}
+        {getEnabledHostCount(cluster)}
         {inParenthesis && ')'}
       </a>
     </Popover>

--- a/src/components/hosts/HostsDiscoveryTable.tsx
+++ b/src/components/hosts/HostsDiscoveryTable.tsx
@@ -16,7 +16,7 @@ import { getDateTimeCell } from '../ui/table/utils';
 import { HostsNotShowingLinkProps } from '../clusterConfiguration/DiscoveryTroubleshootingModal';
 import HostsCount from './HostsCount';
 
-const getColumns = (hosts?: Host[]) => [
+const getColumns = (cluster: Cluster) => [
   { title: 'Hostname', transforms: [sortable], cellFormatters: [expandable] },
   { title: 'Role', transforms: [sortable] },
   { title: 'Status', transforms: [sortable] },
@@ -24,7 +24,7 @@ const getColumns = (hosts?: Host[]) => [
   { title: 'CPU Cores', transforms: [sortable] }, // cores per machine (sockets x cores)
   { title: 'Memory', transforms: [sortable] },
   { title: 'Disk', transforms: [sortable] },
-  { title: <HostsCount hosts={hosts} inParenthesis /> },
+  { title: <HostsCount cluster={cluster} inParenthesis /> },
 ];
 
 const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host): IRow[] => {

--- a/src/components/hosts/HostsTable.tsx
+++ b/src/components/hosts/HostsTable.tsx
@@ -75,7 +75,7 @@ export type OpenRows = {
   [id: string]: boolean;
 };
 
-const defaultGetColumns = (hosts?: Host[]) => [
+const defaultGetColumns = (cluster: Cluster) => [
   { title: 'Hostname', transforms: [sortable], cellFormatters: [expandable] },
   { title: 'Role', transforms: [sortable] },
   { title: 'Status', transforms: [sortable] },
@@ -83,7 +83,7 @@ const defaultGetColumns = (hosts?: Host[]) => [
   { title: 'CPU Cores', transforms: [sortable] }, // cores per machine (sockets x cores)
   { title: 'Memory', transforms: [sortable] },
   { title: 'Disk', transforms: [sortable] },
-  { title: <HostsCount hosts={hosts} inParenthesis /> },
+  { title: <HostsCount cluster={cluster} inParenthesis /> },
 ];
 
 const defaultHostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host): IRow => {
@@ -213,7 +213,7 @@ const HostsTableRowWrapper = (props: RowWrapperProps) => (
 
 type HostsTableProps = {
   cluster: Cluster;
-  getColumns?: (hosts?: Host[]) => (string | ICell)[];
+  getColumns?: (cluster: Cluster) => (string | ICell)[];
   hostToHostTableRow?: (openRows: OpenRows, cluster: Cluster) => (host: Host) => IRow;
   skipDisabled?: boolean;
   setDiscoveryHintModalOpen?: HostsNotShowingLinkProps['setDiscoveryHintModalOpen'];
@@ -258,7 +258,7 @@ const HostsTable: React.FC<HostsTableProps & WithTestID> = ({
     [cluster, skipDisabled, openRows, sortBy, hostToHostTableRow],
   );
 
-  const columns = React.useMemo(() => getColumns(cluster.hosts), [cluster.hosts, getColumns]);
+  const columns = React.useMemo(() => getColumns(cluster), [cluster, getColumns]);
 
   const rows = React.useMemo(() => {
     if (hostRows.length) {

--- a/src/components/hosts/NetworkingHostsTable.tsx
+++ b/src/components/hosts/NetworkingHostsTable.tsx
@@ -40,7 +40,7 @@ const getSelectedNic = (nics: Interface[], currentSubnet: Address4 | Address6) =
   });
 };
 
-const getColumns = (hosts?: Host[]) => [
+const getColumns = (cluster: Cluster) => [
   { title: 'Hostname', transforms: [sortable], cellFormatters: [expandable] },
   { title: 'Role', transforms: [sortable] },
   { title: 'Status', transforms: [sortable] },
@@ -48,7 +48,7 @@ const getColumns = (hosts?: Host[]) => [
   { title: 'IPv4 address', transforms: [sortable] },
   { title: 'Ipv6 address', transforms: [sortable] },
   { title: 'MAC address', transforms: [sortable] },
-  { title: <HostsCount hosts={hosts} inParenthesis /> },
+  { title: <HostsCount cluster={cluster} inParenthesis /> },
 ];
 
 const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host): IRow[] => {

--- a/src/components/hosts/utils.ts
+++ b/src/components/hosts/utils.ts
@@ -126,8 +126,9 @@ export const downloadHostInstallationLogs = async (
   }
 };
 
-export const hasKnownHost = (cluster: Cluster) =>
-  !!cluster.hosts?.find((host) => host.status === 'known');
+export const getReadyHostCount = (cluster: Cluster) => cluster.readyHostCount || 0;
+export const getEnabledHostCount = (cluster: Cluster) => cluster.enabledHostCount || 0;
+export const getTotalHostCount = (cluster: Cluster) => cluster.totalHostCount || 0;
 
 export const getEnabledHosts = (hosts: Host[] = []) =>
   hosts.filter((host) => host.status !== 'disabled');

--- a/src/selectors/clusters.tsx
+++ b/src/selectors/clusters.tsx
@@ -11,7 +11,8 @@ import { getDateTimeCell, HumanizedSortable } from '../components/ui/table/utils
 import ClusterStatus, { getClusterStatusText } from '../components/clusters/ClusterStatus';
 import { DASH } from '../components/constants';
 import { routeBasePath } from '../config';
-import HostsCount, { getEnabledHostsCount } from '../components/hosts/HostsCount';
+import HostsCount from '../components/hosts/HostsCount';
+import { getReadyHostCount } from '../components/hosts/utils';
 
 const selectClusters = (state: RootState) => state.clusters.data;
 const clustersUIState = (state: RootState) => state.clusters.uiState;
@@ -26,7 +27,7 @@ export const selectClustersUIState = createSelector(
 );
 
 const clusterToClusterTableRow = (cluster: Cluster): IRow => {
-  const { id, name, hosts, openshiftVersion, baseDnsDomain, createdAt } = cluster;
+  const { id, name, openshiftVersion, baseDnsDomain, createdAt } = cluster;
   const dateTimeCell = getDateTimeCell(createdAt);
 
   return {
@@ -56,9 +57,9 @@ const clusterToClusterTableRow = (cluster: Cluster): IRow => {
         sortableValue: getClusterStatusText(cluster.status),
       } as HumanizedSortable,
       {
-        title: <HostsCount hosts={hosts} />,
+        title: <HostsCount cluster={cluster} />,
         props: { 'data-testid': `cluster-hosts-count-${name}` },
-        sortableValue: getEnabledHostsCount(hosts),
+        sortableValue: getReadyHostCount(cluster),
       } as HumanizedSortable,
       {
         title: dateTimeCell.title,


### PR DESCRIPTION
Instead of processing Cluster.hosts directly.

For optimization purpose, the API does not populate Cluster.hosts
when querying a list of clusters.