### PR TITLE
MGMT-6644: The validation of the Base Domain length was omitted

### DIFF
--- a/src/common/components/ui/formik/validationSchemas.ts
+++ b/src/common/components/ui/formik/validationSchemas.ts
@@ -218,7 +218,6 @@ export const ipBlockValidationSchema = Yup.string()
   );
 
 export const dnsNameValidationSchema = Yup.string()
-  .max(255, 'The DNS name can not be longer than 255 characters.')
   .test(
     'dns-name-label-length',
     'Single label of the DNS name can not be longer than 63 characters.',


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-6644

Before, the base domain name length validation in the UI gave an error when the Base Domain length was greater than 255, but this doesn't match the BE validation. 
I omitted this validation as we agreed on Standup. 

![image](https://user-images.githubusercontent.com/69599321/129901629-6f374e0e-23b4-4869-acd0-42baaa173686.png)


