### PR TITLE
MGMT-5382 Include operators' installation progress as part of the total installation progress

### DIFF
--- a/src/components/clusterDetail/OperatorsProgressItem.tsx
+++ b/src/components/clusterDetail/OperatorsProgressItem.tsx
@@ -22,6 +22,7 @@ import { MonitoredOperatorsList, OperatorStatus } from '../../api/types';
 import { OPERATOR_LABELS } from '../../config/constants';
 
 import './OperatorsProgressItem.css';
+import { pluralize } from 'humanize-plus';
 
 export function getAggregatedStatus(operators: MonitoredOperatorsList) {
   const operatorStates: (OperatorStatus | 'pending')[] = operators.map(
@@ -33,8 +34,7 @@ export function getAggregatedStatus(operators: MonitoredOperatorsList) {
   return 'available';
 }
 
-export const getOperatorCountString = (count: number) =>
-  `${count} operator${count === 1 ? '' : 's'}`;
+export const getOperatorCountString = (count: number) => `${count} ${pluralize(count, 'operator')}`;
 
 export function getLabel(operators: MonitoredOperatorsList) {
   const failedOperatorsCount = operators.filter((o) => o.status === 'failed').length;

--- a/src/components/hosts/utils.ts
+++ b/src/components/hosts/utils.ts
@@ -81,6 +81,7 @@ export const getHostProgress = (host: Host) =>
 export const getHostProgressStageNumber = (host: Host) => {
   const stages = getHostProgressStages(host);
   const progress = getHostProgress(host);
+  // TODO(jkilzi): progress cannot be undefined! This condition seems to be redundant.
   if (progress) {
     const currentStage = progress.currentStage;
     return stages.findIndex((s) => currentStage.match(s)) + 1;


### PR DESCRIPTION
This PR tweaks the progress bar calculation in a way that the hosts progress account for 75% of the overall progress and the operators for the remaining 25%