### PR TITLE
BZ-1898550: Fix validation of forbidden host names in UI

### DIFF
--- a/src/common/components/hosts/EditHostForm.tsx
+++ b/src/common/components/hosts/EditHostForm.tsx
@@ -38,8 +38,8 @@ const validationSchema = (initialValues: HostUpdateParams, usedHostnames: string
   Yup.object().shape({
     hostname: hostnameValidationSchema.concat(
       uniqueHostnameValidationSchema(initialValues.hostname, usedHostnames).notOneOf(
-        ['localhost'],
-        `Hostname 'localhost' is not allowed.`,
+        ['localhost', 'localhost.localdomain'],
+        'Hostname ${value} is not allowed.',
       ),
     ),
   });


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1898550

Both localhost and localhost.localdomain host names are not be allowed:
![image](https://user-images.githubusercontent.com/69599321/131527542-4aae3821-b3b5-4d08-a7ee-55a0b2af570b.png)
![image](https://user-images.githubusercontent.com/69599321/131527566-a6d4824f-5fea-49b5-bcc1-77d1092c71fb.png)


