### PR TITLE
fix: fixes spacing issue

### DIFF
--- a/src/components/fetching/HostRequirements.css
+++ b/src/components/fetching/HostRequirements.css
@@ -1,3 +1,3 @@
-.host-requirements-link {
+.host-requirements-link.host-requirements-link {
   margin-right: var(--pf-global--spacer--sm);
 }


### PR DESCRIPTION
The .host-requirements-link css class was being overridden. So the rules didn't apply.

![image](https://user-images.githubusercontent.com/77008341/122204430-c7178600-cea7-11eb-907c-97e13afad39e.png)