### PR TITLE
NO-ISSUE: Adds missing aria label

### DIFF
--- a/src/common/components/ui/eventsModal.tsx
+++ b/src/common/components/ui/eventsModal.tsx
@@ -72,6 +72,7 @@ export const EventsModal: React.FC<EventsModalProps> = ({
     <Modal
       title={title}
       isOpen={isOpen}
+      aria-label="Displays events"
       hasNoBodyWrapper
       actions={[
         <Button key="close" variant={ButtonVariant.primary} onClick={onClose}>


### PR DESCRIPTION
Fixes an issue introduced in #714 

According to PF, when using a Modal component with `hasNoBodyWrapper` we must add an `aria-label` as well.