### PR TITLE
Use PF's DescriptionList instead of custom DetailList

### DIFF
--- a/src/components/clusterConfiguration/DownloadIso.tsx
+++ b/src/components/clusterConfiguration/DownloadIso.tsx
@@ -12,6 +12,10 @@ import {
   ModalBoxBody,
   ModalBoxFooter,
   TextContent,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
 } from '@patternfly/react-core';
 import { global_success_color_100 as successColor } from '@patternfly/react-tokens';
 import { CheckCircleIcon } from '@patternfly/react-icons';
@@ -41,35 +45,31 @@ const DownloadIso: React.FC<DownloadISOProps> = ({
             Discovery ISO is ready to download
           </Title>
         </EmptyState>
-        <TextContent>
-          <DetailList>
-            <DetailItem
-              title="Discovery ISO URL"
-              value={
-                <ClipboardCopy isReadOnly onCopy={(event) => clipboardCopyFunc(event, downloadUrl)}>
-                  {downloadUrl}
-                </ClipboardCopy>
-              }
-            />
-            <DetailItem
-              title="Command to download the ISO"
-              value={
-                <ClipboardCopy isReadOnly onCopy={(event) => clipboardCopyFunc(event, wgetCommand)}>
-                  {wgetCommand}
-                </ClipboardCopy>
-              }
-            />
-          </DetailList>
-          <DetailItem
-            title="Boot instructions"
-            value={
-              <>
-                Use a bootable device (local disk, USB drive, etc.) or network booting (PXE) to boot
-                each host <b>once</b> from the Discovery ISO.
-              </>
-            }
-          ></DetailItem>
-        </TextContent>
+        <DescriptionList>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Discovery ISO URL</DescriptionListTerm>
+            <DescriptionListDescription>
+              <ClipboardCopy isReadOnly onCopy={(event) => clipboardCopyFunc(event, downloadUrl)}>
+                {downloadUrl}
+              </ClipboardCopy>
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Command to download the ISO</DescriptionListTerm>
+            <DescriptionListDescription>
+              <ClipboardCopy isReadOnly onCopy={(event) => clipboardCopyFunc(event, wgetCommand)}>
+                {wgetCommand}
+              </ClipboardCopy>
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+          <DescriptionListGroup>
+            <DescriptionListTerm>Boot instructions</DescriptionListTerm>
+            <DescriptionListDescription>
+              Use a bootable device (local disk, USB drive, etc.) or network booting (PXE) to boot
+              each host <b>once</b> from the Discovery ISO.
+            </DescriptionListDescription>
+          </DescriptionListGroup>
+        </DescriptionList>
       </ModalBoxBody>
       <ModalBoxFooter>
         <Button


### PR DESCRIPTION
in DownloadISO component. Nesting definition list in TextContent component
causes applying grid on the definition list.

Before:
<img width="636" alt="Screenshot 2021-06-23 at 12 09 04" src="https://user-images.githubusercontent.com/1121740/123079375-2df2ed00-d41c-11eb-8475-1e9cee7df626.png">

After:
<img width="628" alt="Screenshot 2021-06-23 at 12 11 34" src="https://user-images.githubusercontent.com/1121740/123079395-31867400-d41c-11eb-963f-eaa6854049fd.png">
