### PR TITLE
NO-ISSUE: Update ClusterEventsToolbar.tsx

### DIFF
--- a/src/common/components/ui/ClusterEventsToolbar.tsx
+++ b/src/common/components/ui/ClusterEventsToolbar.tsx
@@ -205,6 +205,7 @@ const ClusterEventsToolbar: React.FC<ClustersListToolbarProps> = ({
 
   return (
     <Toolbar
+      id="clusters-events-toolbar"
       className="pf-m-toggle-group-container"
       collapseListedFiltersBreakpoint="xl"
       clearAllFilters={onClearAllFilters}


### PR DESCRIPTION
Restores missing `cluster-events-toolbar` id, the issue was introduced in #714 