### PR TITLE
MGMT-5433 Add support for disabled validations

### DIFF
--- a/src/components/clusterConfiguration/NetworkConfigurationForm.tsx
+++ b/src/components/clusterConfiguration/NetworkConfigurationForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useDispatch } from 'react-redux';
+import { shallowEqual, useDispatch } from 'react-redux';
 import { Formik, FormikConfig, FormikProps } from 'formik';
 import * as Yup from 'yup';
 import _ from 'lodash';
@@ -114,7 +114,9 @@ const NetworkConfigurationForm: React.FC<{
       initialTouched={_.mapValues(initialValues, () => true)}
       validateOnMount
     >
-      {({ isSubmitting, dirty, errors }: FormikProps<NetworkConfigurationValues>) => {
+      {({ isSubmitting, errors, values }: FormikProps<NetworkConfigurationValues>) => {
+        // Workaround, Formik's "dirty" stays true unless we use enableReinitialize or play with resetForm()
+        const isFormikDirty = !shallowEqual(values, initialValues);
         const form = (
           <>
             <Grid hasGutter>
@@ -150,9 +152,9 @@ const NetworkConfigurationForm: React.FC<{
           <ClusterWizardToolbar
             cluster={cluster}
             formErrors={errors}
-            dirty={dirty}
+            dirty={isFormikDirty}
             isSubmitting={isSubmitting}
-            isNextDisabled={dirty || !canNextNetwork({ cluster })}
+            isNextDisabled={isFormikDirty || !canNextNetwork({ cluster })}
             onNext={() => setCurrentStepId('review')}
             onBack={() => setCurrentStepId('host-discovery')}
           />

--- a/src/components/clusterWizard/wizardTransition.ts
+++ b/src/components/clusterWizard/wizardTransition.ts
@@ -86,6 +86,8 @@ const networkingStepValidationsMap: WizardStepValidationMap = {
   // TODO(jtomasek): container-images-available validation is currently not running on the backend, it stays in pending.
   // marking it as soft validation is the easy way to prevent it from blocking the progress.
   // Alternatively we would have to whitelist network validations instead of using group
+  // TODO(mlibra): remove that container-images-available from soft validations and let backend drive it via disabling it.
+  //   Depends on: https://issues.redhat.com/browse/MGMT-5265
   softValidationIds: ['ntp-synced', 'container-images-available'],
 };
 
@@ -142,16 +144,22 @@ export const checkClusterValidations = (
     .filter((v) => v && requiredIds.includes(v.id));
   return (
     requiredValidations.length === requiredIds.length &&
-    requiredValidations.every((v) => v?.status === 'success')
+    requiredValidations.every((v) => v?.status === 'disabled' || v?.status === 'success')
   );
 };
 
 export const checkClusterValidationGroups = (
   clusterValidationsInfo: ClusterValidationsInfo,
   groups: ClusterValidationGroup[],
+  softValidationIds: WizardStepValidationMap['softValidationIds'],
 ) =>
   groups.every((group) =>
-    clusterValidationsInfo[group]?.every((validation) => validation.status === 'success'),
+    clusterValidationsInfo[group]?.every(
+      (validation) =>
+        validation.status === 'disabled' ||
+        validation.status === 'success' ||
+        softValidationIds.includes(validation.id),
+    ),
   );
 
 export const checkHostValidations = (
@@ -164,16 +172,22 @@ export const checkHostValidations = (
 
   return (
     requiredValidations.length === requiredIds.length &&
-    requiredValidations.every((v) => v?.status === 'success')
+    requiredValidations.every((v) => v?.status === 'disabled' || v?.status === 'success')
   );
 };
 
 export const checkHostValidationGroups = (
   hostValidationsInfo: HostValidationsInfo,
   groups: HostValidationGroup[],
+  softValidationIds: WizardStepValidationMap['softValidationIds'],
 ) =>
   groups.every((group) =>
-    hostValidationsInfo[group]?.every((validation) => validation.status === 'success'),
+    hostValidationsInfo[group]?.every(
+      (validation) =>
+        validation.status === 'disabled' ||
+        validation.status === 'success' ||
+        softValidationIds.includes(validation.id),
+    ),
   );
 
 export const getWizardStepHostValidationsInfo = (
@@ -207,9 +221,10 @@ export const getWizardStepHostStatus = (
 ): Host['status'] => {
   const { status } = host;
   if (['insufficient', 'pending-for-input'].includes(status)) {
+    const { softValidationIds } = wizardStepsValidationsMap[wizardStepId];
     const validationsInfo = stringToJSON<HostValidationsInfo>(host.validationsInfo) || {};
     const { groups, validationIds } = wizardStepsValidationsMap[wizardStepId].host;
-    return checkHostValidationGroups(validationsInfo, groups) &&
+    return checkHostValidationGroups(validationsInfo, groups, softValidationIds) &&
       checkHostValidations(validationsInfo, validationIds)
       ? 'known'
       : status;
@@ -250,12 +265,13 @@ export const getWizardStepClusterStatus = (
   if (['insufficient', 'pending-for-input'].includes(status)) {
     const validationsInfo = stringToJSON<ClusterValidationsInfo>(cluster.validationsInfo) || {};
     const { groups, validationIds } = wizardStepsValidationsMap[wizardStepId].cluster;
+    const { softValidationIds } = wizardStepsValidationsMap[wizardStepId];
     const { allowedStatuses } = wizardStepsValidationsMap[wizardStepId].host;
     const allHostsReady = (cluster?.hosts || []).every((host) =>
       allowedStatuses.includes(getWizardStepHostStatus(host, wizardStepId)),
     );
     return allHostsReady &&
-      checkClusterValidationGroups(validationsInfo, groups) &&
+      checkClusterValidationGroups(validationsInfo, groups, softValidationIds) &&
       checkClusterValidations(validationsInfo, validationIds)
       ? 'ready'
       : status;

--- a/src/components/clusterWizard/wizardTransitions.test.ts
+++ b/src/components/clusterWizard/wizardTransitions.test.ts
@@ -8,7 +8,7 @@ import {
 describe('wizardTransitions module tests', () => {
   describe('checkHostValidationGroups', () => {
     it('should return false when validationsInfo parameter is empty object', () => {
-      expect(checkHostValidationGroups({}, ['hardware'])).toBeFalsy();
+      expect(checkHostValidationGroups({}, ['hardware'], [])).toBeFalsy();
     });
   });
   describe('checkHostValidations', () => {
@@ -18,7 +18,7 @@ describe('wizardTransitions module tests', () => {
   });
   describe('checkClusterValidationGroups', () => {
     it('should return false when validationsInfo parameter is empty object', () => {
-      expect(checkClusterValidationGroups({}, ['hostsData'])).toBeFalsy();
+      expect(checkClusterValidationGroups({}, ['hostsData'], [])).toBeFalsy();
     });
   });
   describe('checkClusterValidations', () => {

--- a/src/types/hosts.ts
+++ b/src/types/hosts.ts
@@ -2,7 +2,7 @@ import { HostRoleUpdateParams, HostValidationId } from '../api/types';
 
 export type Validation = {
   id: HostValidationId;
-  status: 'success' | 'failure' | 'pending';
+  status: 'success' | 'failure' | 'pending' | 'disabled';
   message: string;
 };
 


### PR DESCRIPTION
Important:
We still keep `container-images-available` among soft-validations until https://issues.redhat.com/browse/MGMT-5265 lands in production.