### PR TITLE
Cluster polling hook returns data, state and error

### DIFF
--- a/src/components/clusterDetail/AssistedInstallerDetailCard.tsx
+++ b/src/components/clusterDetail/AssistedInstallerDetailCard.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import { Provider, useSelector } from 'react-redux';
+import { Provider } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { Button, ButtonVariant, Card, CardBody, CardHeader, Title } from '@patternfly/react-core';
 import { store } from '../../store';
 import { isSingleClusterMode, OCM_CLUSTER_LIST_LINK } from '../../config';
-import { selectCurrentClusterState } from '../../selectors';
 import { ResourceUIState } from '../../types';
 import { AlertsContextProvider } from '../AlertsContextProvider';
 import { useClusterPolling, useFetchCluster } from '../clusters/clusterPolling';
@@ -83,9 +82,8 @@ const LoadingDefaultConfigFailedCard: React.FC = () => (
 const AssistedInstallerDetailCard: React.FC<AssistedInstallerDetailCardProps> = ({
   aiClusterId,
 }) => {
-  const { data: cluster, uiState } = useSelector(selectCurrentClusterState);
   const fetchCluster = useFetchCluster(aiClusterId);
-  useClusterPolling(aiClusterId);
+  const { cluster, uiState } = useClusterPolling(aiClusterId);
 
   if (uiState === ResourceUIState.LOADING) {
     return <LoadingCard />;

--- a/src/components/clusters/ClusterPage.tsx
+++ b/src/components/clusters/ClusterPage.tsx
@@ -8,10 +8,8 @@ import {
   TextContent,
   Text,
 } from '@patternfly/react-core';
-import { useSelector } from 'react-redux';
 import { ErrorState, LoadingState } from '../ui/uiState';
 import { ResourceUIState } from '../../types';
-import { selectCurrentClusterState } from '../../selectors/currentCluster';
 import { Cluster } from '../../api/types';
 import { isSingleClusterMode, routeBasePath } from '../../config/constants';
 import ClusterDetail from '../clusterDetail/ClusterDetail';
@@ -32,9 +30,8 @@ type MatchParams = {
 
 const ClusterPage: React.FC<RouteComponentProps<MatchParams>> = ({ match }) => {
   const { clusterId } = match.params;
-  const { data: cluster, uiState, errorDetail } = useSelector(selectCurrentClusterState);
   const fetchCluster = useFetchCluster(clusterId);
-  useClusterPolling(clusterId);
+  const { cluster, uiState, errorDetail } = useClusterPolling(clusterId);
 
   const errorStateActions = [];
   if (!isSingleClusterMode()) {

--- a/src/components/clusters/clusterPolling.ts
+++ b/src/components/clusters/clusterPolling.ts
@@ -1,11 +1,13 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import { Cluster } from '../../api';
 import { POLLING_INTERVAL } from '../../config';
 import {
   fetchClusterAsync,
   cleanCluster,
   forceReload,
   cancelForceReload,
+  RetrievalErrorType,
 } from '../../features/clusters/currentClusterSlice';
 import { selectCurrentClusterState } from '../../selectors';
 import { ResourceUIState } from '../../types';
@@ -15,8 +17,14 @@ export const useFetchCluster = (clusterId: string) => {
   return React.useCallback(() => dispatch(fetchClusterAsync(clusterId)), [clusterId, dispatch]);
 };
 
-export const useClusterPolling = (clusterId: string) => {
-  const { isReloadScheduled, uiState } = useSelector(selectCurrentClusterState);
+export const useClusterPolling = (
+  clusterId: string,
+): {
+  cluster: Cluster | undefined;
+  uiState: ResourceUIState;
+  errorDetail: RetrievalErrorType | undefined;
+} => {
+  const { isReloadScheduled, uiState, data, errorDetail } = useSelector(selectCurrentClusterState);
   const dispatch = useDispatch();
   const fetchCluster = useFetchCluster(clusterId);
 
@@ -38,4 +46,6 @@ export const useClusterPolling = (clusterId: string) => {
       dispatch(cleanCluster());
     };
   }, [dispatch, fetchCluster]);
+
+  return { cluster: data, uiState, errorDetail };
 };

--- a/src/features/clusters/currentClusterSlice.ts
+++ b/src/features/clusters/currentClusterSlice.ts
@@ -5,7 +5,7 @@ import { Cluster, Host } from '../../api/types';
 import { handleApiError } from '../../api/utils';
 import { ResourceUIState } from '../../types';
 
-type RetrievalErrorType = {
+export type RetrievalErrorType = {
   code: string;
 };
 


### PR DESCRIPTION
Just a small improvement - we dont have to use `useSelector` anymore because `useClusterPolling` returns the data we need.