### PR TITLE
Make HostsTable more generic

### DIFF
--- a/src/components/AddHosts/InventoryAddHost.tsx
+++ b/src/components/AddHosts/InventoryAddHost.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Text, TextContent, Button } from '@patternfly/react-core';
-import HostsTable from '../hosts/HostsTable';
+import ClusterHostsTable from '../hosts/ClusterHostsTable';
 import { DiscoveryImageModalButton } from '../clusterConfiguration/discoveryImageModal';
 import { DiscoveryTroubleshootingModal } from '../clusterConfiguration/DiscoveryTroubleshootingModal';
 import InformationAndAlerts from '../clusterConfiguration/InformationAndAlerts';
@@ -34,7 +34,7 @@ const InventoryAddHosts: React.FC = () => {
           setDiscoveryHintModalOpen={setDiscoveryHintModalOpen}
         />
       </TextContent>
-      <HostsTable cluster={cluster} setDiscoveryHintModalOpen={setDiscoveryHintModalOpen} />
+      <ClusterHostsTable cluster={cluster} setDiscoveryHintModalOpen={setDiscoveryHintModalOpen} />
       <DiscoveryTroubleshootingModal
         isOpen={isDiscoveryHintModalOpen}
         setDiscoveryHintModalOpen={setDiscoveryHintModalOpen}

--- a/src/components/clusterDetail/ClusterDetail.tsx
+++ b/src/components/clusterDetail/ClusterDetail.tsx
@@ -11,7 +11,7 @@ import {
 } from '@patternfly/react-core';
 import { Cluster } from '../../api/types';
 import { EventsModalButton } from '../ui/eventsModal';
-import HostsTable from '../hosts/HostsTable';
+import ClusterHostsTable from '../hosts/ClusterHostsTable';
 import ClusterToolbar from '../clusters/ClusterToolbar';
 import { ToolbarButton, ToolbarSecondaryGroup } from '../ui/Toolbar';
 import Alerts from '../ui/Alerts';
@@ -61,7 +61,7 @@ const ClusterDetail: React.FC<ClusterDetailProps> = ({ cluster }) => {
             <TextContent>
               <Text component="h2">Host Inventory</Text>
             </TextContent>
-            <HostsTable cluster={cluster} skipDisabled />
+            <ClusterHostsTable cluster={cluster} skipDisabled />
           </GridItem>
           <ClusterProperties cluster={cluster} />
         </Grid>

--- a/src/components/clusterDetail/ClusterInstallationProgressCard.tsx
+++ b/src/components/clusterDetail/ClusterInstallationProgressCard.tsx
@@ -10,7 +10,7 @@ import {
 } from '@patternfly/react-core';
 import { Cluster } from '../../api';
 import ClusterProgress from './ClusterProgress';
-import HostsTable from '../hosts/HostsTable';
+import ClusterHostsTable from '../hosts/ClusterHostsTable';
 import ClusterDetailsButtonGroup from './ClusterDetailsButtonGroup';
 import { ClusterStatusIcon } from '../clusters/ClusterStatus';
 import ClusterDetailStatusVarieties, {
@@ -50,7 +50,7 @@ const ClusterInstallationProgressCard: React.FC<{ cluster: Cluster }> = ({ clust
           <Grid hasGutter>
             <ClusterDetailStatusVarieties cluster={cluster} clusterVarieties={clusterVarieties} />
             <GridItem>
-              <HostsTable cluster={cluster} skipDisabled />
+              <ClusterHostsTable cluster={cluster} skipDisabled />
             </GridItem>
           </Grid>
         </CardBody>

--- a/src/components/clusters/ClusterStatus.tsx
+++ b/src/components/clusters/ClusterStatus.tsx
@@ -15,6 +15,7 @@ import {
 } from '@patternfly/react-icons';
 import { Cluster } from '../../api/types';
 import { CLUSTER_STATUS_LABELS } from '../../config/constants';
+import { WithTestID } from '../../types';
 
 type ClusterStatusProps = {
   status: Cluster['status'];

--- a/src/components/hosts/ClusterHostsTable.tsx
+++ b/src/components/hosts/ClusterHostsTable.tsx
@@ -1,0 +1,307 @@
+import { expandable, ICell, IRowData, sortable } from '@patternfly/react-table';
+import * as React from 'react';
+import { useDispatch } from 'react-redux';
+import {
+  Cluster,
+  deleteClusterHost,
+  disableClusterHost,
+  enableClusterHost,
+  getErrorMessage,
+  handleApiError,
+  Host,
+  installHost,
+  Inventory,
+  resetClusterHost,
+} from '../../api';
+import {
+  forceReload,
+  updateCluster,
+  updateHost,
+} from '../../features/clusters/currentClusterSlice';
+import { WithTestID } from '../../types';
+import { AlertsContext } from '../AlertsContextProvider';
+import {
+  HostsNotShowingLink,
+  HostsNotShowingLinkProps,
+} from '../clusterConfiguration/DiscoveryTroubleshootingModal';
+import HostsTable, { HostsTableProps } from './HostsTable';
+import { useModalDialogsContext } from './ModalDialogsContext';
+import { EmptyState } from '../ui/uiState';
+import { ConnectedIcon } from '@patternfly/react-icons';
+import { DiscoveryImageModalButton } from '../clusterConfiguration/discoveryImageModal';
+import {
+  canEditDisks as canEditDisksUtil,
+  canEditRole as canEditRoleUtil,
+  canInstallHost as canInstallHostUtil,
+  downloadHostInstallationLogs,
+  canEnable as canEnableUtil,
+  canDisable as canDisableUtil,
+  canDelete as canDeleteUtil,
+  canEditHost as canEditHostUtil,
+  canDownloadHostLogs,
+  canReset as canResetUtil,
+} from './utils';
+import EditHostModal from './EditHostModal';
+import { EventsModal } from '../ui/eventsModal';
+import ResetHostModal from './ResetHostModal';
+import DeleteHostModal from './DeleteHostModal';
+import { AdditionalNTPSourcesDialog } from './AdditionalNTPSourcesDialog';
+import HostsCount from './HostsCount';
+
+type HostsTableEmptyStateProps = {
+  cluster: Cluster;
+  setDiscoveryHintModalOpen?: HostsNotShowingLinkProps['setDiscoveryHintModalOpen'];
+};
+
+const HostsTableEmptyState: React.FC<HostsTableEmptyStateProps> = ({
+  cluster,
+  setDiscoveryHintModalOpen,
+}) => (
+  <EmptyState
+    icon={ConnectedIcon}
+    title="Waiting for hosts..."
+    content="Hosts may take a few minutes to appear here after booting."
+    primaryAction={<DiscoveryImageModalButton cluster={cluster} idPrefix="host-table-empty" />}
+    secondaryActions={
+      setDiscoveryHintModalOpen && [
+        <HostsNotShowingLink
+          key="hosts-not-showing"
+          setDiscoveryHintModalOpen={setDiscoveryHintModalOpen}
+        />,
+      ]
+    }
+  />
+);
+
+type ClusterHostsTableProps = {
+  cluster: Cluster;
+  columns?: (string | ICell)[];
+  hostToHostTableRow?: HostsTableProps['hostToHostTableRow'];
+  skipDisabled?: boolean;
+  setDiscoveryHintModalOpen?: HostsNotShowingLinkProps['setDiscoveryHintModalOpen'];
+};
+
+const ClusterHostsTable: React.FC<ClusterHostsTableProps & WithTestID> = ({
+  columns,
+  cluster,
+  setDiscoveryHintModalOpen,
+  hostToHostTableRow,
+  ...rest
+}) => {
+  const { addAlert } = React.useContext(AlertsContext);
+  const {
+    eventsDialog,
+    editHostDialog,
+    deleteHostDialog,
+    resetHostDialog,
+    additionalNTPSourcesDialog,
+  } = useModalDialogsContext();
+  const dispatch = useDispatch();
+
+  const hostActions = React.useMemo(
+    () => ({
+      onDeleteHost: (event: React.MouseEvent, rowIndex: number, rowData: IRowData) =>
+        deleteHostDialog.open({
+          hostId: rowData.host.id,
+          hostname: rowData.host?.requestedHostname || rowData.inventory?.hostname,
+        }),
+      onHostEnable: async (event: React.MouseEvent, rowIndex: number, rowData: IRowData) => {
+        const hostId = rowData.host.id;
+        try {
+          const { data } = await enableClusterHost(cluster.id, hostId);
+          dispatch(updateCluster(data));
+        } catch (e) {
+          handleApiError(e, () =>
+            addAlert({ title: `Failed to enable host ${hostId}`, message: getErrorMessage(e) }),
+          );
+        }
+      },
+      onInstallHost: async (event: React.MouseEvent, rowIndex: number, rowData: IRowData) => {
+        const hostId = rowData.host.id;
+        try {
+          const { data } = await installHost(cluster.id, hostId);
+          dispatch(updateHost(data));
+        } catch (e) {
+          handleApiError(e, () =>
+            addAlert({ title: `Failed to enable host ${hostId}`, message: getErrorMessage(e) }),
+          );
+        }
+      },
+      onHostDisable: async (event: React.MouseEvent, rowIndex: number, rowData: IRowData) => {
+        const hostId = rowData.host.id;
+        try {
+          const { data } = await disableClusterHost(cluster.id, hostId);
+          dispatch(updateCluster(data));
+        } catch (e) {
+          handleApiError(e, () =>
+            addAlert({ title: `Failed to disable host ${hostId}`, message: getErrorMessage(e) }),
+          );
+        }
+      },
+    }),
+    [cluster.id, dispatch, addAlert, deleteHostDialog],
+  );
+
+  const onViewHostEvents = React.useCallback(
+    (event: React.MouseEvent, rowIndex: number, rowData: IRowData) => {
+      const host = rowData.host;
+      const { id, requestedHostname } = host;
+      const hostname = requestedHostname || rowData.inventory?.hostname || id;
+      eventsDialog.open({ hostId: id, hostname });
+    },
+    [eventsDialog],
+  );
+
+  const onEditHost = React.useCallback(
+    (host: Host, inventory: Inventory) => {
+      editHostDialog.open({ host, inventory });
+    },
+    [editHostDialog],
+  );
+
+  const onHostReset = React.useCallback(
+    (host: Host, inventory: Inventory) => {
+      const hostname = host?.requestedHostname || inventory?.hostname || '';
+      resetHostDialog.open({ hostId: host.id, hostname });
+    },
+    [resetHostDialog],
+  );
+
+  const onDownloadHostLogs = React.useCallback(
+    (event: React.MouseEvent, rowIndex: number, rowData: IRowData) =>
+      downloadHostInstallationLogs(addAlert, rowData.host),
+    [addAlert],
+  );
+
+  const EmptyState = React.useCallback(
+    () => (
+      <HostsTableEmptyState
+        cluster={cluster}
+        setDiscoveryHintModalOpen={setDiscoveryHintModalOpen}
+      />
+    ),
+    [setDiscoveryHintModalOpen, cluster],
+  );
+
+  const [tableColumns, actionChecks] = React.useMemo(
+    () => [
+      columns || [
+        { title: 'Hostname', transforms: [sortable], cellFormatters: [expandable] },
+        { title: 'Role', transforms: [sortable] },
+        { title: 'Status', transforms: [sortable] },
+        { title: 'Discovered At', transforms: [sortable] },
+        { title: 'CPU Cores', transforms: [sortable] }, // cores per machine (sockets x cores)
+        { title: 'Memory', transforms: [sortable] },
+        { title: 'Disk', transforms: [sortable] },
+        { title: <HostsCount cluster={cluster} inParenthesis /> },
+      ],
+      {
+        canEditRole: (host: Host) => canEditRoleUtil(cluster, host.status),
+        canInstallHost: (host: Host) => canInstallHostUtil(cluster, host.status),
+        canEditDisks: (host: Host) => canEditDisksUtil(cluster.status, host.status),
+        canEnable: (host: Host) => canEnableUtil(cluster.status, host.status),
+        canDisable: (host: Host) => canDisableUtil(cluster.status, host.status),
+        canDelete: (host: Host) => canDeleteUtil(cluster.status, host.status),
+        canEditHost: (host: Host) => canEditHostUtil(cluster.status, host.status),
+        canReset: (host: Host) => canResetUtil(cluster.status, host.status),
+      },
+    ],
+    [cluster, columns],
+  );
+
+  const onReset = React.useCallback(() => {
+    const reset = async (hostId: string | undefined) => {
+      if (hostId) {
+        try {
+          const { data } = await resetClusterHost(cluster.id, hostId);
+          dispatch(updateHost(data));
+        } catch (e) {
+          return handleApiError(e, () =>
+            addAlert({
+              title: `Failed to reset host ${hostId}`,
+              message: getErrorMessage(e),
+            }),
+          );
+        }
+      }
+    };
+    reset(resetHostDialog.data?.hostId);
+    resetHostDialog.close();
+  }, [addAlert, cluster.id, dispatch, resetHostDialog]);
+
+  const onDelete = React.useCallback(() => {
+    () => {
+      const deleteHost = async (hostId: string | undefined) => {
+        if (hostId) {
+          try {
+            await deleteClusterHost(cluster.id, hostId);
+            dispatch(forceReload());
+          } catch (e) {
+            return handleApiError(e, () =>
+              addAlert({
+                title: `Failed to delete host ${hostId}`,
+                message: getErrorMessage(e),
+              }),
+            );
+          }
+        }
+      };
+      deleteHost(deleteHostDialog.data?.hostId);
+      deleteHostDialog.close();
+    };
+  }, [addAlert, cluster.id, dispatch, deleteHostDialog]);
+
+  return (
+    <>
+      <HostsTable
+        {...rest}
+        {...hostActions}
+        {...actionChecks}
+        columns={tableColumns}
+        hosts={cluster.hosts}
+        EmptyState={EmptyState}
+        onHostReset={onHostReset}
+        onViewHostEvents={onViewHostEvents}
+        onEditHost={onEditHost}
+        onDownloadHostLogs={onDownloadHostLogs}
+        hostToHostTableRow={hostToHostTableRow}
+        canDownloadHostLogs={canDownloadHostLogs}
+      />
+      <EventsModal
+        title={`Host Events${eventsDialog.isOpen ? `: ${eventsDialog.data?.hostname}` : ''}`}
+        entityKind="host"
+        cluster={cluster}
+        hostId={eventsDialog.data?.hostId}
+        onClose={eventsDialog.close}
+        isOpen={eventsDialog.isOpen}
+      />
+      <ResetHostModal
+        hostname={resetHostDialog.data?.hostname}
+        onClose={resetHostDialog.close}
+        isOpen={resetHostDialog.isOpen}
+        onReset={onReset}
+      />
+      <DeleteHostModal
+        hostname={deleteHostDialog.data?.hostname}
+        onClose={deleteHostDialog.close}
+        isOpen={deleteHostDialog.isOpen}
+        onDelete={onDelete}
+      />
+      <EditHostModal
+        host={editHostDialog.data?.host}
+        inventory={editHostDialog.data?.inventory}
+        cluster={cluster}
+        onClose={editHostDialog.close}
+        isOpen={editHostDialog.isOpen}
+        onSave={editHostDialog.close}
+      />
+      <AdditionalNTPSourcesDialog
+        cluster={cluster}
+        isOpen={additionalNTPSourcesDialog.isOpen}
+        onClose={additionalNTPSourcesDialog.close}
+      />
+    </>
+  );
+};
+
+export default ClusterHostsTable;

--- a/src/components/hosts/HardwareStatus.tsx
+++ b/src/components/hosts/HardwareStatus.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Cluster, Host } from '../../api/types';
+import { Host } from '../../api/types';
 import { ValidationsInfo } from '../../types/hosts';
 import HostStatus from './HostStatus';
 import {
@@ -11,7 +11,7 @@ import {
 type HardwareStatusProps = {
   host: Host;
   validationsInfo: ValidationsInfo;
-  cluster: Cluster;
+  onEditHostname?: () => void;
 };
 
 const HardwareStatus: React.FC<HardwareStatusProps> = (props) => {

--- a/src/components/hosts/HostRowDetail.tsx
+++ b/src/components/hosts/HostRowDetail.tsx
@@ -10,7 +10,7 @@ import {
   IRow,
 } from '@patternfly/react-table';
 import { ExtraParamsType } from '@patternfly/react-table/dist/js/components/Table/base';
-import { Host, Inventory, Disk, Interface, Cluster } from '../../api/types';
+import { Host, Inventory, Disk, Interface } from '../../api/types';
 import { getHostRowHardwareInfo } from './hardwareInfo';
 import { DASH } from '../constants';
 import { DetailList, DetailListProps, DetailItem } from '../ui/DetailList';
@@ -18,10 +18,11 @@ import { ValidationsInfo } from '../../types/hosts';
 import NtpValidationStatus from './NtpValidationStatus';
 import DiskLimitations from './DiskLimitations';
 import DiskRole from './DiskRole';
-import { canEditDisks, getHardwareTypeText, fileSize } from './utils';
+import { getHardwareTypeText, fileSize } from './utils';
+import { WithTestID } from '../../types';
 
 type HostDetailProps = {
-  cluster: Cluster;
+  canEditDisks?: (host: Host) => boolean;
   inventory: Inventory;
   host: Host;
   validationsInfo: ValidationsInfo;
@@ -36,7 +37,7 @@ type SectionColumnProps = {
 };
 
 type DisksTableProps = {
-  cluster: Cluster;
+  canEditDisks?: (host: Host) => boolean;
   host: Host;
   disks: Disk[];
   installationDiskId?: string;
@@ -81,13 +82,13 @@ const DisksTableRowWrapper = (props: RowWrapperProps) => (
 );
 
 const DisksTable: React.FC<DisksTableProps & WithTestID> = ({
-  cluster,
+  canEditDisks,
   host,
   disks,
   installationDiskId,
   testId,
 }) => {
-  const isEditable = canEditDisks(cluster.status, host.status);
+  const isEditable = !!canEditDisks?.(host);
   const rows: IRow[] = disks
     .sort((diskA, diskB) => diskA.name?.localeCompare(diskB.name || '') || 0)
     .map((disk) => ({
@@ -190,7 +191,7 @@ const NicsTable: React.FC<NicsTableProps & WithTestID> = ({ interfaces, testId }
 };
 
 export const HostDetail: React.FC<HostDetailProps> = ({
-  cluster,
+  canEditDisks,
   inventory,
   host,
   validationsInfo,
@@ -276,7 +277,7 @@ export const HostDetail: React.FC<HostDetailProps> = ({
       <GridItem>
         <DisksTable
           testId={'disks-table'}
-          cluster={cluster}
+          canEditDisks={canEditDisks}
           host={host}
           disks={disks}
           installationDiskId={installationDiskId}

--- a/src/components/hosts/HostStatus.tsx
+++ b/src/components/hosts/HostStatus.tsx
@@ -17,7 +17,7 @@ import {
   AddCircleOIcon,
 } from '@patternfly/react-icons';
 import hdate from 'human-date';
-import { Cluster, Host } from '../../api/types';
+import { Host } from '../../api/types';
 import { ValidationsInfo } from '../../types/hosts';
 import HostProgress from './HostProgress';
 import { HOST_STATUS_LABELS, HOST_STATUS_DETAILS } from '../../config/constants';
@@ -126,7 +126,7 @@ const HostStatusPopoverContent: React.FC<HostStatusPopoverContentProps> = (props
 type HostStatusProps = {
   host: Host;
   validationsInfo: ValidationsInfo;
-  cluster: Cluster;
+  onEditHostname?: () => void;
   statusOverride?: Host['status'];
   sublabel?: string;
 };
@@ -162,16 +162,21 @@ const HostStatusPopoverFooter: React.FC<{ host: Host }> = ({ host }) => {
 
 const HostStatus: React.FC<HostStatusProps> = ({
   host,
-  cluster,
   validationsInfo,
   statusOverride,
   sublabel,
+  onEditHostname,
 }) => {
   const [keepOnOutsideClick, onValidationActionToggle] = React.useState(false);
   const status = statusOverride || host.status;
   const title = HOST_STATUS_LABELS[status] || status;
   const icon = getStatusIcon(status) || null;
   const hostProgressStages = getHostProgressStages(host);
+
+  const toggleHostname = React.useCallback(() => {
+    onValidationActionToggle(!keepOnOutsideClick);
+    onEditHostname?.();
+  }, [keepOnOutsideClick, onEditHostname]);
 
   sublabel =
     sublabel ||
@@ -187,8 +192,7 @@ const HostStatus: React.FC<HostStatusProps> = ({
           <HostStatusPopoverContent
             host={host}
             validationsInfo={validationsInfo}
-            cluster={cluster}
-            onValidationActionToggle={onValidationActionToggle}
+            onEditHostname={toggleHostname}
           />
         }
         footerContent={<HostStatusPopoverFooter host={host} />}

--- a/src/components/hosts/HostValidationGroups.tsx
+++ b/src/components/hosts/HostValidationGroups.tsx
@@ -11,7 +11,7 @@ import {
   HOST_VALIDATION_FAILURE_HINTS,
   HOST_VALIDATION_LABELS,
 } from '../../config/constants';
-import { Cluster, Host } from '../../api';
+import { Host } from '../../api';
 import Hostname from './Hostname';
 import { AdditionalNTPSourcesDialogToggle } from './AdditionalNTPSourcesDialog';
 
@@ -19,9 +19,8 @@ import './HostValidationGroups.css';
 import { toSentence } from '../ui/table/utils';
 
 export type ValidationInfoActionProps = {
+  onEditHostname?: () => void;
   host: Host;
-  cluster: Cluster;
-  onValidationActionToggle: (isOpen: boolean) => void;
 };
 
 type HostValidationGroupsProps = ValidationInfoActionProps & {
@@ -38,7 +37,6 @@ const ValidationGroupAlert: React.FC<ValidationGroupAlertProps> = ({
   variant,
   validations,
   title,
-  onValidationActionToggle,
   ...props
 }) => {
   if (!validations.length) {
@@ -53,14 +51,7 @@ const ValidationGroupAlert: React.FC<ValidationGroupAlertProps> = ({
         ['hostname-unique', 'hostname-valid'].includes(validation.id),
     )
   ) {
-    actionLinks.push(
-      <Hostname
-        key="change-hostname"
-        title="Change hostname"
-        onToggle={onValidationActionToggle}
-        {...props}
-      />,
-    );
+    actionLinks.push(<Hostname key="change-hostname" title="Change hostname" {...props} />);
   }
   if (
     validations.find(

--- a/src/components/hosts/Hostname.tsx
+++ b/src/components/hosts/Hostname.tsx
@@ -1,15 +1,13 @@
 import React from 'react';
 import { Button, ButtonVariant } from '@patternfly/react-core';
-import EditHostModal from './EditHostModal';
-import { Host, Inventory, Cluster } from '../../api/types';
+import { Host, Inventory } from '../../api/types';
 import { getHostname } from './utils';
 import { DASH } from '../constants';
 
 type HostnameProps = {
   host: Host;
-  cluster: Cluster;
+  onEditHostname?: () => void;
   className?: string;
-  onToggle?: (isOpen: boolean) => void;
   // Provide either inventory or title
   inventory?: Inventory;
   title?: string;
@@ -18,41 +16,28 @@ type HostnameProps = {
 const Hostname: React.FC<HostnameProps> = ({
   host,
   inventory = {},
-  cluster,
+  onEditHostname,
   title,
   className,
-  onToggle,
 }) => {
-  const [isOpen, _setOpen] = React.useState(false);
-
-  const setOpen = (isOpen: boolean) => {
-    onToggle && onToggle(isOpen);
-    _setOpen(isOpen);
-  };
-
   const hostname = title || getHostname(host, inventory) || DASH;
   const isHostnameChangeRequested = !title && host.requestedHostname !== inventory.hostname;
 
-  return (
+  const body = (
     <>
-      <Button
-        variant={ButtonVariant.link}
-        isInline
-        onClick={() => setOpen(true)}
-        className={className}
-      >
-        {hostname}
-        {isHostnameChangeRequested && ' *'}
-      </Button>
-      <EditHostModal
-        host={host}
-        inventory={inventory}
-        cluster={cluster}
-        onClose={() => setOpen(false)}
-        isOpen={isOpen}
-        onSave={() => setOpen(false)}
-      />
+      {hostname}
+      {isHostnameChangeRequested && ' *'}
     </>
+  );
+
+  return onEditHostname ? (
+    <>
+      <Button variant={ButtonVariant.link} isInline onClick={onEditHostname} className={className}>
+        {body}
+      </Button>
+    </>
+  ) : (
+    body
   );
 };
 export default Hostname;

--- a/src/components/hosts/HostsTable.tsx
+++ b/src/components/hosts/HostsTable.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import _ from 'lodash';
-import { useDispatch } from 'react-redux';
 import {
   Table,
   TableHeader,
@@ -16,58 +15,21 @@ import {
   RowWrapperProps,
   RowWrapper,
 } from '@patternfly/react-table';
-import { ConnectedIcon } from '@patternfly/react-icons';
 import { ExtraParamsType } from '@patternfly/react-table/dist/js/components/Table/base';
 import { EmptyState } from '../ui/uiState';
 import { getColSpanRow, rowSorter, getDateTimeCell } from '../ui/table/utils';
-import { Host, Cluster, Inventory } from '../../api/types';
-import {
-  enableClusterHost,
-  disableClusterHost,
-  deleteClusterHost,
-  resetClusterHost,
-} from '../../api/clusters';
-import { EventsModal } from '../ui/eventsModal';
-import { DiscoveryImageModalButton } from '../clusterConfiguration/discoveryImageModal';
+import { Host, Inventory } from '../../api/types';
 import HostStatus from './HostStatus';
 import { HostDetail } from './HostRowDetail';
-import {
-  forceReload,
-  updateCluster,
-  updateHost,
-} from '../../features/clusters/currentClusterSlice';
-import { handleApiError, stringToJSON, getErrorMessage } from '../../api/utils';
+import { stringToJSON } from '../../api/utils';
 import sortable from '../ui/table/sortable';
-import { useAlerts } from '../AlertsContextProvider';
-import {
-  HostsNotShowingLink,
-  HostsNotShowingLinkProps,
-} from '../clusterConfiguration/DiscoveryTroubleshootingModal';
 import { ValidationsInfo } from '../../types/hosts';
-import { installHost } from '../../api';
 import { getHostRowHardwareInfo } from './hardwareInfo';
 import RoleCell from './RoleCell';
-import DeleteHostModal from './DeleteHostModal';
-import ResetHostModal from './ResetHostModal';
-import {
-  canEnable,
-  canDisable,
-  canDelete,
-  canEditHost,
-  getHostRole,
-  canDownloadHostLogs,
-  downloadHostInstallationLogs,
-  canReset,
-  getHostname,
-  canInstallHost,
-  canEditRole,
-} from './utils';
-import EditHostModal from './EditHostModal';
+import { getHostRole, getHostname } from './utils';
 import Hostname from './Hostname';
-import HostsCount from './HostsCount';
 import HostPropertyValidationPopover from './HostPropertyValidationPopover';
-import { AdditionalNTPSourcesDialog } from './AdditionalNTPSourcesDialog';
-import { useModalDialogsContext } from './ModalDialogsContext';
+import { WithTestID } from '../../types';
 
 import './HostsTable.css';
 
@@ -75,7 +37,7 @@ export type OpenRows = {
   [id: string]: boolean;
 };
 
-const defaultGetColumns = (cluster: Cluster) => [
+const defaultColumns = [
   { title: 'Hostname', transforms: [sortable], cellFormatters: [expandable] },
   { title: 'Role', transforms: [sortable] },
   { title: 'Status', transforms: [sortable] },
@@ -83,10 +45,14 @@ const defaultGetColumns = (cluster: Cluster) => [
   { title: 'CPU Cores', transforms: [sortable] }, // cores per machine (sockets x cores)
   { title: 'Memory', transforms: [sortable] },
   { title: 'Disk', transforms: [sortable] },
-  { title: <HostsCount cluster={cluster} inParenthesis /> },
 ];
 
-const defaultHostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host): IRow => {
+const defaultHostToHostTableRow = (
+  openRows: OpenRows,
+  canEditDisks?: (host: Host) => boolean,
+  onEditHostname?: (host: Host, inventory: Inventory) => void,
+  canEditRole?: (host: Host) => boolean,
+) => (host: Host): IRow => {
   const { id, status, createdAt, inventory: inventoryString = '' } = host;
   const inventory = stringToJSON<Inventory>(inventoryString) || {};
   const { cores, memory, disk } = getHostRowHardwareInfo(inventory);
@@ -100,25 +66,31 @@ const defaultHostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (hos
   const hostRole = getHostRole(host);
   const dateTimeCell = getDateTimeCell(createdAt);
 
+  const editHostname = onEditHostname ? () => onEditHostname(host, inventory) : undefined;
+
   return [
     {
       // visible row
       isOpen: !!openRows[id],
       cells: [
         {
-          title: <Hostname host={host} inventory={inventory} cluster={cluster} />,
+          title: <Hostname host={host} inventory={inventory} onEditHostname={editHostname} />,
           props: { 'data-testid': 'host-name' },
           sortableValue: computedHostname || '',
         },
         {
-          title: (
-            <RoleCell host={host} readonly={!canEditRole(cluster, host.status)} role={hostRole} />
-          ),
+          title: <RoleCell host={host} readonly={!canEditRole?.(host)} role={hostRole} />,
           props: { 'data-testid': 'host-role' },
           sortableValue: hostRole,
         },
         {
-          title: <HostStatus host={host} cluster={cluster} validationsInfo={validationsInfo} />,
+          title: (
+            <HostStatus
+              host={host}
+              onEditHostname={editHostname}
+              validationsInfo={validationsInfo}
+            />
+          ),
           props: { 'data-testid': 'host-status' },
           sortableValue: status,
         },
@@ -156,7 +128,6 @@ const defaultHostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (hos
         },
       ],
       host,
-      clusterStatus: cluster.status,
       inventory,
       key: `${host.id}-master`,
     },
@@ -169,7 +140,7 @@ const defaultHostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (hos
           title: (
             <HostDetail
               key={id}
-              cluster={cluster}
+              canEditDisks={canEditDisks}
               inventory={inventory}
               host={host}
               validationsInfo={validationsInfo}
@@ -183,26 +154,6 @@ const defaultHostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (hos
   ];
 };
 
-const HostsTableEmptyState: React.FC<{
-  cluster: Cluster;
-  setDiscoveryHintModalOpen?: HostsNotShowingLinkProps['setDiscoveryHintModalOpen'];
-}> = ({ cluster, setDiscoveryHintModalOpen }) => (
-  <EmptyState
-    icon={ConnectedIcon}
-    title="Waiting for hosts..."
-    content="Hosts may take a few minutes to appear here after booting."
-    primaryAction={<DiscoveryImageModalButton cluster={cluster} idPrefix="host-table-empty" />}
-    secondaryActions={
-      setDiscoveryHintModalOpen && [
-        <HostsNotShowingLink
-          key="hosts-not-showing"
-          setDiscoveryHintModalOpen={setDiscoveryHintModalOpen}
-        />,
-      ]
-    }
-  />
-);
-
 const rowKey = ({ rowData }: ExtraParamsType) => rowData?.key;
 const isHostShown = (skipDisabled: boolean) => (host: Host) =>
   !skipDisabled || host.status != 'disabled';
@@ -211,67 +162,96 @@ const HostsTableRowWrapper = (props: RowWrapperProps) => (
   <RowWrapper {...props} data-testid={`host-row-${props.rowProps?.rowIndex}`} />
 );
 
-type HostsTableProps = {
-  cluster: Cluster;
-  getColumns?: (cluster: Cluster) => (string | ICell)[];
-  hostToHostTableRow?: (openRows: OpenRows, cluster: Cluster) => (host: Host) => IRow;
+export type HostsTableProps = {
+  hosts: Host[] | undefined;
+  EmptyState: React.ComponentType<{}>;
+  canEditRole?: (host: Host) => boolean;
+  columns?: (string | ICell)[];
+  hostToHostTableRow?: (
+    openRows: OpenRows,
+    canEditDisks?: (host: Host) => boolean,
+    onEditHostname?: (host: Host, inventory: Inventory) => void,
+    canEditRole?: (host: Host) => boolean,
+  ) => (host: Host) => IRow;
   skipDisabled?: boolean;
-  setDiscoveryHintModalOpen?: HostsNotShowingLinkProps['setDiscoveryHintModalOpen'];
+  onDeleteHost?: (event: React.MouseEvent, rowIndex: number, rowData: IRowData) => void;
+  onHostEnable?: (event: React.MouseEvent, rowIndex: number, rowData: IRowData) => void;
+  onInstallHost?: (event: React.MouseEvent, rowIndex: number, rowData: IRowData) => void;
+  onHostDisable?: (event: React.MouseEvent, rowIndex: number, rowData: IRowData) => void;
+  onHostReset?: (host: Host, inventory: Inventory) => void;
+  onViewHostEvents?: (event: React.MouseEvent, rowIndex: number, rowData: IRowData) => void;
+  onEditHost?: (host: Host, inventory: Inventory) => void;
+  onDownloadHostLogs?: (event: React.MouseEvent, rowIndex: number, rowData: IRowData) => void;
+  canInstallHost?: (host: Host) => boolean;
+  canEditDisks?: (host: Host) => boolean;
+  canEditHost?: (host: Host) => boolean;
+  canEnable?: (host: Host) => boolean;
+  canDisable?: (host: Host) => boolean;
+  canReset?: (host: Host) => boolean;
+  canDownloadHostLogs?: (host: Host) => boolean;
+  canDelete?: (host: Host) => boolean;
 };
 
 const HostsTable: React.FC<HostsTableProps & WithTestID> = ({
-  cluster,
+  hosts,
   hostToHostTableRow = defaultHostToHostTableRow,
-  getColumns = defaultGetColumns,
+  columns = defaultColumns,
   skipDisabled = false,
-  setDiscoveryHintModalOpen,
   testId = 'hosts-table',
+  onDeleteHost,
+  onHostEnable,
+  onInstallHost,
+  onHostDisable,
+  onHostReset,
+  onDownloadHostLogs,
+  onEditHost,
+  onViewHostEvents,
+  canInstallHost,
+  canEditDisks,
+  canEditRole,
+  canEditHost,
+  canEnable,
+  canDisable,
+  canReset,
+  canDownloadHostLogs,
+  canDelete,
 }) => {
-  const { addAlert } = useAlerts();
-  const {
-    eventsDialog,
-    editHostDialog,
-    deleteHostDialog,
-    resetHostDialog,
-    additionalNTPSourcesDialog,
-  } = useModalDialogsContext();
-
-  const [openRows, setOpenRows] = React.useState({} as OpenRows);
-  const [sortBy, setSortBy] = React.useState({
+  const [openRows, setOpenRows] = React.useState<OpenRows>({});
+  const [sortBy, setSortBy] = React.useState<ISortBy>({
     index: 1, // Hostname-column
     direction: SortByDirection.asc,
-  } as ISortBy);
-  const dispatch = useDispatch();
+  });
 
   const hostRows = React.useMemo(
     () =>
       _.flatten(
-        (cluster.hosts || [])
+        (hosts || [])
           .filter(isHostShown(skipDisabled))
-          .map(hostToHostTableRow(openRows, cluster))
+          .map(hostToHostTableRow(openRows, canEditDisks, onEditHost, canEditRole))
           .sort(rowSorter(sortBy, (row: IRow, index = 1) => row[0].cells[index - 1]))
           .map((row: IRow, index: number) => {
             row[1].parent = index * 2;
             return row;
           }),
       ),
-    [cluster, skipDisabled, openRows, sortBy, hostToHostTableRow],
+    [
+      hosts,
+      skipDisabled,
+      openRows,
+      sortBy,
+      hostToHostTableRow,
+      onEditHost,
+      canEditRole,
+      canEditDisks,
+    ],
   );
-
-  const columns = React.useMemo(() => getColumns(cluster), [cluster, getColumns]);
 
   const rows = React.useMemo(() => {
     if (hostRows.length) {
       return hostRows;
     }
-    return getColSpanRow(
-      <HostsTableEmptyState
-        cluster={cluster}
-        setDiscoveryHintModalOpen={setDiscoveryHintModalOpen}
-      />,
-      columns.length,
-    );
-  }, [hostRows, cluster, columns, setDiscoveryHintModalOpen]);
+    return getColSpanRow(<EmptyState />, columns.length);
+  }, [hostRows, columns]);
 
   const onCollapse = React.useCallback(
     (_event, rowKey) => {
@@ -284,105 +264,9 @@ const HostsTable: React.FC<HostsTableProps & WithTestID> = ({
     [hostRows, openRows],
   );
 
-  const onDeleteHost = React.useCallback(
-    async (hostId) => {
-      try {
-        await deleteClusterHost(cluster.id, hostId);
-        dispatch(forceReload());
-      } catch (e) {
-        return handleApiError(e, () =>
-          addAlert({ title: `Failed to delete host ${hostId}`, message: getErrorMessage(e) }),
-        );
-      }
-    },
-    [cluster.id, dispatch, addAlert],
-  );
-
-  const onHostEnable = React.useCallback(
-    async (event: React.MouseEvent, rowIndex: number, rowData: IRowData) => {
-      const hostId = rowData.host.id;
-      try {
-        const { data } = await enableClusterHost(cluster.id, hostId);
-        dispatch(updateCluster(data));
-      } catch (e) {
-        handleApiError(e, () =>
-          addAlert({ title: `Failed to enable host ${hostId}`, message: getErrorMessage(e) }),
-        );
-      }
-    },
-    [cluster.id, dispatch, addAlert],
-  );
-
-  const onInstallHost = React.useCallback(
-    async (event: React.MouseEvent, rowIndex: number, rowData: IRowData) => {
-      const hostId = rowData.host.id;
-      try {
-        const { data } = await installHost(cluster.id, hostId);
-        dispatch(updateHost(data));
-      } catch (e) {
-        handleApiError(e, () =>
-          addAlert({ title: `Failed to enable host ${hostId}`, message: getErrorMessage(e) }),
-        );
-      }
-    },
-    [cluster.id, dispatch, addAlert],
-  );
-
-  const onHostDisable = React.useCallback(
-    async (event: React.MouseEvent, rowIndex: number, rowData: IRowData) => {
-      const hostId = rowData.host.id;
-      try {
-        const { data } = await disableClusterHost(cluster.id, hostId);
-        dispatch(updateCluster(data));
-      } catch (e) {
-        handleApiError(e, () =>
-          addAlert({ title: `Failed to disable host ${hostId}`, message: getErrorMessage(e) }),
-        );
-      }
-    },
-    [cluster.id, dispatch, addAlert],
-  );
-  const onHostReset = React.useCallback(
-    async (hostId) => {
-      try {
-        const { data } = await resetClusterHost(cluster.id, hostId);
-        dispatch(updateHost(data));
-      } catch (e) {
-        return handleApiError(e, () =>
-          addAlert({ title: `Failed to reset host ${hostId}`, message: getErrorMessage(e) }),
-        );
-      }
-    },
-    [cluster.id, dispatch, addAlert],
-  );
-
-  const onViewHostEvents = React.useCallback(
-    (event: React.MouseEvent, rowIndex: number, rowData: IRowData) => {
-      const host = rowData.host;
-      const { id, requestedHostname } = host;
-      const hostname = requestedHostname || rowData.inventory?.hostname || id;
-      eventsDialog.open({ hostId: id, hostname });
-    },
-    [eventsDialog],
-  );
-
-  const onEditHost = React.useCallback(
-    (event: React.MouseEvent, rowIndex: number, rowData: IRowData) => {
-      editHostDialog.open({ host: rowData.host, inventory: rowData.inventory });
-    },
-    [editHostDialog],
-  );
-
-  const onDownloadHostLogs = React.useCallback(
-    (event: React.MouseEvent, rowIndex: number, rowData: IRowData) =>
-      downloadHostInstallationLogs(addAlert, rowData.host),
-    [addAlert],
-  );
-
   const actionResolver = React.useCallback(
     (rowData: IRowData) => {
       const host: Host | undefined = rowData.host;
-      const clusterStatus: Cluster['status'] = rowData.clusterStatus;
       const hostname = rowData.host?.requestedHostname || rowData.inventory?.hostname;
 
       if (!host) {
@@ -392,77 +276,83 @@ const HostsTable: React.FC<HostsTableProps & WithTestID> = ({
 
       const actions = [];
 
-      if (canInstallHost(cluster, host.status)) {
+      if (onInstallHost && canInstallHost?.(host)) {
         actions.push({
           title: 'Install host',
           id: `button-install-host-${hostname}`,
           onClick: onInstallHost,
         });
       }
-      if (canEditHost(clusterStatus, host.status)) {
+      if (onEditHost && canEditHost?.(host)) {
         actions.push({
           title: 'Edit host',
           id: `button-edit-host-${hostname}`, // id is everchanging, not ideal for tests
-          onClick: onEditHost,
+          onClick: (event: React.MouseEvent, rowIndex: number, rowData: IRowData) =>
+            onEditHost(rowData.host, rowData.inventory),
         });
       }
-      if (canEnable(clusterStatus, host.status)) {
+      if (onHostEnable && canEnable?.(host)) {
         actions.push({
           title: 'Enable in cluster',
           id: `button-enable-in-cluster-${hostname}`,
           onClick: onHostEnable,
         });
       }
-      if (canDisable(clusterStatus, host.status)) {
+      if (onHostDisable && canDisable?.(host)) {
         actions.push({
           title: 'Disable in cluster',
           id: `button-disable-in-cluster-${hostname}`,
           onClick: onHostDisable,
         });
       }
-      if (canReset(clusterStatus, host.status)) {
+      if (onHostReset && canReset?.(host)) {
         actions.push({
           title: 'Reset host',
           id: `button-reset-host-${hostname}`,
-          onClick: () => {
-            resetHostDialog.open({ hostId: host.id, hostname });
-          },
+          onClick: (event: React.MouseEvent, rowIndex: number, rowData: IRowData) =>
+            onHostReset(rowData.host, rowData.inventory),
         });
       }
-      actions.push({
-        title: 'View host events',
-        id: `button-view-host-events-${hostname}`,
-        onClick: onViewHostEvents,
-      });
-      if (canDownloadHostLogs(host)) {
+      if (onViewHostEvents) {
+        actions.push({
+          title: 'View host events',
+          id: `button-view-host-events-${hostname}`,
+          onClick: onViewHostEvents,
+        });
+      }
+      if (onDownloadHostLogs && canDownloadHostLogs?.(host)) {
         actions.push({
           title: 'Download host logs',
           id: `button-download-host-installation-logs-${hostname}`,
           onClick: onDownloadHostLogs,
         });
       }
-      if (canDelete(clusterStatus, host.status)) {
+      if (onDeleteHost && canDelete?.(host)) {
         actions.push({
           title: 'Delete host',
           id: `button-delete-host-${hostname}`,
-          onClick: () => {
-            deleteHostDialog.open({ hostId: host.id, hostname });
-          },
+          onClick: onDeleteHost,
         });
       }
 
       return actions;
     },
     [
-      cluster,
       onHostEnable,
       onHostDisable,
       onViewHostEvents,
       onEditHost,
       onDownloadHostLogs,
       onInstallHost,
-      deleteHostDialog,
-      resetHostDialog,
+      onHostReset,
+      onDeleteHost,
+      canInstallHost,
+      canDelete,
+      canDisable,
+      canEnable,
+      canEditHost,
+      canReset,
+      canDownloadHostLogs,
     ],
   );
 
@@ -478,63 +368,22 @@ const HostsTable: React.FC<HostsTableProps & WithTestID> = ({
   );
 
   return (
-    <>
-      <Table
-        rows={rows}
-        cells={columns}
-        onCollapse={onCollapse}
-        variant={TableVariant.compact}
-        aria-label="Hosts table"
-        actionResolver={actionResolver}
-        className="hosts-table"
-        sortBy={sortBy}
-        onSort={onSort}
-        rowWrapper={HostsTableRowWrapper}
-        data-testid={testId}
-      >
-        <TableHeader />
-        <TableBody rowKey={rowKey} />
-      </Table>
-      <EventsModal
-        title={`Host Events${eventsDialog.isOpen ? `: ${eventsDialog.data?.hostname}` : ''}`}
-        entityKind="host"
-        cluster={cluster}
-        hostId={eventsDialog.data?.hostId}
-        onClose={() => eventsDialog.close()}
-        isOpen={eventsDialog.isOpen}
-      />
-      <ResetHostModal
-        hostname={resetHostDialog.data?.hostname}
-        onClose={() => resetHostDialog.close()}
-        isOpen={resetHostDialog.isOpen}
-        onReset={() => {
-          onHostReset(resetHostDialog.data?.hostId);
-          resetHostDialog.close();
-        }}
-      />
-      <DeleteHostModal
-        hostname={deleteHostDialog.data?.hostname}
-        onClose={() => deleteHostDialog.close()}
-        isOpen={deleteHostDialog.isOpen}
-        onDelete={() => {
-          onDeleteHost(deleteHostDialog.data?.hostId);
-          deleteHostDialog.close();
-        }}
-      />
-      <EditHostModal
-        host={editHostDialog.data?.host}
-        inventory={editHostDialog.data?.inventory}
-        cluster={cluster}
-        onClose={() => editHostDialog.close()}
-        isOpen={editHostDialog.isOpen}
-        onSave={() => editHostDialog.close()}
-      />
-      <AdditionalNTPSourcesDialog
-        cluster={cluster}
-        isOpen={additionalNTPSourcesDialog.isOpen}
-        onClose={() => additionalNTPSourcesDialog.close()}
-      />
-    </>
+    <Table
+      rows={rows}
+      cells={columns}
+      onCollapse={onCollapse}
+      variant={TableVariant.compact}
+      aria-label="Hosts table"
+      actionResolver={actionResolver}
+      className="hosts-table"
+      sortBy={sortBy}
+      onSort={onSort}
+      rowWrapper={HostsTableRowWrapper}
+      data-testid={testId}
+    >
+      <TableHeader />
+      <TableBody rowKey={rowKey} />
+    </Table>
   );
 };
 

--- a/src/components/hosts/NetworkingStatus.tsx
+++ b/src/components/hosts/NetworkingStatus.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Cluster, Host } from '../../api/types';
+import { Host } from '../../api/types';
 import { ValidationsInfo } from '../../types/hosts';
 import HostStatus from './HostStatus';
 import {
@@ -11,7 +11,7 @@ import {
 type NetworkingStatusProps = {
   host: Host;
   validationsInfo: ValidationsInfo;
-  cluster: Cluster;
+  onEditHostname?: () => void;
 };
 
 const NetworkingStatus: React.FC<NetworkingStatusProps> = (props) => {

--- a/src/components/hosts/index.ts
+++ b/src/components/hosts/index.ts
@@ -1,1 +1,2 @@
 export { default as HostsTable } from './HostsTable';
+export { default as ClusterHostsTable } from './ClusterHostsTable';

--- a/src/components/ui/DetailList.tsx
+++ b/src/components/ui/DetailList.tsx
@@ -10,6 +10,7 @@ import {
 } from '@patternfly/react-core';
 
 import './DetailList.css';
+import { WithTestID } from '../../types';
 
 export type DetailListProps = {
   children: ReactChild | (ReactChild | undefined)[];

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -7,7 +7,3 @@ declare module '*.jpg' {
   const content: string;
   export default content;
 }
-
-interface WithTestID {
-  testId?: string;
-}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,3 +5,7 @@ export enum ResourceUIState {
   EMPTY = 'EMPTY',
   LOADED = 'LOADED',
 }
+
+export type WithTestID = {
+  testId?: string;
+};


### PR DESCRIPTION
This PR changes HostsTable to make it reusable for other environments.
The table now accepts callbacks for all actions so the consumer can use its own way of opening modals.
If no callback for the action is provided, then its not shown (the table becomes read-only)


Example of consuming the table is here https://github.com/rawagner/dynamic-cim/blob/infra_hosts/src/components/Agent/AgentTable.tsx#L24

The `AgentTable` fetches Agent CR from k8s, maps the fields of the CR to format expected by `HostsTable` (we will need some util method to do this in the future). And passes the mapped hosts to `HostsTable`. Since no callbacks for the actions are provided, the table is in read-only mode.

`HostsTable` in OpenShift Console
![Screenshot from 2021-05-13 11-29-12](https://user-images.githubusercontent.com/2078045/118107001-8cb95580-b3de-11eb-9675-689874b3e317.png)

Expanded state
![Screenshot from 2021-05-13 11-29-27](https://user-images.githubusercontent.com/2078045/118107015-8fb44600-b3de-11eb-80e9-3d77bad8385a.png)

