### PR TITLE
BZ-1953528 Don't call PATCH API if the form hasn't changed

### DIFF
--- a/src/components/clusterWizard/ClusterDetails.tsx
+++ b/src/components/clusterWizard/ClusterDetails.tsx
@@ -181,6 +181,19 @@ const ClusterDetailsForm: React.FC<ClusterDetailsFormProps> = (props) => {
     }
   };
 
+  const handleOnNext = (
+    dirty: boolean,
+    submitForm: FormikHelpers<unknown>['submitForm'],
+    cluster?: Cluster,
+  ): (() => Promise<void> | void) => {
+    let fn: () => Promise<void> | void = submitForm;
+    if (!dirty && !_.isUndefined(cluster) && canNextClusterDetails({ cluster })) {
+      fn = () => setCurrentStepId('host-discovery');
+    }
+
+    return fn;
+  };
+
   const initialValues = getInitialValues(props);
   const validationSchema = getValidationSchema(cluster);
 
@@ -271,7 +284,7 @@ const ClusterDetailsForm: React.FC<ClusterDetailsFormProps> = (props) => {
                 (dirty || (cluster && canNextClusterDetails({ cluster })))
               )
             }
-            onNext={submitForm}
+            onNext={handleOnNext(dirty, submitForm, cluster)}
           />
         );
         return (


### PR DESCRIPTION
Before this PR we were calling the PATCH API on every transition from the "Cluster Details" to the "Host Discovery" (first to second step) even though the form remains pristine.
For the rest of the steps there is no PATCH API call when the form is pristine. This PR prevents calling the PATCH API when the form is pristine during the first transition only.
