### PR TITLE
MGMT-6447 Add Networking step to the ClusterDeployment wizard

### DIFF
--- a/src/components/ClusterDeployment/ClusterDeploymentDetails.tsx
+++ b/src/components/ClusterDeployment/ClusterDeploymentDetails.tsx
@@ -16,6 +16,7 @@ const ClusterDeploymentDetails: React.FC<{
     );
   };
 
+  const isEditFlow = !!cluster;
   return (
     <Grid hasGutter>
       <GridItem>
@@ -30,7 +31,9 @@ const ClusterDeploymentDetails: React.FC<{
           defaultPullSecret={defaultPullSecret}
           canEditPullSecret={!cluster || !cluster.pullSecretSet}
           isSNOGroupDisabled={true}
-          forceOpenshiftVersion={undefined}
+          isNameDisabled={isEditFlow}
+          isBaseDnsDomainDisabled={isEditFlow}
+          forceOpenshiftVersion={cluster?.openshiftVersion}
         />
       </GridItem>
     </Grid>

--- a/src/components/ClusterDeployment/ClusterDeploymentDetailsStep.tsx
+++ b/src/components/ClusterDeployment/ClusterDeploymentDetailsStep.tsx
@@ -79,7 +79,7 @@ const ClusterDeploymentDetailsStep: React.FC<ClusterDeploymentDetailsStepProps> 
             submitForm();
           }
           // TODO(mlibra): check behaviour if submit fails, no transition in that case
-          setCurrentStepId('todo'); // TODO(mlibra): set next step ID here
+          setCurrentStepId('networking'); // TODO(mlibra): fix the next step to Hosts once ready
         };
 
         const footer = (

--- a/src/components/ClusterDeployment/ClusterDeploymentHostsTable.tsx
+++ b/src/components/ClusterDeployment/ClusterDeploymentHostsTable.tsx
@@ -1,10 +1,11 @@
-import { ICell } from '@patternfly/react-table';
 import * as React from 'react';
+import { ICell } from '@patternfly/react-table';
+import { ConnectedIcon } from '@patternfly/react-icons';
 import { Cluster } from '../../api';
 import { WithTestID } from '../../types';
 import HostsTable, { HostsTableProps } from '../hosts/HostsTable';
 import { EmptyState } from '../ui/uiState';
-import { ConnectedIcon } from '@patternfly/react-icons';
+import { ClusterDeploymentHostsTablePropsActions } from './types';
 
 const HostsTableEmptyState: React.FC<{}> = () => (
   <EmptyState
@@ -22,12 +23,6 @@ const HostsTableEmptyState: React.FC<{}> = () => (
     // }
   />
 );
-
-// TODO(mlibra): List other picked hooks
-export type ClusterDeploymentHostsTablePropsActions = Pick<
-  HostsTableProps,
-  'onEditHost' | 'canEditHost'
->;
 
 type ClusterDeploymentHostsTableProps = {
   cluster: Cluster;

--- a/src/components/ClusterDeployment/ClusterDeploymentHostsTable.tsx
+++ b/src/components/ClusterDeployment/ClusterDeploymentHostsTable.tsx
@@ -1,0 +1,77 @@
+import { ICell } from '@patternfly/react-table';
+import * as React from 'react';
+import { Cluster } from '../../api';
+import { WithTestID } from '../../types';
+import HostsTable, { HostsTableProps } from '../hosts/HostsTable';
+import { EmptyState } from '../ui/uiState';
+import { ConnectedIcon } from '@patternfly/react-icons';
+
+const HostsTableEmptyState: React.FC<{}> = () => (
+  <EmptyState
+    icon={ConnectedIcon}
+    title="Waiting for hosts..."
+    content="Hosts may take a few minutes to appear here after booting."
+    // primaryAction={<DiscoveryImageModalButton cluster={cluster} idPrefix="host-table-empty" />}
+    // secondaryActions={
+    //   setDiscoveryHintModalOpen && [
+    //     <HostsNotShowingLink
+    //       key="hosts-not-showing"
+    //       setDiscoveryHintModalOpen={setDiscoveryHintModalOpen}
+    //     />,
+    //   ]
+    // }
+  />
+);
+
+// TODO(mlibra): List other picked hooks
+export type ClusterDeploymentHostsTablePropsActions = Pick<
+  HostsTableProps,
+  'onEditHost' | 'canEditHost'
+>;
+
+type ClusterDeploymentHostsTableProps = {
+  cluster: Cluster;
+  columns?: (string | ICell)[];
+  hostToHostTableRow?: HostsTableProps['hostToHostTableRow'];
+  skipDisabled?: boolean;
+} & ClusterDeploymentHostsTablePropsActions &
+  WithTestID;
+
+const ClusterDeploymentHostsTable: React.FC<ClusterDeploymentHostsTableProps> = ({
+  columns,
+  cluster,
+  hostToHostTableRow,
+  ...rest
+}) => {
+  /* TODO(mlibra): Implement actions, pass callbacks from higher context
+      onDeleteHost: (event: React.MouseEvent, rowIndex: number, rowData: IRowData) =>
+      onHostEnable: async (event: React.MouseEvent, rowIndex: number, rowData: IRowData) => {
+      onInstallHost: async (event: React.MouseEvent, rowIndex: number, rowData: IRowData) => {
+      onHostDisable: async (event: React.MouseEvent, rowIndex: number, rowData: IRowData) => {
+     const onViewHostEvents = React.useCallback(
+     const onHostReset = React.useCallback(
+     const onDownloadHostLogs = React.useCallback(
+
+        canEditRole: (host: Host) => canEditRoleUtil(cluster, host.status),
+        canInstallHost: (host: Host) => canInstallHostUtil(cluster, host.status),
+        canEditDisks: (host: Host) => canEditDisksUtil(cluster.status, host.status),
+        canEnable: (host: Host) => canEnableUtil(cluster.status, host.status),
+        canDisable: (host: Host) => canDisableUtil(cluster.status, host.status),
+        canDelete: (host: Host) => canDeleteUtil(cluster.status, host.status),
+        canEditHost: (host: Host) => canEditHostUtil(cluster.status, host.status),
+        canReset: (host: Host) => canResetUtil(cluster.status, host.status),
+*/
+  return (
+    <>
+      <HostsTable
+        {...rest}
+        columns={columns}
+        hostToHostTableRow={hostToHostTableRow}
+        hosts={cluster.hosts}
+        EmptyState={HostsTableEmptyState}
+      />
+    </>
+  );
+};
+
+export default ClusterDeploymentHostsTable;

--- a/src/components/ClusterDeployment/ClusterDeploymentNetworking.tsx
+++ b/src/components/ClusterDeployment/ClusterDeploymentNetworking.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Grid, GridItem, Text, TextContent } from '@patternfly/react-core';
 import ClusterWizardStepHeader from '../clusterWizard/ClusterWizardStepHeader';
-import { Cluster } from '../../api';
+import { Cluster, ClusterDefaultConfig } from '../../api';
 import NetworkConfigurationFormFields from '../clusterConfiguration/NetworkConfigurationFormFields';
 import { HostSubnets } from '../../types/clusters';
 import NetworkingHostsTable from '../hosts/NetworkingHostsTable';
@@ -12,8 +12,9 @@ const ClusterDeploymentNetworking: React.FC<
   {
     cluster: Cluster;
     hostSubnets: HostSubnets;
+    defaultNetworkSettings: ClusterDefaultConfig;
   } & ClusterDeploymentHostsTablePropsActions
-> = ({ cluster, hostSubnets, ...rest }) => {
+> = ({ cluster, hostSubnets, defaultNetworkSettings, ...rest }) => {
   const isVipDhcpAllocationDisabled = true; // So far not supported
 
   return (
@@ -28,6 +29,7 @@ const ClusterDeploymentNetworking: React.FC<
           cluster={cluster}
           hostSubnets={hostSubnets}
           isVipDhcpAllocationDisabled={isVipDhcpAllocationDisabled}
+          defaultNetworkSettings={defaultNetworkSettings}
         />
       </GridItem>
 

--- a/src/components/ClusterDeployment/ClusterDeploymentNetworking.tsx
+++ b/src/components/ClusterDeployment/ClusterDeploymentNetworking.tsx
@@ -5,9 +5,8 @@ import { Cluster } from '../../api';
 import NetworkConfigurationFormFields from '../clusterConfiguration/NetworkConfigurationFormFields';
 import { HostSubnets } from '../../types/clusters';
 import NetworkingHostsTable from '../hosts/NetworkingHostsTable';
-import ClusterDeploymentHostsTable, {
-  ClusterDeploymentHostsTablePropsActions,
-} from './ClusterDeploymentHostsTable';
+import ClusterDeploymentHostsTable from './ClusterDeploymentHostsTable';
+import { ClusterDeploymentHostsTablePropsActions } from './types';
 
 const ClusterDeploymentNetworking: React.FC<
   {
@@ -15,6 +14,8 @@ const ClusterDeploymentNetworking: React.FC<
     hostSubnets: HostSubnets;
   } & ClusterDeploymentHostsTablePropsActions
 > = ({ cluster, hostSubnets, ...rest }) => {
+  const isVipDhcpAllocationDisabled = true; // So far not supported
+
   return (
     <Grid hasGutter>
       <GridItem>
@@ -23,7 +24,11 @@ const ClusterDeploymentNetworking: React.FC<
         </ClusterWizardStepHeader>
       </GridItem>
       <GridItem span={12} lg={10} xl={9} xl2={7}>
-        <NetworkConfigurationFormFields cluster={cluster} hostSubnets={hostSubnets} />
+        <NetworkConfigurationFormFields
+          cluster={cluster}
+          hostSubnets={hostSubnets}
+          isVipDhcpAllocationDisabled={isVipDhcpAllocationDisabled}
+        />
       </GridItem>
 
       <GridItem>

--- a/src/components/ClusterDeployment/ClusterDeploymentNetworking.tsx
+++ b/src/components/ClusterDeployment/ClusterDeploymentNetworking.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { Grid, GridItem, Text, TextContent } from '@patternfly/react-core';
+import ClusterWizardStepHeader from '../clusterWizard/ClusterWizardStepHeader';
+import { Cluster } from '../../api';
+import NetworkConfigurationFormFields from '../clusterConfiguration/NetworkConfigurationFormFields';
+import { HostSubnets } from '../../types/clusters';
+import NetworkingHostsTable from '../hosts/NetworkingHostsTable';
+import ClusterDeploymentHostsTable, {
+  ClusterDeploymentHostsTablePropsActions,
+} from './ClusterDeploymentHostsTable';
+
+const ClusterDeploymentNetworking: React.FC<
+  {
+    cluster: Cluster;
+    hostSubnets: HostSubnets;
+  } & ClusterDeploymentHostsTablePropsActions
+> = ({ cluster, hostSubnets, ...rest }) => {
+  return (
+    <Grid hasGutter>
+      <GridItem>
+        <ClusterWizardStepHeader cluster={undefined /* Intentional to hide Events */}>
+          Networking
+        </ClusterWizardStepHeader>
+      </GridItem>
+      <GridItem span={12} lg={10} xl={9} xl2={7}>
+        <NetworkConfigurationFormFields cluster={cluster} hostSubnets={hostSubnets} />
+      </GridItem>
+
+      <GridItem>
+        <TextContent>
+          <Text component="h2">Host inventory</Text>
+        </TextContent>
+        <NetworkingHostsTable
+          cluster={cluster}
+          TableComponent={ClusterDeploymentHostsTable}
+          {...rest}
+        />
+      </GridItem>
+    </Grid>
+  );
+};
+
+export default ClusterDeploymentNetworking;

--- a/src/components/ClusterDeployment/ClusterDeploymentNetworkingStep.tsx
+++ b/src/components/ClusterDeployment/ClusterDeploymentNetworkingStep.tsx
@@ -78,7 +78,7 @@ const ClusterDeploymentNetworkingStep: React.FC<ClusterDeploymentDetailsNetworki
             submitForm();
           }
           // TODO(mlibra): check behaviour if submit fails, no transition in that case
-          // setCurrentStepId('networking'); // TODO(mlibra): set next step ID here
+          // setCurrentStepId('something-next'); // TODO(mlibra): set next step ID here
           onClose(); // TODO(mlibra): just temporarily - the flow will continue
         };
 

--- a/src/components/ClusterDeployment/ClusterDeploymentNetworkingStep.tsx
+++ b/src/components/ClusterDeployment/ClusterDeploymentNetworkingStep.tsx
@@ -95,7 +95,12 @@ const ClusterDeploymentNetworkingStep: React.FC<ClusterDeploymentDetailsNetworki
 
         return (
           <ClusterDeploymentWizardStep navigation={navigation} footer={footer}>
-            <ClusterDeploymentNetworking cluster={cluster} hostSubnets={hostSubnets} {...rest} />
+            <ClusterDeploymentNetworking
+              cluster={cluster}
+              hostSubnets={hostSubnets}
+              defaultNetworkSettings={defaultNetworkSettings}
+              {...rest}
+            />
           </ClusterDeploymentWizardStep>
         );
       }}

--- a/src/components/ClusterDeployment/ClusterDeploymentNetworkingStep.tsx
+++ b/src/components/ClusterDeployment/ClusterDeploymentNetworkingStep.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { Formik } from 'formik';
+
+import { getFormikErrorFields } from '../ui/formik/utils';
+import { Cluster, ClusterDefaultConfig } from '../../api';
+import { useAlerts } from '../AlertsContextProvider';
+
+import {
+  ClusterDeploymentDetailsNetworkingProps,
+  ClusterDeploymentNetworkingValues,
+} from './types';
+import ClusterDeploymentWizardFooter from './ClusterDeploymentWizardFooter';
+import ClusterDeploymentWizardNavigation from './ClusterDeploymentWizardNavigation';
+import ClusterDeploymentWizardStep from './ClusterDeploymentWizardStep';
+import ClusterDeploymentNetworking from './ClusterDeploymentNetworking';
+import {
+  getNetworkConfigurationValidationSchema,
+  getNetworkInitialValues,
+} from '../clusterConfiguration/networkConfigurationValidation';
+import { HostSubnets, NetworkConfigurationValues } from '../../types/clusters';
+import { CLUSTER_DEFAULT_NETWORK_SETTINGS_IPV4 } from '../../config';
+import { getHostSubnets } from '../clusterConfiguration/utils';
+
+const getInitialValues = ({
+  cluster,
+  defaultNetworkSettings,
+}: {
+  cluster: Cluster;
+  defaultNetworkSettings: ClusterDefaultConfig;
+}): ClusterDeploymentNetworkingValues => getNetworkInitialValues(cluster, defaultNetworkSettings);
+
+const getValidationSchema = (initialValues: NetworkConfigurationValues, hostSubnets: HostSubnets) =>
+  getNetworkConfigurationValidationSchema(initialValues, hostSubnets);
+
+const ClusterDeploymentNetworkingStep: React.FC<ClusterDeploymentDetailsNetworkingProps> = ({
+  cluster,
+  onSaveNetworking,
+  onClose,
+  ...rest
+}) => {
+  const { addAlert } = useAlerts();
+  // TODO(mlibra) - see bellow const { setCurrentStepId } = React.useContext(ClusterDeploymentWizardContext);
+
+  // TODO(mlibra): So far a constant. Should be queried from somewhere.
+  const defaultNetworkSettings: ClusterDefaultConfig = CLUSTER_DEFAULT_NETWORK_SETTINGS_IPV4;
+
+  const hostSubnets = React.useMemo(() => getHostSubnets(cluster), [cluster]);
+
+  const initialValues = React.useMemo(
+    () => getInitialValues({ cluster, defaultNetworkSettings }),
+    [], // eslint-disable-line react-hooks/exhaustive-deps
+  );
+  const validationSchema = React.useMemo(() => getValidationSchema(initialValues, hostSubnets), [
+    initialValues,
+    hostSubnets,
+  ]);
+
+  const handleSubmit = async (values: ClusterDeploymentNetworkingValues) => {
+    try {
+      await onSaveNetworking(values);
+    } catch (error) {
+      addAlert({
+        title: 'Failed to save ClusterDeployment',
+        message: error,
+      });
+    }
+  };
+
+  return (
+    <Formik
+      initialValues={initialValues}
+      validationSchema={validationSchema}
+      onSubmit={handleSubmit}
+    >
+      {({ submitForm, isSubmitting, isValid, isValidating, dirty, errors, touched }) => {
+        const handleOnNext = () => {
+          if (dirty) {
+            submitForm();
+          }
+          // TODO(mlibra): check behaviour if submit fails, no transition in that case
+          // setCurrentStepId('networking'); // TODO(mlibra): set next step ID here
+          onClose(); // TODO(mlibra): just temporarily - the flow will continue
+        };
+
+        const footer = (
+          <ClusterDeploymentWizardFooter
+            errorFields={getFormikErrorFields(errors, touched)}
+            isSubmitting={isSubmitting}
+            isNextDisabled={!isValid || isValidating || isSubmitting}
+            onNext={handleOnNext}
+            onCancel={onClose}
+          />
+        );
+        const navigation = <ClusterDeploymentWizardNavigation />;
+
+        return (
+          <ClusterDeploymentWizardStep navigation={navigation} footer={footer}>
+            <ClusterDeploymentNetworking cluster={cluster} hostSubnets={hostSubnets} {...rest} />
+          </ClusterDeploymentWizardStep>
+        );
+      }}
+    </Formik>
+  );
+};
+
+export default ClusterDeploymentNetworkingStep;

--- a/src/components/ClusterDeployment/ClusterDeploymentWizard.tsx
+++ b/src/components/ClusterDeployment/ClusterDeploymentWizard.tsx
@@ -12,6 +12,8 @@ const ClusterDeploymentWizard: React.FC<ClusterDeploymentWizardProps> = ({
   onClose,
   onEditHost,
   canEditHost,
+  onEditRole,
+  canEditRole,
   cluster,
   ocpVersions,
   defaultPullSecret,
@@ -31,6 +33,8 @@ const ClusterDeploymentWizard: React.FC<ClusterDeploymentWizardProps> = ({
               onClose={onClose}
               onEditHost={onEditHost}
               canEditHost={canEditHost}
+              onEditRole={onEditRole}
+              canEditRole={canEditRole}
               // TODO(mlibra) Add more networking-table actions here
             />
           );
@@ -62,6 +66,8 @@ const ClusterDeploymentWizard: React.FC<ClusterDeploymentWizardProps> = ({
     onClose,
     onEditHost,
     canEditHost,
+    onEditRole,
+    canEditRole,
   ]);
 
   return (

--- a/src/components/ClusterDeployment/ClusterDeploymentWizard.tsx
+++ b/src/components/ClusterDeployment/ClusterDeploymentWizard.tsx
@@ -21,7 +21,6 @@ const ClusterDeploymentWizard: React.FC<ClusterDeploymentWizardProps> = ({
     'cluster-details',
   );
   const renderCurrentStep = React.useCallback(() => {
-    // console.log('--- ClusterDeploymentWizard.renderCurrentStep), currentStepId: ', currentStepId, ', cluster: ', cluster);
     switch (currentStepId) {
       case 'networking':
         if (cluster) {

--- a/src/components/ClusterDeployment/ClusterDeploymentWizard.tsx
+++ b/src/components/ClusterDeployment/ClusterDeploymentWizard.tsx
@@ -21,6 +21,7 @@ const ClusterDeploymentWizard: React.FC<ClusterDeploymentWizardProps> = ({
     'cluster-details',
   );
   const renderCurrentStep = React.useCallback(() => {
+    // console.log('--- ClusterDeploymentWizard.renderCurrentStep), currentStepId: ', currentStepId, ', cluster: ', cluster);
     switch (currentStepId) {
       case 'networking':
         if (cluster) {
@@ -36,7 +37,7 @@ const ClusterDeploymentWizard: React.FC<ClusterDeploymentWizardProps> = ({
           );
         }
 
-        console.error(`Missing the AI Cluster object for the ${currentStepId} step`);
+        console.log(`Missing the AI Cluster object for the ${currentStepId} step, waiting ...`);
       // falls through to default
       case 'cluster-details':
       default:

--- a/src/components/ClusterDeployment/ClusterDeploymentWizard.tsx
+++ b/src/components/ClusterDeployment/ClusterDeploymentWizard.tsx
@@ -3,11 +3,15 @@ import { AlertsContextProvider } from '../AlertsContextProvider';
 import { ClusterDeploymentWizardProps, ClusterDeploymentWizardStepsType } from './types';
 import ClusterDeploymentWizardContext from './ClusterDeploymentWizardContext';
 import ClusterDeploymentDetailsStep from './ClusterDeploymentDetailsStep';
+import ClusterDeploymentNetworkingStep from './ClusterDeploymentNetworkingStep';
 
 const ClusterDeploymentWizard: React.FC<ClusterDeploymentWizardProps> = ({
   className = '',
   onSaveDetails,
+  onSaveNetworking,
   onClose,
+  onEditHost,
+  canEditHost,
   cluster,
   ocpVersions,
   defaultPullSecret,
@@ -18,14 +22,29 @@ const ClusterDeploymentWizard: React.FC<ClusterDeploymentWizardProps> = ({
   );
   const renderCurrentStep = React.useCallback(() => {
     switch (currentStepId) {
+      case 'networking':
+        if (cluster) {
+          return (
+            <ClusterDeploymentNetworkingStep
+              cluster={cluster}
+              onSaveNetworking={onSaveNetworking}
+              onClose={onClose}
+              onEditHost={onEditHost}
+              canEditHost={canEditHost}
+            />
+          );
+        }
+
+        console.error(`Missing the AI Cluster object for the ${currentStepId} step`);
+      // falls through to default
       case 'cluster-details':
       default:
         return (
           <ClusterDeploymentDetailsStep
-            cluster={cluster}
             defaultPullSecret={defaultPullSecret}
             ocpVersions={ocpVersions}
             usedClusterNames={usedClusterNames}
+            cluster={cluster}
             onSaveDetails={onSaveDetails}
             onClose={onClose}
           />
@@ -38,7 +57,10 @@ const ClusterDeploymentWizard: React.FC<ClusterDeploymentWizardProps> = ({
     ocpVersions,
     usedClusterNames,
     onSaveDetails,
+    onSaveNetworking,
     onClose,
+    onEditHost,
+    canEditHost,
   ]);
 
   return (

--- a/src/components/ClusterDeployment/ClusterDeploymentWizard.tsx
+++ b/src/components/ClusterDeployment/ClusterDeploymentWizard.tsx
@@ -31,6 +31,7 @@ const ClusterDeploymentWizard: React.FC<ClusterDeploymentWizardProps> = ({
               onClose={onClose}
               onEditHost={onEditHost}
               canEditHost={canEditHost}
+              // TODO(mlibra) Add more networking-table actions here
             />
           );
         }

--- a/src/components/ClusterDeployment/ClusterDeploymentWizardNavigation.tsx
+++ b/src/components/ClusterDeployment/ClusterDeploymentWizardNavigation.tsx
@@ -3,9 +3,9 @@ import { WizardNav } from '@patternfly/react-core';
 import WizardNavItem from '../ui/WizardNavItem';
 import { wizardStepNames } from './constants';
 import ClusterDeploymentWizardContext from './ClusterDeploymentWizardContext';
-// import { ClusterDeploymentWizardStepsType } from './types';
+import { ClusterDeploymentWizardStepsType } from './types';
 
-// const wizardSteps = Object.keys(wizardStepNames) as ClusterDeploymentWizardStepsType[];
+const wizardSteps = Object.keys(wizardStepNames) as ClusterDeploymentWizardStepsType[];
 
 const ClusterDeploymentWizardNavigation: React.FC<{
   // cluster?: Cluster
@@ -23,15 +23,18 @@ const ClusterDeploymentWizardNavigation: React.FC<{
         step={0}
         onNavItemClick={() => setCurrentStepId('cluster-details')}
       />
-      {/* <WizardNavItem
-        key="host-discovery"
-        content={wizardStepNames['host-discovery']}
+      <WizardNavItem
+        key="networking"
+        content={wizardStepNames['networking']}
         isDisabled={!wizardSteps.slice(1).includes(currentStepId)}
-        isValid={() => !cluster || canNextHostDiscovery({ cluster })}
-        isCurrent={currentStepId === 'host-discovery'}
+        isValid={
+          () => true /* TODO(mlibra)*/ /* () => !cluster || canNextHostDiscovery({ cluster })*/
+        }
+        isCurrent={currentStepId === 'networking'}
         step={1}
-        onNavItemClick={() => setCurrentStepId('host-discovery')}
+        onNavItemClick={() => setCurrentStepId('networking')}
       />
+      {/*
       <WizardNavItem
         content={wizardStepNames['networking']}
         step={2}

--- a/src/components/ClusterDeployment/constants.ts
+++ b/src/components/ClusterDeployment/constants.ts
@@ -10,5 +10,5 @@ export const wizardStepNames: {
   [key in ClusterDeploymentWizardStepsType]: string;
 } = {
   'cluster-details': 'Cluster Details',
-  todo: 'Next Step Name',
+  networking: 'Installation details',
 };

--- a/src/components/ClusterDeployment/types.ts
+++ b/src/components/ClusterDeployment/types.ts
@@ -2,7 +2,29 @@ import { Cluster } from '../../api';
 import { OpenshiftVersionOptionType } from '../../types';
 import { NetworkConfigurationValues } from '../../types/clusters';
 import { ClusterDetailsValues } from '../clusterWizard/types';
-import { ClusterDeploymentHostsTablePropsActions } from './ClusterDeploymentHostsTable';
+import { HostsTableProps } from '../hosts/HostsTable';
+
+export type ClusterDeploymentHostsTablePropsActions = Pick<
+  HostsTableProps,
+  'onEditHost' | 'canEditHost' | 'onDeleteHost' | 'canDelete'
+
+  /* TODO(mlibra): List other actions
+      onHostEnable: async (event: React.MouseEvent, rowIndex: number, rowData: IRowData) => {
+      onInstallHost: async (event: React.MouseEvent, rowIndex: number, rowData: IRowData) => {
+      onHostDisable: async (event: React.MouseEvent, rowIndex: number, rowData: IRowData) => {
+      onViewHostEvents 
+      onHostReset
+      onDownloadHostLogs
+
+      canEditRole: (host: Host) => canEditRoleUtil(cluster, host.status),
+      canInstallHost: (host: Host) => canInstallHostUtil(cluster, host.status),
+      canEditDisks: (host: Host) => canEditDisksUtil(cluster.status, host.status),
+      canEnable: (host: Host) => canEnableUtil(cluster.status, host.status),
+      canDisable: (host: Host) => canDisableUtil(cluster.status, host.status),
+      canEditHost: (host: Host) => canEditHostUtil(cluster.status, host.status),
+      canReset: (host: Host) => canResetUtil(cluster.status, host.status),
+  */
+>;
 
 export type ClusterDeploymentWizardStepsType = 'cluster-details' | 'networking';
 

--- a/src/components/ClusterDeployment/types.ts
+++ b/src/components/ClusterDeployment/types.ts
@@ -6,7 +6,7 @@ import { HostsTableProps } from '../hosts/HostsTable';
 
 export type ClusterDeploymentHostsTablePropsActions = Pick<
   HostsTableProps,
-  'onEditHost' | 'canEditHost' | 'onDeleteHost' | 'canDelete'
+  'onEditHost' | 'canEditHost' | 'onEditRole' | 'canEditRole' | 'onDeleteHost' | 'canDelete'
 
   /* TODO(mlibra): List other actions
       onHostEnable: async (event: React.MouseEvent, rowIndex: number, rowData: IRowData) => {

--- a/src/components/ClusterDeployment/types.ts
+++ b/src/components/ClusterDeployment/types.ts
@@ -1,8 +1,10 @@
 import { Cluster } from '../../api';
 import { OpenshiftVersionOptionType } from '../../types';
+import { NetworkConfigurationValues } from '../../types/clusters';
 import { ClusterDetailsValues } from '../clusterWizard/types';
+import { ClusterDeploymentHostsTablePropsActions } from './ClusterDeploymentHostsTable';
 
-export type ClusterDeploymentWizardStepsType = 'cluster-details' | 'todo';
+export type ClusterDeploymentWizardStepsType = 'cluster-details' | 'networking';
 
 export type ClusterDeploymentDetailsProps = {
   defaultPullSecret: string;
@@ -13,15 +15,24 @@ export type ClusterDeploymentDetailsProps = {
 
 export type ClusterDeploymentDetailsValues = ClusterDetailsValues;
 
+export type ClusterDeploymentNetworkingValues = NetworkConfigurationValues;
+
 export type ClusterDeploymentDetailsStepProps = ClusterDeploymentDetailsProps & {
   onSaveDetails: (values: ClusterDeploymentDetailsValues) => Promise<string | void>;
   onClose: () => void;
 };
+
+export type ClusterDeploymentDetailsNetworkingProps = {
+  cluster: Cluster;
+
+  onSaveNetworking: (values: ClusterDeploymentNetworkingValues) => Promise<string | void>;
+  onClose: () => void;
+} & ClusterDeploymentHostsTablePropsActions;
 
 export type ClusterDeploymentWizardProps = ClusterDeploymentDetailsProps & {
   className?: string;
 
   onClose: () => void;
   onSaveDetails: ClusterDeploymentDetailsStepProps['onSaveDetails'];
-  // onClusterSave: (params: ClusterDeploymentWizardValues) => Promise<void>;
-};
+  onSaveNetworking: ClusterDeploymentDetailsNetworkingProps['onSaveNetworking'];
+} & ClusterDeploymentHostsTablePropsActions;

--- a/src/components/clusterConfiguration/ClusterDefaultConfigurationContext.tsx
+++ b/src/components/clusterConfiguration/ClusterDefaultConfigurationContext.tsx
@@ -87,5 +87,6 @@ export const ClusterDefaultConfigurationProvider = ({
 };
 
 export const useDefaultConfiguration = (keys: Array<keyof ClusterDefaultConfig>) => {
+  // TODO(mlibra): There is no more the need to pick just selected values here, we can pass all the retrieved data
   return _.pick(useContext(ClusterDefaultConfigurationContext), keys);
 };

--- a/src/components/clusterConfiguration/NetworkConfiguration.tsx
+++ b/src/components/clusterConfiguration/NetworkConfiguration.tsx
@@ -2,8 +2,7 @@ import React, { useEffect } from 'react';
 import { useFormikContext } from 'formik';
 import { Checkbox } from '@patternfly/react-core';
 import AdvancedNetworkFields from './AdvancedNetworkFields';
-import { HostSubnets, NetworkConfigurationValues } from '../../types/clusters';
-import { Cluster } from '../../api';
+import { NetworkConfigurationValues } from '../../types/clusters';
 import { isSingleNodeCluster } from '../clusters/utils';
 import { isAdvConf } from './utils';
 import { useDefaultConfiguration } from './ClusterDefaultConfigurationContext';
@@ -11,16 +10,18 @@ import {
   AvailableSubnetsControl,
   UserManagedNetworkingTextContent,
   VirtualIPControlGroup,
+  VirtualIPControlGroupProps,
 } from '../clusterWizard/networkingSteps';
 import { RenderIf } from '../ui/RenderIf';
 import { NO_SUBNET_SET } from '../../config';
 
-type NetworkConfigurationProps = {
-  cluster: Cluster;
-  hostSubnets: HostSubnets;
-};
+export type NetworkConfigurationProps = VirtualIPControlGroupProps;
 
-const NetworkConfiguration = ({ cluster, hostSubnets }: NetworkConfigurationProps) => {
+const NetworkConfiguration = ({
+  cluster,
+  hostSubnets,
+  isVipDhcpAllocationDisabled,
+}: NetworkConfigurationProps) => {
   const { setFieldValue, values, touched, validateField } = useFormikContext<
     NetworkConfigurationValues
   >();
@@ -93,7 +94,11 @@ const NetworkConfiguration = ({ cluster, hostSubnets }: NetworkConfigurationProp
       </RenderIf>
 
       <RenderIf condition={!isUserManagedNetworking}>
-        <VirtualIPControlGroup cluster={cluster} hostSubnets={hostSubnets} />
+        <VirtualIPControlGroup
+          cluster={cluster}
+          hostSubnets={hostSubnets}
+          isVipDhcpAllocationDisabled={isVipDhcpAllocationDisabled}
+        />
       </RenderIf>
 
       <Checkbox

--- a/src/components/clusterConfiguration/NetworkConfiguration.tsx
+++ b/src/components/clusterConfiguration/NetworkConfiguration.tsx
@@ -5,7 +5,6 @@ import AdvancedNetworkFields from './AdvancedNetworkFields';
 import { NetworkConfigurationValues } from '../../types/clusters';
 import { isSingleNodeCluster } from '../clusters/utils';
 import { isAdvConf } from './utils';
-import { useDefaultConfiguration } from './ClusterDefaultConfigurationContext';
 import {
   AvailableSubnetsControl,
   UserManagedNetworkingTextContent,
@@ -14,23 +13,21 @@ import {
 } from '../clusterWizard/networkingSteps';
 import { RenderIf } from '../ui/RenderIf';
 import { NO_SUBNET_SET } from '../../config';
+import { ClusterDefaultConfig } from '../../api';
 
-export type NetworkConfigurationProps = VirtualIPControlGroupProps;
+export type NetworkConfigurationProps = VirtualIPControlGroupProps & {
+  defaultNetworkSettings: ClusterDefaultConfig;
+};
 
 const NetworkConfiguration = ({
   cluster,
   hostSubnets,
   isVipDhcpAllocationDisabled,
+  defaultNetworkSettings,
 }: NetworkConfigurationProps) => {
   const { setFieldValue, values, touched, validateField } = useFormikContext<
     NetworkConfigurationValues
   >();
-  const defaultNetworkSettings = useDefaultConfiguration([
-    'clusterNetworkCidr',
-    'serviceNetworkCidr',
-    'clusterNetworkHostPrefix',
-  ]);
-
   const [isAdvanced, setAdvanced] = React.useState(isAdvConf(cluster, defaultNetworkSettings));
 
   const toggleAdvConfiguration = (checked: boolean) => {

--- a/src/components/clusterConfiguration/NetworkConfigurationForm.tsx
+++ b/src/components/clusterConfiguration/NetworkConfigurationForm.tsx
@@ -116,7 +116,11 @@ const NetworkConfigurationForm: React.FC<{
                 <ClusterWizardStepHeader cluster={cluster}>Networking</ClusterWizardStepHeader>
               </GridItem>
               <GridItem span={12} lg={10} xl={9} xl2={7}>
-                <NetworkConfigurationFormFields cluster={cluster} hostSubnets={hostSubnets} />
+                <NetworkConfigurationFormFields
+                  cluster={cluster}
+                  hostSubnets={hostSubnets}
+                  defaultNetworkSettings={defaultNetworkSettings}
+                />
               </GridItem>
               <GridItem>
                 <TextContent>

--- a/src/components/clusterConfiguration/NetworkConfigurationFormFields.tsx
+++ b/src/components/clusterConfiguration/NetworkConfigurationFormFields.tsx
@@ -1,18 +1,16 @@
 import React from 'react';
 import { Form } from 'formik';
 import { TextContent, Text } from '@patternfly/react-core';
-import { HostSubnets } from '../../types/clusters';
-import NetworkConfiguration from './NetworkConfiguration';
+import NetworkConfiguration, { NetworkConfigurationProps } from './NetworkConfiguration';
 import ClusterSshKeyFields from './ClusterSshKeyFields';
-import { Cluster } from '../../api';
 
-const NetworkConfigurationFormFields: React.FC<{
-  cluster: Cluster;
-  hostSubnets: HostSubnets;
-}> = ({ cluster, hostSubnets }) => {
+type NetworkConfigurationFormFieldsProps = NetworkConfigurationProps;
+
+const NetworkConfigurationFormFields: React.FC<NetworkConfigurationFormFieldsProps> = (props) => {
+  const { cluster } = props;
   return (
     <Form>
-      <NetworkConfiguration cluster={cluster} hostSubnets={hostSubnets} />
+      <NetworkConfiguration {...props} />
       <TextContent>
         <Text component="h2">Security</Text>
       </TextContent>

--- a/src/components/clusterConfiguration/NetworkConfigurationFormFields.tsx
+++ b/src/components/clusterConfiguration/NetworkConfigurationFormFields.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Form } from 'formik';
+import { Form } from '@patternfly/react-core';
 import { TextContent, Text } from '@patternfly/react-core';
 import NetworkConfiguration, { NetworkConfigurationProps } from './NetworkConfiguration';
 import ClusterSshKeyFields from './ClusterSshKeyFields';

--- a/src/components/clusterConfiguration/NetworkConfigurationFormFields.tsx
+++ b/src/components/clusterConfiguration/NetworkConfigurationFormFields.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Form } from 'formik';
+import { TextContent, Text } from '@patternfly/react-core';
+import { HostSubnets } from '../../types/clusters';
+import NetworkConfiguration from './NetworkConfiguration';
+import ClusterSshKeyFields from './ClusterSshKeyFields';
+import { Cluster } from '../../api';
+
+const NetworkConfigurationFormFields: React.FC<{
+  cluster: Cluster;
+  hostSubnets: HostSubnets;
+}> = ({ cluster, hostSubnets }) => {
+  return (
+    <Form>
+      <NetworkConfiguration cluster={cluster} hostSubnets={hostSubnets} />
+      <TextContent>
+        <Text component="h2">Security</Text>
+      </TextContent>
+      <ClusterSshKeyFields
+        clusterSshKey={cluster.sshPublicKey}
+        imageSshKey={cluster.imageInfo.sshPublicKey}
+      />
+    </Form>
+  );
+};
+
+export default NetworkConfigurationFormFields;

--- a/src/components/clusterConfiguration/SNOControlGroup.tsx
+++ b/src/components/clusterConfiguration/SNOControlGroup.tsx
@@ -5,7 +5,7 @@ import SingleNodeCheckbox from '../ui/formik/SingleNodeCheckbox';
 import { ClusterDetailsValues } from '../clusterWizard/types';
 
 type SNOControlGroupProps = {
-  isDisabled: boolean;
+  isDisabled?: boolean;
   versions: OpenshiftVersionOptionType[];
   highAvailabilityMode: ClusterDetailsValues['highAvailabilityMode'];
 };

--- a/src/components/clusterConfiguration/SNODisclaimer.tsx
+++ b/src/components/clusterConfiguration/SNODisclaimer.tsx
@@ -3,9 +3,9 @@ import { Alert, AlertVariant, List, ListItem, Stack, StackItem } from '@patternf
 import { CheckboxField } from '../ui';
 
 type SNODisclaimerProps = {
-  isDisabled: boolean;
+  isDisabled?: boolean;
 };
-const SNODisclaimer = ({ isDisabled }: SNODisclaimerProps) => {
+const SNODisclaimer = ({ isDisabled = false }: SNODisclaimerProps) => {
   return (
     <Alert
       variant={AlertVariant.warning}

--- a/src/components/clusterConfiguration/networkConfigurationValidation.ts
+++ b/src/components/clusterConfiguration/networkConfigurationValidation.ts
@@ -1,0 +1,48 @@
+import * as Yup from 'yup';
+import { Cluster, ClusterDefaultConfig } from '../../api';
+import { HostSubnets, NetworkConfigurationValues } from '../../types/clusters';
+import {
+  hostPrefixValidationSchema,
+  ipBlockValidationSchema,
+  sshPublicKeyValidationSchema,
+  vipValidationSchema,
+} from '../ui/formik/validationSchemas';
+import { getSubnetFromMachineNetworkCidr } from './utils';
+
+export const getNetworkInitialValues = (
+  cluster: Cluster,
+  defaultNetworkSettings: ClusterDefaultConfig,
+): NetworkConfigurationValues => {
+  return {
+    clusterNetworkCidr: cluster.clusterNetworkCidr || defaultNetworkSettings.clusterNetworkCidr,
+    clusterNetworkHostPrefix:
+      cluster.clusterNetworkHostPrefix || defaultNetworkSettings.clusterNetworkHostPrefix,
+    serviceNetworkCidr: cluster.serviceNetworkCidr || defaultNetworkSettings.serviceNetworkCidr,
+    apiVip: cluster.apiVip || '',
+    ingressVip: cluster.ingressVip || '',
+    sshPublicKey: cluster.sshPublicKey || '',
+    hostSubnet: getSubnetFromMachineNetworkCidr(cluster.machineNetworkCidr),
+    vipDhcpAllocation: cluster.vipDhcpAllocation,
+    networkingType: cluster.userManagedNetworking ? 'userManaged' : 'clusterManaged',
+  };
+};
+
+export const getNetworkConfigurationValidationSchema = (
+  initialValues: NetworkConfigurationValues,
+  hostSubnets: HostSubnets,
+) =>
+  Yup.lazy<Pick<NetworkConfigurationValues, 'clusterNetworkCidr' | 'apiVip' | 'ingressVip'>>(
+    ({ clusterNetworkCidr, apiVip, ingressVip }) =>
+      Yup.object<NetworkConfigurationValues>().shape({
+        clusterNetworkHostPrefix: hostPrefixValidationSchema({ clusterNetworkCidr }),
+        clusterNetworkCidr: ipBlockValidationSchema,
+        serviceNetworkCidr: ipBlockValidationSchema,
+        apiVip: vipValidationSchema(hostSubnets, { apiVip, ingressVip }, initialValues.apiVip),
+        ingressVip: vipValidationSchema(
+          hostSubnets,
+          { apiVip, ingressVip },
+          initialValues.ingressVip,
+        ),
+        sshPublicKey: sshPublicKeyValidationSchema,
+      }),
+  );

--- a/src/components/clusterConfiguration/utils.ts
+++ b/src/components/clusterConfiguration/utils.ts
@@ -1,4 +1,4 @@
-import { HostDiscoveryValues, HostSubnets, NetworkConfigurationValues } from '../../types/clusters';
+import { HostDiscoveryValues, HostSubnets } from '../../types/clusters';
 import { Cluster, ClusterDefaultConfig, Inventory } from '../../api/types';
 import { stringToJSON } from '../../api/utils';
 import { Address4, Address6 } from 'ip-address';
@@ -68,23 +68,5 @@ export const getHostDiscoveryInitialValues = (cluster: Cluster): HostDiscoveryVa
   return {
     useExtraDisksForLocalStorage: isOperatorEnabled('ocs'),
     useContainerNativeVirtualization: isOperatorEnabled('cnv'),
-  };
-};
-
-export const getNetworkInitialValues = (
-  cluster: Cluster,
-  defaultNetworkSettings: ClusterDefaultConfig,
-): NetworkConfigurationValues => {
-  return {
-    clusterNetworkCidr: cluster.clusterNetworkCidr || defaultNetworkSettings.clusterNetworkCidr,
-    clusterNetworkHostPrefix:
-      cluster.clusterNetworkHostPrefix || defaultNetworkSettings.clusterNetworkHostPrefix,
-    serviceNetworkCidr: cluster.serviceNetworkCidr || defaultNetworkSettings.serviceNetworkCidr,
-    apiVip: cluster.apiVip || '',
-    ingressVip: cluster.ingressVip || '',
-    sshPublicKey: cluster.sshPublicKey || '',
-    hostSubnet: getSubnetFromMachineNetworkCidr(cluster.machineNetworkCidr),
-    vipDhcpAllocation: cluster.vipDhcpAllocation,
-    networkingType: cluster.userManagedNetworking ? 'userManaged' : 'clusterManaged',
   };
 };

--- a/src/components/clusterWizard/ClusterDetailsFormFields.tsx
+++ b/src/components/clusterWizard/ClusterDetailsFormFields.tsx
@@ -16,6 +16,8 @@ type ClusterDetailsFormFieldsProps = {
   canEditPullSecret: boolean;
   forceOpenshiftVersion?: string;
   isSNOGroupDisabled: boolean;
+  isNameDisabled: boolean;
+  isBaseDnsDomainDisabled: boolean;
   defaultPullSecret?: string;
 
   managedDomains?: ManagedDomain[];
@@ -41,6 +43,8 @@ const ClusterDetailsFormFields: React.FC<ClusterDetailsFormFieldsProps> = ({
   toggleRedHatDnsService,
   canEditPullSecret,
   isSNOGroupDisabled,
+  isNameDisabled,
+  isBaseDnsDomainDisabled,
   versions,
   defaultPullSecret,
   forceOpenshiftVersion,
@@ -55,7 +59,13 @@ const ClusterDetailsFormFields: React.FC<ClusterDetailsFormFieldsProps> = ({
   // TODO(mlibra): Disable fields based on props passed from the caller context. In CIM, the name or domain can not be edited.
   return (
     <Form id="wizard-cluster-details__form">
-      <InputField ref={nameInputRef} label="Cluster Name" name="name" isRequired />
+      <InputField
+        ref={nameInputRef}
+        label="Cluster Name"
+        name="name"
+        isRequired
+        isDisabled={isNameDisabled}
+      />
       {!!managedDomains.length && (
         <CheckboxField
           name="useRedHatDnsService"
@@ -81,7 +91,7 @@ const ClusterDetailsFormFields: React.FC<ClusterDetailsFormFieldsProps> = ({
           name="baseDnsDomain"
           helperText={<BaseDnsHelperText name={name} baseDnsDomain={baseDnsDomain} />}
           placeholder="example.com"
-          isDisabled={useRedHatDnsService}
+          isDisabled={isBaseDnsDomainDisabled || useRedHatDnsService}
           isRequired
         />
       )}

--- a/src/components/clusterWizard/ClusterDetailsFormFields.tsx
+++ b/src/components/clusterWizard/ClusterDetailsFormFields.tsx
@@ -15,9 +15,9 @@ import { ClusterDetailsValues } from './types';
 type ClusterDetailsFormFieldsProps = {
   canEditPullSecret: boolean;
   forceOpenshiftVersion?: string;
-  isSNOGroupDisabled: boolean;
-  isNameDisabled: boolean;
-  isBaseDnsDomainDisabled: boolean;
+  isSNOGroupDisabled?: boolean;
+  isNameDisabled?: boolean;
+  isBaseDnsDomainDisabled?: boolean;
   defaultPullSecret?: string;
 
   managedDomains?: ManagedDomain[];

--- a/src/components/clusterWizard/networkingSteps/AvailableSubnetsControl.tsx
+++ b/src/components/clusterWizard/networkingSteps/AvailableSubnetsControl.tsx
@@ -33,7 +33,7 @@ const SubnetHelperText = ({ matchingSubnet, hosts }: SubnetHelperTextProps) => {
                 hostA.requestedHostname?.localeCompare(hostB.requestedHostname || '') || 0,
             )
             .map((host) => (
-              <li key={host.id}>{host.requestedHostname}</li>
+              <li key={host.id}>{host.requestedHostname || host.id}</li>
             ))}
         </ul>
       }

--- a/src/components/clusterWizard/networkingSteps/VirtualIPControlGroup.tsx
+++ b/src/components/clusterWizard/networkingSteps/VirtualIPControlGroup.tsx
@@ -76,12 +76,17 @@ const getVipValidationsById = (
   }, {});
 };
 
-export interface VirtualIPControlGroupProps {
+export type VirtualIPControlGroupProps = {
   cluster: Cluster;
   hostSubnets: HostSubnets;
-}
+  isVipDhcpAllocationDisabled?: boolean;
+};
 
-export const VirtualIPControlGroup = ({ cluster, hostSubnets }: VirtualIPControlGroupProps) => {
+export const VirtualIPControlGroup = ({
+  cluster,
+  hostSubnets,
+  isVipDhcpAllocationDisabled,
+}: VirtualIPControlGroupProps) => {
   const { values } = useFormikContext<NetworkConfigurationValues>();
 
   const apiVipHelperText = `Virtual IP used to reach the OpenShift cluster API. ${getVipHelperSuffix(
@@ -104,7 +109,9 @@ export const VirtualIPControlGroup = ({ cluster, hostSubnets }: VirtualIPControl
 
   return (
     <>
-      <CheckboxField label="Allocate virtual IPs via DHCP server" name="vipDhcpAllocation" />
+      {!isVipDhcpAllocationDisabled && (
+        <CheckboxField label="Allocate virtual IPs via DHCP server" name="vipDhcpAllocation" />
+      )}
       {values.vipDhcpAllocation ? (
         <>
           <FormikStaticField

--- a/src/components/hosts/ClusterHostsTable.tsx
+++ b/src/components/hosts/ClusterHostsTable.tsx
@@ -73,7 +73,7 @@ const HostsTableEmptyState: React.FC<HostsTableEmptyStateProps> = ({
   />
 );
 
-type ClusterHostsTableProps = {
+export type ClusterHostsTableProps = {
   cluster: Cluster;
   columns?: (string | ICell)[];
   hostToHostTableRow?: HostsTableProps['hostToHostTableRow'];

--- a/src/components/hosts/HostsCount.tsx
+++ b/src/components/hosts/HostsCount.tsx
@@ -16,14 +16,18 @@ const HostsCount: React.FC<HostsCountProps> = ({
 }) => {
   const body = (
     <>
-      <Level>
-        <LevelItem>Ready for the installation</LevelItem>
-        <LevelItem>{getReadyHostCount(cluster)}</LevelItem>
-      </Level>
-      <Level>
-        <LevelItem>Enabled for the installation</LevelItem>
-        <LevelItem>{getEnabledHostCount(cluster)}</LevelItem>
-      </Level>
+      {'readyHostCount' in cluster && (
+        <Level>
+          <LevelItem>Ready for the installation</LevelItem>
+          <LevelItem>{getReadyHostCount(cluster)}</LevelItem>
+        </Level>
+      )}
+      {'enabledHostCount' in cluster && (
+        <Level>
+          <LevelItem>Enabled for the installation</LevelItem>
+          <LevelItem>{getEnabledHostCount(cluster)}</LevelItem>
+        </Level>
+      )}
       <Level>
         <LevelItem>All discovered</LevelItem>
         <LevelItem>{getTotalHostCount(cluster)}</LevelItem>
@@ -31,11 +35,13 @@ const HostsCount: React.FC<HostsCountProps> = ({
     </>
   );
 
+  const summary =
+    'enabledHostCount' in cluster ? getEnabledHostCount(cluster) : getTotalHostCount(cluster);
   return (
     <Popover headerContent="Hosts in the cluster" bodyContent={body}>
       <a id={valueId}>
         {inParenthesis && '('}
-        {getEnabledHostCount(cluster)}
+        {summary}
         {inParenthesis && ')'}
       </a>
     </Popover>

--- a/src/components/hosts/HostsTable.tsx
+++ b/src/components/hosts/HostsTable.tsx
@@ -300,6 +300,7 @@ const HostsTable: React.FC<HostsTableProps & WithTestID> = ({
           onClick: onInstallHost,
         });
       }
+      console.log('--- onEditHost: ', onEditHost, ', canEditHost: ', canEditHost);
       if (onEditHost && canEditHost?.(host)) {
         actions.push({
           title: 'Edit host',

--- a/src/components/hosts/HostsTable.tsx
+++ b/src/components/hosts/HostsTable.tsx
@@ -300,7 +300,6 @@ const HostsTable: React.FC<HostsTableProps & WithTestID> = ({
           onClick: onInstallHost,
         });
       }
-      console.log('--- onEditHost: ', onEditHost, ', canEditHost: ', canEditHost);
       if (onEditHost && canEditHost?.(host)) {
         actions.push({
           title: 'Edit host',

--- a/src/components/hosts/NetworkingHostsTable.tsx
+++ b/src/components/hosts/NetworkingHostsTable.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { sortable, expandable } from '@patternfly/react-table';
 import { Cluster, Interface, Inventory } from '../../api/types';
-import { ClusterHostsTable } from '.';
 import { HostDetail } from './HostRowDetail';
 import { HostsTableProps } from './HostsTable';
 import { stringToJSON } from '../../api/utils';
@@ -15,6 +14,8 @@ import NetworkingStatus from './NetworkingStatus';
 import { getSubnet } from '../clusterConfiguration/utils';
 import { Address4, Address6 } from 'ip-address';
 import RoleCell from './RoleCell';
+import { ClusterHostsTableProps } from './ClusterHostsTable';
+import { WithTestID } from '../../types';
 
 const getSelectedNic = (nics: Interface[], currentSubnet: Address4 | Address6) => {
   return nics.find((nic) => {
@@ -150,12 +151,19 @@ type NetworkingHostsTableProps = {
   cluster: Cluster;
   skipDisabled?: boolean;
   setDiscoveryHintModalOpen?: HostsNotShowingLinkProps['setDiscoveryHintModalOpen'];
+  TableComponent: React.FC<NetworkingHostsTableComponentProps>;
 };
 
-const NetworkingHostsTable: React.FC<NetworkingHostsTableProps> = (props) => {
+// So far we can reuse ClusterHostsTableProps even for the ClusterDeployment flow. Change it if needed.
+export type NetworkingHostsTableComponentProps = ClusterHostsTableProps & WithTestID;
+
+const NetworkingHostsTable: React.FC<NetworkingHostsTableProps> = ({
+  TableComponent,
+  ...props
+}) => {
   const columns = React.useMemo(() => getColumns(props.cluster), [props.cluster]);
   return (
-    <ClusterHostsTable
+    <TableComponent
       {...props}
       testId={'networking-host-table'}
       columns={columns}

--- a/src/components/hosts/NetworkingHostsTable.tsx
+++ b/src/components/hosts/NetworkingHostsTable.tsx
@@ -13,7 +13,7 @@ import HostsCount from './HostsCount';
 import NetworkingStatus from './NetworkingStatus';
 import { getSubnet } from '../clusterConfiguration/utils';
 import { Address4, Address6 } from 'ip-address';
-import RoleCell from './RoleCell';
+import RoleCell, { RoleCellProps } from './RoleCell';
 import { ClusterHostsTableProps } from './ClusterHostsTable';
 import { WithTestID } from '../../types';
 
@@ -58,6 +58,8 @@ const hostToHostTableRow: HostToHostTableRow = (cluster) => (
   openRows,
   canEditDisks,
   onEditHostname,
+  canEditRole,
+  onEditRole,
 ) => (host) => {
   const { id, status, inventory: inventoryString = '' } = host;
   const inventory = stringToJSON<Inventory>(inventoryString) || {};
@@ -72,6 +74,9 @@ const hostToHostTableRow: HostToHostTableRow = (cluster) => (
 
   const editHostname = onEditHostname ? () => onEditHostname(host, inventory) : undefined;
 
+  const onEditHostRole: RoleCellProps['onEditRole'] = onEditRole
+    ? (role) => onEditRole(host, role)
+    : undefined;
   return [
     {
       // visible row
@@ -83,7 +88,14 @@ const hostToHostTableRow: HostToHostTableRow = (cluster) => (
           sortableValue: computedHostname || '',
         },
         {
-          title: <RoleCell host={host} readonly role={hostRole} />,
+          title: (
+            <RoleCell
+              host={host}
+              readonly={!onEditRole || !canEditRole || !canEditRole(host)}
+              onEditRole={onEditHostRole}
+              role={hostRole}
+            />
+          ),
           props: { 'data-testid': 'host-role' },
           sortableValue: hostRole,
         },

--- a/src/components/hosts/RoleCell.tsx
+++ b/src/components/hosts/RoleCell.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { RoleDropdown } from './RoleDropdown';
 import { Host } from '../../api/types';
 
-type RoleCellProps = {
+export type RoleCellProps = {
   host: Host;
   role: string;
   readonly?: boolean;


### PR DESCRIPTION
Depends on:
- [x] #624 Introduce ClusterDeploymentWizard and related refactoring

Required by:
- https://github.com/rawagner/dynamic-cim/pull/17

TODO:
- [x] Allocate virtual IPs via DHCP server - recently not supported by BE, we need to disable it
- [x] Cluster defaults - can we query them? Deferred to `MGMT-7063`
- [x] Additional actions (so far just the first one Edit Host) + `can*` functions (so far just `() => true`) - will be implemented later, TODOs added
- [x] add at least Role selection action
- [x] validations in the left-side navigation - deferred to `MGMT-7062`
- [x] Fix passing of the OCP version
- [x]  fix wiping of data when Advanced is selected/unselected
- [x] disable fields which we can not `Edit` in the k8s flow
- [x] review calculation of `aiCluster.hostNetworks` - use `connectivityMajorityGroups`
- [x] set `agentClusterInstall?.spec?.networking?.machineNetwork?.[0]?.cidr`  from hostSubnet
- [x] spruce up CSS - esp. row spacing
- [ ] form-based validations and transitions (i.e. subnet is required)
