### PR TITLE
MGMT-7719: New cluster page v2 API migration

### DIFF
--- a/src/ocm/adapters/LocalStorageBackedCache.ts
+++ b/src/ocm/adapters/LocalStorageBackedCache.ts
@@ -1,0 +1,61 @@
+const CACHE_KEY = 'ai-lib-cache';
+
+const update = (cache: Record<string, string>): void => {
+  localStorage.setItem(CACHE_KEY, JSON.stringify(cache));
+};
+
+const read = (): Record<string, string> => {
+  const EMPTY_CACHE = '{}';
+  const cache = localStorage.getItem(CACHE_KEY) || EMPTY_CACHE;
+
+  try {
+    return JSON.parse(cache) as Record<string, string>;
+  } catch {
+    return {};
+  }
+};
+
+const LocalStorageBackedCache: Storage = {
+  key(index: number): string | null {
+    return localStorage.key(index);
+  },
+
+  get length(): number {
+    return localStorage.length;
+  },
+
+  clear(): void {
+    localStorage.removeItem(CACHE_KEY);
+  },
+
+  getItem(key: string): string | null {
+    if (!key) {
+      return null;
+    }
+
+    const cache = read();
+    return cache[key] || null;
+  },
+
+  removeItem(key: string): void {
+    if (!key) {
+      return;
+    }
+
+    const cache = read();
+    delete cache[key];
+    update(cache);
+  },
+
+  setItem(key: string, value: string): void {
+    if (!key || !value) {
+      return;
+    }
+
+    const cache = read();
+    cache[key] = value;
+    update(cache);
+  },
+};
+
+export default LocalStorageBackedCache;

--- a/src/ocm/api/InfraEnvService.ts
+++ b/src/ocm/api/InfraEnvService.ts
@@ -1,0 +1,11 @@
+import { AxiosPromise } from 'axios';
+import { InfraEnv, InfraEnvCreateParams, InfraEnvList } from '../../common/api/types';
+import { client } from './axiosClient';
+
+export const registerInfraEnv = (params: InfraEnvCreateParams): AxiosPromise<InfraEnv> =>
+  client.post('/v2/infra-envs', params);
+
+export const deregisterInfraEnv = (infraEnvId: string): AxiosPromise<void> =>
+  client.delete(`/v2/infra-envs/${infraEnvId}`);
+
+export const listInfraEnvs = (): AxiosPromise<InfraEnvList> => client.get('/v2/infra-envs/');

--- a/src/ocm/api/clusters.ts
+++ b/src/ocm/api/clusters.ts
@@ -18,7 +18,7 @@ import { client, BASE_PATH } from './axiosClient';
 
 export const getClusters = (): AxiosPromise<Cluster[]> => client.get('/v1/clusters');
 export const getClustersDefaultConfiguration = (): AxiosPromise<ClusterDefaultConfig> =>
-  client.get('/v1/clusters/default-config');
+  client.get('/v2/clusters/default-config');
 
 export const getCluster = (id: string): AxiosPromise<Cluster> => client.get(`/v1/clusters/${id}`);
 export const getClustersByOpenshiftId = (openshiftId: string): AxiosPromise<Cluster[]> =>

--- a/src/ocm/api/domains.tsx
+++ b/src/ocm/api/domains.tsx
@@ -2,4 +2,4 @@ import { AxiosPromise } from 'axios';
 import { client } from './axiosClient';
 import { ManagedDomain } from '../../common';
 
-export const getManagedDomains = (): AxiosPromise<ManagedDomain[]> => client.get('/v1/domains');
+export const getManagedDomains = (): AxiosPromise<ManagedDomain[]> => client.get('/v2/domains');

--- a/src/ocm/api/versions.ts
+++ b/src/ocm/api/versions.ts
@@ -5,4 +5,4 @@ import { ListVersions, OpenshiftVersions } from '../../common';
 export const getVersions = (): AxiosPromise<ListVersions> => client.get('/v1/component_versions');
 
 export const getOpenshiftVersions = (): AxiosPromise<OpenshiftVersions> =>
-  client.get('/v1/openshift_versions');
+  client.get('/v2/openshift-versions');


### PR DESCRIPTION
[MGMT-7719](https://issues.redhat.com/browse/MGMT-7719)

Implements Create cluster with v2 APIs only

Migrated:
- GET /v2/default-config
- GET /v2/domains/
- GET /v2/openshift-versions