### PR TITLE
BZ-1928653 Fixes flooding sentry when there is and API error

### DIFF
--- a/src/components/clusters/ClusterPage.tsx
+++ b/src/components/clusters/ClusterPage.tsx
@@ -28,7 +28,7 @@ type MatchParams = {
   clusterId: string;
 };
 
-const ClusterPage: React.FC<RouteComponentProps<MatchParams>> = ({ match }) => {
+const ClusterPage: React.FC<RouteComponentProps<MatchParams>> = ({ match, history }) => {
   const { clusterId } = match.params;
   const fetchCluster = useFetchCluster(clusterId);
   const { cluster, uiState, errorDetail } = useClusterPolling(clusterId);
@@ -113,7 +113,7 @@ const ClusterPage: React.FC<RouteComponentProps<MatchParams>> = ({ match }) => {
       <PageSection variant={PageSectionVariants.light} isFilled>
         <ErrorState
           title="Failed to fetch the cluster"
-          fetchData={fetchCluster}
+          fetchData={errorDetail?.code === '401' ? () => history.go(0) : fetchCluster}
           actions={errorStateActions}
         />
       </PageSection>

--- a/src/components/clusters/clusterPolling.ts
+++ b/src/components/clusters/clusterPolling.ts
@@ -30,7 +30,12 @@ export const useClusterPolling = (
 
   React.useEffect(() => {
     if (isReloadScheduled) {
-      if (![ResourceUIState.LOADING, ResourceUIState.RELOADING].includes(uiState)) {
+      const bannedUIStates = [
+        ResourceUIState.LOADING,
+        ResourceUIState.RELOADING,
+        ResourceUIState.ERROR,
+      ];
+      if (!bannedUIStates.includes(uiState)) {
         fetchCluster();
       }
     }
@@ -39,7 +44,7 @@ export const useClusterPolling = (
 
   React.useEffect(() => {
     fetchCluster();
-    const timer = setInterval(() => dispatch(forceReload()), POLLING_INTERVAL);
+    const timer = window.setInterval(() => dispatch(forceReload()), POLLING_INTERVAL);
     return () => {
       clearInterval(timer);
       dispatch(cancelForceReload());


### PR DESCRIPTION
This PR modifies the polling mechanism so it doesn't continues fetching
when there is an API error.
Also, the 'try again' action in the `ErrorState` component will trigger a full page reload only when the received HTTP status code is 401 Unauthorized, this is done in order to force OCM to send the users to the login page so they can renew their token.