### PR TITLE
BZ-1975228: CNV help popover arrow is misplaced

### DIFF
--- a/src/components/clusterConfiguration/DiscoveryImageTypeControlGroup.tsx
+++ b/src/components/clusterConfiguration/DiscoveryImageTypeControlGroup.tsx
@@ -20,6 +20,7 @@ const DiscoveryImageTypeControlGroupLabel = ({
       variant={'plain'}
       IconComponent={HelpIcon}
       bodyContent={popoverContent}
+      noVerticalAlign
     />
   </>
 );

--- a/src/components/clusterConfiguration/HostInventory.tsx
+++ b/src/components/clusterConfiguration/HostInventory.tsx
@@ -26,7 +26,7 @@ const OCSLabel: React.FC = () => (
       component={'a'}
       variant={'plain'}
       IconComponent={HelpIcon}
-      hasAutoWidth
+      minWidth="50rem"
       headerContent="Additional Requirements"
       bodyContent={<>FOO BAR </>}/>
     */}
@@ -44,7 +44,7 @@ const CNVLabel: React.FC<{ clusterId: Cluster['id']; isSingleNode?: boolean }> =
         component={'a'}
         variant={'plain'}
         IconComponent={HelpIcon}
-        hasAutoWidth
+        minWidth="50rem"
         headerContent="Additional Requirements"
         bodyContent={
           <CNVHostRequirementsContent clusterId={clusterId} isSingleNode={isSingleNode} />
@@ -119,5 +119,4 @@ const HostInventory: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
     </Stack>
   );
 };
-
 export default HostInventory;

--- a/src/components/ui/PopoverIcon.tsx
+++ b/src/components/ui/PopoverIcon.tsx
@@ -8,12 +8,14 @@ type PopoverIconProps = PopoverProps & {
   variant?: ButtonProps['variant'];
   component?: ButtonProps['component'];
   IconComponent?: React.ComponentClass<SVGIconProps>;
+  noVerticalAlign?: boolean;
 };
 
 const PopoverIcon: React.FC<PopoverIconProps> = ({
   component,
   variant = 'link',
   IconComponent = OutlinedQuestionCircleIcon,
+  noVerticalAlign = false,
   ...props
 }) => (
   <Popover {...props}>
@@ -23,7 +25,7 @@ const PopoverIcon: React.FC<PopoverIconProps> = ({
       onClick={(e) => e.preventDefault()}
       className="pf-c-form__group-label-help"
     >
-      <IconComponent noVerticalAlign />
+      <IconComponent noVerticalAlign={noVerticalAlign} />
     </Button>
   </Popover>
 );

--- a/src/components/ui/formik/PullSecretField.tsx
+++ b/src/components/ui/formik/PullSecretField.tsx
@@ -12,6 +12,7 @@ export type PullSecretFieldProps = {
 
 export const PullSecretInfo: React.FC = () => (
   <PopoverIcon
+    noVerticalAlign
     bodyContent={
       <>
         Pull secrets are used to download OpenShift Container Platform components and connect


### PR DESCRIPTION
[BZ-1975228](https://bugzilla.redhat.com/show_bug.cgi?id=1975228)


Before:
https://user-images.githubusercontent.com/77008341/125964772-b639dad7-4c5d-4730-9249-651ac8e300ce.mp4


After:
https://user-images.githubusercontent.com/77008341/125964506-03e57eb8-6121-46bc-bc8c-aa8e8eaeb209.mp4
