### PR TITLE
MGMT-6608 Do not allow the user to select user-managed networking in non-SNO installations

### DIFF
--- a/src/components/clusterConfiguration/NetworkConfiguration.tsx
+++ b/src/components/clusterConfiguration/NetworkConfiguration.tsx
@@ -9,7 +9,6 @@ import { isAdvConf } from './utils';
 import { useDefaultConfiguration } from './ClusterDefaultConfigurationContext';
 import {
   AvailableSubnetsControl,
-  ManagedNetworkingControlGroup,
   UserManagedNetworkingTextContent,
   VirtualIPControlGroup,
 } from '../clusterWizard/networkingSteps';
@@ -74,7 +73,13 @@ const NetworkConfiguration = ({ cluster, hostSubnets }: NetworkConfigurationProp
 
   return (
     <>
-      <ManagedNetworkingControlGroup disabled={!isMultiNodeCluster} />
+      {
+        // TODO(jkilzi): The BE currently doesn't support user-managed networking in a non-SNO
+        // installation. Once they implement support for this scenario we can uncomment the line
+        // below and add an import statement for the ManagedNetworkingControlGroup component above.
+        // See https://issues.redhat.com/browse/MGMT-6608 for more info.
+        /*<ManagedNetworkingControlGroup disabled={!isMultiNodeCluster} />*/
+      }
       <RenderIf condition={isUserManagedNetworking}>
         <UserManagedNetworkingTextContent shouldDisplayLoadBalancersBullet={isMultiNodeCluster} />
       </RenderIf>


### PR DESCRIPTION
The radio buttons are removed temporarily until the BE implements
support for non-SNO

