### PR TITLE
Fix positioning of Events Dialog in Wizard steps

### DIFF
--- a/src/components/clusterConfiguration/HostInventory.tsx
+++ b/src/components/clusterConfiguration/HostInventory.tsx
@@ -15,6 +15,7 @@ import {
   SingleHostRequirementsContent,
   CNVHostRequirementsContent,
 } from '../hosts/HostRequirementsContent';
+import ClusterWizardStepHeader from '../clusterWizard/ClusterWizardStepHeader';
 
 const OCSLabel: React.FC = () => (
   <>
@@ -48,9 +49,7 @@ const HostInventory: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
   return (
     <Stack hasGutter>
       <StackItem>
-        <TextContent>
-          <Text component="h2">Host Discovery</Text>
-        </TextContent>
+        <ClusterWizardStepHeader cluster={cluster}>Host Discovery</ClusterWizardStepHeader>
       </StackItem>
       <StackItem>
         <TextContent>

--- a/src/components/clusterConfiguration/NetworkConfigurationForm.tsx
+++ b/src/components/clusterConfiguration/NetworkConfigurationForm.tsx
@@ -32,6 +32,7 @@ import { useDefaultConfiguration } from './ClusterDefaultConfigurationContext';
 import NetworkingHostsTable from '../hosts/NetworkingHostsTable';
 import FormikAutoSave from '../ui/formik/FormikAutoSave';
 import { isSingleNodeCluster } from '../clusters/utils';
+import ClusterWizardStepHeader from '../clusterWizard/ClusterWizardStepHeader';
 
 const validationSchema = (initialValues: NetworkConfigurationValues, hostSubnets: HostSubnets) =>
   Yup.lazy<NetworkConfigurationValues>((values) =>
@@ -126,9 +127,7 @@ const NetworkConfigurationForm: React.FC<{
           <>
             <Grid hasGutter>
               <GridItem>
-                <TextContent>
-                  <Text component="h2">Networking</Text>
-                </TextContent>
+                <ClusterWizardStepHeader cluster={cluster}>Networking</ClusterWizardStepHeader>
               </GridItem>
               <GridItem span={12} lg={10} xl={9} xl2={7}>
                 <Form>

--- a/src/components/clusterConfiguration/ReviewStep.tsx
+++ b/src/components/clusterConfiguration/ReviewStep.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
-import { Grid, GridItem, Text, TextContent } from '@patternfly/react-core';
+import { Grid, GridItem } from '@patternfly/react-core';
 import { Cluster } from '../../api/types';
 import ClusterWizardStep from '../clusterWizard/ClusterWizardStep';
 import { AlertsContext } from '../AlertsContextProvider';
@@ -9,6 +9,7 @@ import ClusterWizardToolbar from '../clusterWizard/ClusterWizardToolbar';
 import { getErrorMessage, handleApiError, postInstallCluster } from '../../api';
 import { updateCluster } from '../../features/clusters/currentClusterSlice';
 import ReviewCluster from './ReviewCluster';
+import ClusterWizardStepHeader from '../clusterWizard/ClusterWizardStepHeader';
 
 const ReviewStep: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
   const { addAlert } = React.useContext(AlertsContext);
@@ -42,10 +43,8 @@ const ReviewStep: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
   return (
     <ClusterWizardStep cluster={cluster} footer={footer}>
       <Grid hasGutter>
-        <GridItem span={12}>
-          <TextContent>
-            <Text component="h2">Review and create</Text>
-          </TextContent>
+        <GridItem>
+          <ClusterWizardStepHeader cluster={cluster}>Review and create</ClusterWizardStepHeader>
         </GridItem>
         <GridItem>
           <ReviewCluster cluster={cluster} />

--- a/src/components/clusterWizard/ClusterDetails.tsx
+++ b/src/components/clusterWizard/ClusterDetails.tsx
@@ -9,7 +9,7 @@ import {
   nameValidationSchema,
   validJSONSchema,
 } from '../ui/formik/validationSchemas';
-import { Form, Grid, GridItem, Text, TextContent } from '@patternfly/react-core';
+import { Form, Grid, GridItem } from '@patternfly/react-core';
 import InputField from '../ui/formik/InputField';
 import SelectField from '../ui/formik/SelectField';
 import PullSecret from '../clusters/PullSecret';
@@ -33,6 +33,7 @@ import OpenShiftVersionSelect from '../clusterConfiguration/OpenShiftVersionSele
 import ClusterWizardToolbar from './ClusterWizardToolbar';
 import { StaticTextField } from '../ui/StaticTextField';
 import SNOControlGroup from '../clusterConfiguration/SNOControlGroup';
+import ClusterWizardStepHeader from './ClusterWizardStepHeader';
 
 type ClusterDetailsFormProps = {
   cluster?: Cluster;
@@ -208,9 +209,7 @@ const ClusterDetailsForm: React.FC<ClusterDetailsFormProps> = (props) => {
           <>
             <Grid hasGutter>
               <GridItem>
-                <TextContent>
-                  <Text component="h2">Cluster Details</Text>
-                </TextContent>
+                <ClusterWizardStepHeader cluster={cluster}>Cluster Details</ClusterWizardStepHeader>
               </GridItem>
               <GridItem span={12} lg={10} xl={9} xl2={7}>
                 <Form id="wizard-cluster-details__form">

--- a/src/components/clusterWizard/ClusterWizardStep.css
+++ b/src/components/clusterWizard/ClusterWizardStep.css
@@ -9,8 +9,3 @@
 .cluster-wizard-step__footer {
   display: block;
 }
-
-.wizard-cluster-events-button {
-  position: relative;
-  float: right;
-}

--- a/src/components/clusterWizard/ClusterWizardStep.tsx
+++ b/src/components/clusterWizard/ClusterWizardStep.tsx
@@ -1,17 +1,10 @@
 import React from 'react';
-import {
-  ButtonVariant,
-  WizardBody,
-  WizardNav,
-  WizardNavItem,
-  WizardNavItemProps,
-} from '@patternfly/react-core';
+import { WizardBody, WizardNav, WizardNavItem, WizardNavItemProps } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Wizard/wizard';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { global_danger_color_100 as dangerColor } from '@patternfly/react-tokens';
 import { Cluster } from '../../api/types';
-import { EventsModalButton } from '../ui/eventsModal';
 import ClusterWizardContext from './ClusterWizardContext';
 import {
   canNextHostDiscovery,
@@ -110,18 +103,6 @@ const ClusterWizardStep: React.FC<ClusterWizardStepProps> = ({ cluster, footer, 
       <div className={css(styles.wizardInnerWrap)}>
         {nav}
         <WizardBody aria-labelledby="step-id" hasNoBodyPadding={false}>
-          {cluster && (
-            <EventsModalButton
-              className="wizard-cluster-events-button"
-              id="cluster-events-button"
-              entityKind="cluster"
-              cluster={cluster}
-              title="Cluster Events"
-              variant={ButtonVariant.secondary}
-            >
-              View Cluster Events
-            </EventsModalButton>
-          )}
           {children}
         </WizardBody>
       </div>

--- a/src/components/clusterWizard/ClusterWizardStepHeader.tsx
+++ b/src/components/clusterWizard/ClusterWizardStepHeader.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Split, SplitItem, Text, TextContent, ButtonVariant } from '@patternfly/react-core';
+import { EventsModalButton } from '../ui/eventsModal';
+import { Cluster } from '../../api/types';
+
+const ClusterWizardStepHeader: React.FC<{ cluster?: Cluster }> = ({ cluster, children }) => {
+  return (
+    <Split>
+      <SplitItem>
+        <TextContent>
+          <Text component="h2">{children}</Text>
+        </TextContent>
+      </SplitItem>
+      <SplitItem isFilled />
+      {cluster && (
+        <SplitItem>
+          <EventsModalButton
+            id="cluster-events-button"
+            entityKind="cluster"
+            cluster={cluster}
+            title="Cluster Events"
+            variant={ButtonVariant.secondary}
+          >
+            View Cluster Events
+          </EventsModalButton>
+        </SplitItem>
+      )}
+    </Split>
+  );
+};
+
+export default ClusterWizardStepHeader;


### PR DESCRIPTION
The button floating did not work well with Stack and Grid used in wizard step
content. The button prevented grid from spanning full width. This change
puts the button into the grid next to wizard step title.

<img width="844" alt="Screenshot 2021-05-06 at 15 39 14" src="https://user-images.githubusercontent.com/1121740/117307892-44031900-ae81-11eb-80ca-becefecdad86.png">
