### PR TITLE
Add cluster scale up functionality to CIM

### DIFF
--- a/src/cim/components/Agent/AgentsSelectionHostCountAlerts.tsx
+++ b/src/cim/components/Agent/AgentsSelectionHostCountAlerts.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Alert, AlertGroup, AlertVariant } from '@patternfly/react-core';
+
+const getHostCountWarningText = (hostsSelected: number) => {
+  switch (hostsSelected) {
+    case 0:
+      return 'No host is selected.';
+    case 1:
+      return 'Only 1 host is selected.';
+  }
+  return `Only ${hostsSelected} hosts are selected.`;
+};
+
+type AgentsSelectionHostCountAlertsProps = {
+  matchingAgentsCount: number;
+  selectedAgentsCount: number;
+  targetHostCount: number;
+};
+
+const AgentsSelectionHostCountAlerts = ({
+  matchingAgentsCount,
+  selectedAgentsCount,
+  targetHostCount,
+}: AgentsSelectionHostCountAlertsProps) => {
+  return (
+    <AlertGroup>
+      {selectedAgentsCount === targetHostCount && (
+        <Alert
+          variant={AlertVariant.success}
+          title={`${selectedAgentsCount} ${
+            selectedAgentsCount === 1 ? 'host' : 'hosts'
+          } selected out of ${matchingAgentsCount} matching.`}
+          isInline
+        />
+      )}
+      {selectedAgentsCount < targetHostCount && (
+        <Alert
+          variant={AlertVariant.warning}
+          title={getHostCountWarningText(selectedAgentsCount)}
+          isInline
+        />
+      )}
+    </AlertGroup>
+  );
+};
+
+export default AgentsSelectionHostCountAlerts;

--- a/src/cim/components/Agent/AgentsSelectionHostCountLabelIcon.tsx
+++ b/src/cim/components/Agent/AgentsSelectionHostCountLabelIcon.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import PopoverIcon from '../../../common/components/ui/PopoverIcon';
+
+const AgentsSelectionHostCountLabelIcon = () => (
+  <PopoverIcon
+    position="right"
+    bodyContent={<>Total count of hosts to be included in the cluster.</>}
+  />
+);
+
+export default AgentsSelectionHostCountLabelIcon;

--- a/src/cim/components/Agent/AgentsSelectionTable.tsx
+++ b/src/cim/components/Agent/AgentsSelectionTable.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { useField } from 'formik';
+import HostsTable from '../../../common/components/hosts/HostsTable';
+import {
+  cpuCoresColumn,
+  disksColumn,
+  hostnameColumn,
+  memoryColumn,
+} from '../../../common/components/hosts/tableUtils';
+import { AgentK8sResource } from '../../types/k8s/agent';
+import { ClusterDeploymentHostsSelectionValues } from '../ClusterDeployment/types';
+import { infraEnvColumn, useAgentsTable } from './tableUtils';
+import DefaultEmptyState from '../../../common/components/ui/uiState/EmptyState';
+
+type AgentsSelectionTableProps = {
+  matchingAgents: AgentK8sResource[];
+};
+
+const AgentsSelectionTable: React.FC<AgentsSelectionTableProps> = ({ matchingAgents }) => {
+  const [selectedHostIdsField, , { setValue: setSelectedHostIdsValue }] = useField<
+    ClusterDeploymentHostsSelectionValues['selectedHostIds']
+  >('selectedHostIds');
+
+  React.useEffect(() => {
+    const allIds = matchingAgents.map((a) => a.metadata?.uid);
+    const presentIds = selectedHostIdsField.value.filter((id) => allIds.includes(id));
+    if (presentIds.length !== selectedHostIdsField.value.length) {
+      setSelectedHostIdsValue(presentIds);
+    }
+  }, [matchingAgents, setSelectedHostIdsValue, selectedHostIdsField.value]);
+
+  const onSelect = (agent: AgentK8sResource, selected: boolean) => {
+    if (selected) {
+      setSelectedHostIdsValue([...selectedHostIdsField.value, agent.metadata?.uid || '']);
+    } else {
+      setSelectedHostIdsValue(
+        selectedHostIdsField.value.filter((uid: string) => uid !== agent.metadata?.uid),
+      );
+    }
+  };
+
+  const [hosts, actions, actionResolver] = useAgentsTable({ onSelect }, { agents: matchingAgents });
+  const content = React.useMemo(
+    () => [
+      hostnameColumn(),
+      infraEnvColumn(matchingAgents),
+      cpuCoresColumn,
+      memoryColumn,
+      disksColumn,
+    ],
+    [matchingAgents],
+  );
+
+  return (
+    <HostsTable
+      hosts={hosts}
+      content={content}
+      selectedIDs={selectedHostIdsField.value}
+      actionResolver={actionResolver}
+      className="agents-table"
+      {...actions}
+    >
+      <DefaultEmptyState
+        title="No hosts found"
+        content="No host matches provided labels/locations"
+      />
+    </HostsTable>
+  );
+};
+
+export default AgentsSelectionTable;

--- a/src/cim/components/Agent/AgentsSelectionUtils.ts
+++ b/src/cim/components/Agent/AgentsSelectionUtils.ts
@@ -1,0 +1,37 @@
+import React from 'react';
+import { useFormikContext } from 'formik';
+import * as _ from 'lodash';
+import { AgentK8sResource } from '../../types/k8s/agent';
+import {
+  ClusterDeploymentHostsSelectionValues,
+  ScaleUpFormValues,
+} from '../ClusterDeployment/types';
+import { AGENT_LOCATION_LABEL_KEY, AGENT_NOLOCATION_VALUE } from '../common/constants';
+
+type AllowedFormValues = ClusterDeploymentHostsSelectionValues | ScaleUpFormValues;
+
+export const useAgentsAutoSelection = <FormValues extends AllowedFormValues>(
+  availableAgents: AgentK8sResource[],
+) => {
+  const { setFieldValue, values } = useFormikContext<FormValues>();
+  const { hostCount, locations, autoSelectedHostIds } = values;
+
+  const [matchingAgents, selectedAgents] = React.useMemo(() => {
+    const mAgents = availableAgents.filter((agent) => {
+      const agentLocation =
+        agent.metadata?.labels?.[AGENT_LOCATION_LABEL_KEY] || AGENT_NOLOCATION_VALUE;
+      return locations.length ? locations.includes(agentLocation) : true;
+    });
+    const sAgents = mAgents.filter((a) => autoSelectedHostIds.includes(a.metadata?.uid || ''));
+    return [mAgents, sAgents];
+  }, [availableAgents, locations, autoSelectedHostIds]);
+
+  React.useEffect(() => {
+    const ids = matchingAgents.map((a) => a.metadata?.uid).splice(0, hostCount);
+    if (!_.isEqual(ids, autoSelectedHostIds)) {
+      setTimeout(() => setFieldValue('autoSelectedHostIds', ids, true));
+    }
+  }, [matchingAgents, setFieldValue, autoSelectedHostIds, hostCount]);
+
+  return { matchingAgents, selectedAgents, hostCount };
+};

--- a/src/cim/components/Agent/BMCForm.tsx
+++ b/src/cim/components/Agent/BMCForm.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import * as yaml from 'js-yaml';
 import {
   Alert,
+  AlertActionCloseButton,
   AlertVariant,
   Button,
   ButtonVariant,
@@ -252,7 +253,7 @@ const BMCForm: React.FC<BMCFormProps> = ({
                   title="Failed to add host"
                   variant={AlertVariant.danger}
                   isInline
-                  actionClose={() => setError(undefined)}
+                  actionClose={<AlertActionCloseButton onClose={() => setError(undefined)} />}
                 >
                   {error}
                 </Alert>

--- a/src/cim/components/ClusterDeployment/ClusterDeploymentHostSelectionStep.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentHostSelectionStep.tsx
@@ -18,7 +18,7 @@ import {
   ClusterDeploymentHostsSelectionValues,
 } from './types';
 import { hostCountValidationSchema } from './validationSchemas';
-import { getAgentSelectorFieldsFromAnnotations } from '../helpers';
+import { getAgentSelectorFieldsFromAnnotations, getIsSNOCluster } from '../helpers';
 
 const getInitialValues = ({
   agents,
@@ -29,7 +29,7 @@ const getInitialValues = ({
   clusterDeployment: ClusterDeploymentK8sResource;
   agentClusterInstall: AgentClusterInstallK8sResource;
 }): ClusterDeploymentHostsSelectionValues => {
-  const isSNOCluster = agentClusterInstall?.spec?.provisionRequirements?.controlPlaneAgents === 1;
+  const isSNOCluster = getIsSNOCluster(agentClusterInstall);
   const cdName = clusterDeployment?.metadata?.name;
   const cdNamespace = clusterDeployment?.metadata?.namespace;
 
@@ -69,7 +69,7 @@ const getInitialValues = ({
 };
 
 const getValidationSchema = (agentClusterInstall: AgentClusterInstallK8sResource) => {
-  const isSNOCluster = agentClusterInstall?.spec?.provisionRequirements?.controlPlaneAgents === 1;
+  const isSNOCluster = getIsSNOCluster(agentClusterInstall);
 
   return Yup.lazy<ClusterDeploymentHostsSelectionValues>((values) => {
     return Yup.object<ClusterDeploymentHostsSelectionValues>().shape({
@@ -132,7 +132,7 @@ const ClusterDeploymentHostSelectionStep: React.FC<ClusterDeploymentHostSelectio
     } catch (error) {
       addAlert({
         title: 'Failed to save host selection.',
-        message: error,
+        message: error as string,
       });
     }
   };

--- a/src/cim/components/ClusterDeployment/ClusterDeploymentHostsNetworkTable.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentHostsNetworkTable.tsx
@@ -7,7 +7,7 @@ import {
   AgentK8sResource,
   ClusterDeploymentK8sResource,
 } from '../../types';
-import { getAICluster } from '../helpers';
+import { getAICluster, getIsSNOCluster } from '../helpers';
 import { AdditionalNTPSourcesDialogToggle } from './AdditionalNTPSourcesDialogToggle';
 import { networkingStatusColumn, useAgentsTable } from '../Agent/tableUtils';
 import HostsTable from '../../../common/components/hosts/HostsTable';
@@ -45,8 +45,7 @@ const ClusterDeploymentHostsNetworkTable: React.FC<ClusterDeploymentHostsNetwork
     [cluster],
   );
 
-  const isSNOCluster = agentClusterInstall?.spec?.provisionRequirements?.controlPlaneAgents === 1;
-
+  const isSNOCluster = getIsSNOCluster(agentClusterInstall);
   const content = React.useMemo(
     () =>
       isSNOCluster

--- a/src/cim/components/ClusterDeployment/ClusterDeploymentHostsSelection.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentHostsSelection.tsx
@@ -1,24 +1,14 @@
 import React from 'react';
 import { useFormikContext } from 'formik';
-import { Grid, GridItem, TextContent, Text } from '@patternfly/react-core';
-import { Host, SwitchField } from '../../../common';
+import { Grid, GridItem, TextContent, Text, Form } from '@patternfly/react-core';
+import { SwitchField } from '../../../common';
 import {
   ClusterDeploymentHostsSelectionProps,
   ClusterDeploymentHostsSelectionValues,
 } from './types';
 import ClusterDeploymentHostsSelectionBasic from './ClusterDeploymentHostsSelectionBasic';
 import ClusterDeploymentHostsSelectionAdvanced from './ClusterDeploymentHostsSelectionAdvanced';
-import { getAgentStatus } from '../helpers';
-
-const LISTED_HOST_STATUSES: Host['status'][] = [
-  'known',
-  'known-unbound',
-  'insufficient',
-  'insufficient-unbound',
-  'pending-for-input',
-  'discovering',
-  'discovering-unbound',
-];
+import { getAgentsForSelection, getIsSNOCluster } from '../helpers';
 
 const ClusterDeploymentHostsSelection: React.FC<ClusterDeploymentHostsSelectionProps> = ({
   agentClusterInstall,
@@ -31,23 +21,21 @@ const ClusterDeploymentHostsSelection: React.FC<ClusterDeploymentHostsSelectionP
   React.useEffect(() => onValuesChanged?.(values), [values, onValuesChanged]);
 
   const { autoSelectHosts } = values;
-  const isSNOCluster = agentClusterInstall?.spec?.provisionRequirements?.controlPlaneAgents === 1;
+  const isSNOCluster = getIsSNOCluster(agentClusterInstall);
 
   const cdName = clusterDeployment?.metadata?.name;
   const cdNamespace = clusterDeployment?.metadata?.namespace;
 
-  const availableAgents = React.useMemo(() => {
-    return (agents || []).filter((agent) => {
-      const [status] = getAgentStatus(agent);
-      return (
-        LISTED_HOST_STATUSES.includes(status) &&
-        agent.spec?.approved &&
-        ((agent.spec.clusterDeploymentName?.name === cdName &&
-          agent.spec.clusterDeploymentName?.namespace === cdNamespace) ||
-          (!agent.spec.clusterDeploymentName?.name && !agent.spec.clusterDeploymentName?.namespace))
-      );
-    });
-  }, [agents, cdNamespace, cdName]);
+  const availableAgents = React.useMemo(
+    () =>
+      getAgentsForSelection(agents).filter(
+        (agent) =>
+          (agent.spec.clusterDeploymentName?.name === cdName &&
+            agent.spec.clusterDeploymentName?.namespace === cdNamespace) ||
+          (!agent.spec.clusterDeploymentName?.name && !agent.spec.clusterDeploymentName?.namespace),
+      ),
+    [agents, cdNamespace, cdName],
+  );
 
   return (
     <Grid hasGutter>
@@ -65,19 +53,23 @@ const ClusterDeploymentHostsSelection: React.FC<ClusterDeploymentHostsSelectionP
       </GridItem>
 
       <GridItem>
-        <SwitchField name="autoSelectHosts" label="Auto-select hosts" />
+        <Form>
+          <SwitchField name="autoSelectHosts" label="Auto-select hosts" />
+
+          {autoSelectHosts && (
+            <ClusterDeploymentHostsSelectionBasic
+              availableAgents={availableAgents}
+              isSNOCluster={isSNOCluster}
+            />
+          )}
+
+          {!autoSelectHosts && (
+            <ClusterDeploymentHostsSelectionAdvanced<ClusterDeploymentHostsSelectionValues>
+              availableAgents={availableAgents}
+            />
+          )}
+        </Form>
       </GridItem>
-
-      {autoSelectHosts && (
-        <ClusterDeploymentHostsSelectionBasic
-          availableAgents={availableAgents}
-          isSNOCluster={isSNOCluster}
-        />
-      )}
-
-      {!autoSelectHosts && (
-        <ClusterDeploymentHostsSelectionAdvanced availableAgents={availableAgents} />
-      )}
     </Grid>
   );
 };

--- a/src/cim/components/ClusterDeployment/ClusterDeploymentHostsSelectionAdvanced.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentHostsSelectionAdvanced.tsx
@@ -1,119 +1,55 @@
-import { GridItem } from '@patternfly/react-core';
 import * as _ from 'lodash';
-import { useField, useFormikContext } from 'formik';
+import { useFormikContext } from 'formik';
 import React from 'react';
-import HostsTable from '../../../common/components/hosts/HostsTable';
-import {
-  cpuCoresColumn,
-  disksColumn,
-  hostnameColumn,
-  memoryColumn,
-} from '../../../common/components/hosts/tableUtils';
 import { AgentK8sResource } from '../../types';
-import DefaultEmptyState from '../../../common/components/ui/uiState/EmptyState';
-import { infraEnvColumn, useAgentsTable } from '../Agent/tableUtils';
 import { AGENT_LOCATION_LABEL_KEY, AGENT_NOLOCATION_VALUE } from '../common';
 import LocationsSelector from './LocationsSelector';
-import { ClusterDeploymentHostsSelectionValues } from './types';
+import { ClusterDeploymentHostsSelectionValues, ScaleUpFormValues } from './types';
 import LabelsSelector from './LabelsSelector';
-
-type AgentsSelectionTableProps = {
-  matchingAgents: AgentK8sResource[];
-};
-
-const AgentsSelectionTable: React.FC<AgentsSelectionTableProps> = ({ matchingAgents }) => {
-  const [selectedHostIdsField, , { setValue: setSelectedHostIdsValue }] = useField<
-    ClusterDeploymentHostsSelectionValues['selectedHostIds']
-  >('selectedHostIds');
-
-  React.useEffect(() => {
-    const allIds = matchingAgents.map((a) => a.metadata?.uid);
-    const presentIds = selectedHostIdsField.value.filter((id) => allIds.includes(id));
-    if (presentIds.length !== selectedHostIdsField.value.length) {
-      setSelectedHostIdsValue(presentIds);
-    }
-  }, [matchingAgents, setSelectedHostIdsValue, selectedHostIdsField.value]);
-
-  const onSelect = (agent: AgentK8sResource, selected: boolean) => {
-    if (selected) {
-      setSelectedHostIdsValue([...selectedHostIdsField.value, agent.metadata?.uid || '']);
-    } else {
-      setSelectedHostIdsValue(
-        selectedHostIdsField.value.filter((uid: string) => uid !== agent.metadata?.uid),
-      );
-    }
-  };
-
-  const [hosts, actions, actionResolver] = useAgentsTable({ onSelect }, { agents: matchingAgents });
-  const content = React.useMemo(
-    () => [
-      hostnameColumn(),
-      infraEnvColumn(matchingAgents),
-      cpuCoresColumn,
-      memoryColumn,
-      disksColumn,
-    ],
-    [matchingAgents],
-  );
-
-  return (
-    <HostsTable
-      hosts={hosts}
-      content={content}
-      selectedIDs={selectedHostIdsField.value}
-      actionResolver={actionResolver}
-      className="agents-table"
-      {...actions}
-    >
-      <DefaultEmptyState
-        title="No hosts found"
-        content="No host matches provided labels/locations"
-      />
-    </HostsTable>
-  );
-};
+import AgentsSelectionTable from '../Agent/AgentsSelectionTable';
+import { Grid, GridItem } from '@patternfly/react-core';
 
 type ClusterDeploymentHostsSelectionAdvancedProps = {
   availableAgents: AgentK8sResource[];
 };
 
-const ClusterDeploymentHostsSelectionAdvanced: React.FC<ClusterDeploymentHostsSelectionAdvancedProps> = ({
-  availableAgents,
-}) => {
-  const { values } = useFormikContext<ClusterDeploymentHostsSelectionValues>();
+type FormValues = ClusterDeploymentHostsSelectionValues | ScaleUpFormValues;
 
-  const matchingAgents = React.useMemo(
-    () =>
-      availableAgents.filter((agent) => {
-        const labels = values.agentLabels.reduce((acc, curr) => {
-          const label = curr.split('=');
-          acc[label[0]] = label[1];
-          return acc;
-        }, {});
-        const matchesLocation = values.locations.length
-          ? values.locations.includes(
-              agent.metadata?.labels?.[AGENT_LOCATION_LABEL_KEY] || AGENT_NOLOCATION_VALUE,
-            )
-          : true;
-        const matchesLabels = agent.metadata?.labels
-          ? _.isMatch(agent.metadata?.labels, labels)
-          : true;
-        return matchesLocation && matchesLabels;
-      }),
-    [availableAgents, values.locations, values.agentLabels],
-  );
+const ClusterDeploymentHostsSelectionAdvanced = <T extends FormValues>({
+  availableAgents,
+}: ClusterDeploymentHostsSelectionAdvancedProps) => {
+  const { values } = useFormikContext<T>();
+
+  const matchingAgents = React.useMemo(() => {
+    return availableAgents.filter((agent) => {
+      const labels = values.agentLabels.reduce((acc, curr) => {
+        const label = curr.split('=');
+        acc[label[0]] = label[1];
+        return acc;
+      }, {});
+      const matchesLocation = values.locations.length
+        ? values.locations.includes(
+            agent.metadata?.labels?.[AGENT_LOCATION_LABEL_KEY] || AGENT_NOLOCATION_VALUE,
+          )
+        : true;
+      const matchesLabels = agent.metadata?.labels
+        ? _.isMatch(agent.metadata?.labels, labels)
+        : true;
+      return matchesLocation && matchesLabels;
+    });
+  }, [availableAgents, values.locations, values.agentLabels]);
 
   return (
     <>
-      <GridItem>
-        <LocationsSelector agents={availableAgents} />
-      </GridItem>
-      <GridItem>
-        <LabelsSelector agents={matchingAgents} />
-      </GridItem>
-      <GridItem>
-        <AgentsSelectionTable matchingAgents={matchingAgents} />
-      </GridItem>
+      <Grid hasGutter>
+        <GridItem>
+          <LocationsSelector agents={availableAgents} />
+        </GridItem>
+        <GridItem>
+          <LabelsSelector agents={matchingAgents} />
+        </GridItem>
+      </Grid>
+      <AgentsSelectionTable matchingAgents={matchingAgents} />
     </>
   );
 };

--- a/src/cim/components/ClusterDeployment/ClusterDeploymentHostsSelectionBasic.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentHostsSelectionBasic.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import * as _ from 'lodash';
-import { Alert, AlertGroup, AlertVariant, GridItem } from '@patternfly/react-core';
+import { Grid, GridItem } from '@patternfly/react-core';
 import { CheckboxField, NumberInputField } from '../../../common';
 import { HOSTS_MAX_COUNT, HOSTS_MIN_COUNT } from './constants';
 import { useFormikContext } from 'formik';
@@ -8,117 +7,72 @@ import { ClusterDeploymentHostsSelectionValues } from './types';
 import LocationsSelector from './LocationsSelector';
 import ShortCapacitySummary from './ShortCapacitySummary';
 import { AgentK8sResource } from '../../types';
-import { AGENT_LOCATION_LABEL_KEY, AGENT_NOLOCATION_VALUE } from '../common';
-
-const HostCountLabelIcon: React.FC = () => <>Total count of hosts to be included in the cluster.</>;
+import AgentsSelectionHostCountAlerts from '../Agent/AgentsSelectionHostCountAlerts';
+import AgentsSelectionHostCountLabelIcon from '../Agent/AgentsSelectionHostCountLabelIcon';
+import { useAgentsAutoSelection } from '../Agent/AgentsSelectionUtils';
 
 type ClusterDeploymentHostsSelectionBasicProps = {
   availableAgents: AgentK8sResource[];
-  isSNOCluster: boolean;
-};
-
-const getHostCountWarningText = (hostsSelected: number) => {
-  switch (hostsSelected) {
-    case 0:
-      return 'No host is selected.';
-    case 1:
-      return 'Only 1 host is selected.';
-  }
-  return `Only ${hostsSelected} hosts are selected.`;
+  isSNOCluster?: boolean;
 };
 
 const ClusterDeploymentHostsSelectionBasic: React.FC<ClusterDeploymentHostsSelectionBasicProps> = ({
   isSNOCluster,
   availableAgents,
 }) => {
-  const { setFieldValue, values } = useFormikContext<ClusterDeploymentHostsSelectionValues>();
-  const { hostCount, locations, autoSelectedHostIds } = values;
-
-  const [matchingAgents, selectedAgents] = React.useMemo(() => {
-    const mAgents = availableAgents.filter((agent) => {
-      const agentLocation =
-        agent.metadata?.labels?.[AGENT_LOCATION_LABEL_KEY] || AGENT_NOLOCATION_VALUE;
-      return locations.length ? locations.includes(agentLocation) : true;
-    });
-    const sAgents = mAgents.filter((a) => autoSelectedHostIds.includes(a.metadata?.uid || ''));
-    return [mAgents, sAgents];
-  }, [availableAgents, locations, autoSelectedHostIds]);
+  const { setFieldValue } = useFormikContext<ClusterDeploymentHostsSelectionValues>();
+  const { matchingAgents, selectedAgents, hostCount } = useAgentsAutoSelection(availableAgents);
 
   React.useEffect(() => {
-    const ids = matchingAgents.map((a) => a.metadata?.uid).splice(0, hostCount);
-    if (!_.isEqual(ids, autoSelectedHostIds)) {
-      setTimeout(() => setFieldValue('autoSelectedHostIds', ids, true));
+    if (hostCount === 3) {
+      setFieldValue('useMastersAsWorkers', true);
     }
-  }, [matchingAgents, setFieldValue, autoSelectedHostIds, hostCount]);
+  }, [hostCount, setFieldValue]);
 
   return (
     <>
-      <GridItem span={12} lg={10} xl={9} xl2={7}>
-        <NumberInputField
-          labelIcon={<HostCountLabelIcon />}
-          idPostfix="hostcount"
-          name="hostCount"
-          isRequired
-          minValue={isSNOCluster ? 1 : HOSTS_MIN_COUNT}
-          maxValue={isSNOCluster ? 1 : HOSTS_MAX_COUNT}
-          isDisabled={isSNOCluster}
-          onChange={(newValue) => {
-            if (newValue === 4) {
-              newValue = values.hostCount >= 4 ? 3 : 5;
-            }
-            setFieldValue('hostCount', newValue);
-            if (newValue === 3) {
-              setFieldValue('useMastersAsWorkers', true);
-            }
-          }}
-        />
-      </GridItem>
+      <Grid hasGutter>
+        <GridItem>
+          <NumberInputField
+            label="Number of hosts"
+            labelIcon={<AgentsSelectionHostCountLabelIcon />}
+            idPostfix="hostcount"
+            name="hostCount"
+            isRequired
+            minValue={isSNOCluster ? 1 : HOSTS_MIN_COUNT}
+            maxValue={isSNOCluster ? 1 : HOSTS_MAX_COUNT}
+            isDisabled={isSNOCluster}
+            formatValue={(newValue) => {
+              if (newValue === 4) {
+                return hostCount >= 4 ? 3 : 5;
+              }
+              return newValue;
+            }}
+          />
+        </GridItem>
 
-      {/* That field is not supported ATM - (requires MGMT-7677) */}
-      <GridItem>
-        <CheckboxField
-          idPostfix="mastersasworkers"
-          name="useMastersAsWorkers"
-          label="Run workloads on control plane (master) hosts"
-          isDisabled={hostCount < 5}
-        />
-      </GridItem>
+        <GridItem>
+          {/* That field is not supported ATM - (requires MGMT-7677) */}
+          <CheckboxField
+            idPostfix="mastersasworkers"
+            name="useMastersAsWorkers"
+            label="Run workloads on control plane (master) hosts"
+            isDisabled={hostCount < 5}
+          />
+        </GridItem>
 
-      <GridItem>
-        <LocationsSelector agents={availableAgents} />
-      </GridItem>
+        <GridItem>
+          <LocationsSelector agents={availableAgents} />
+        </GridItem>
+      </Grid>
 
-      {selectedAgents.length === hostCount && (
-        <>
-          <GridItem>
-            <AlertGroup>
-              <Alert
-                variant={AlertVariant.success}
-                title={`${selectedAgents.length} hosts selected out of ${matchingAgents.length} matching.`}
-                isInline
-              />
-            </AlertGroup>
-          </GridItem>
-        </>
-      )}
+      <AgentsSelectionHostCountAlerts
+        matchingAgentsCount={matchingAgents.length}
+        selectedAgentsCount={selectedAgents.length}
+        targetHostCount={hostCount}
+      />
 
-      {selectedAgents.length < hostCount && (
-        <>
-          <GridItem>
-            <AlertGroup>
-              <Alert
-                variant={AlertVariant.warning}
-                title={getHostCountWarningText(selectedAgents.length)}
-                isInline
-              />
-            </AlertGroup>
-          </GridItem>
-        </>
-      )}
-
-      <GridItem>
-        <ShortCapacitySummary selectedAgents={selectedAgents} />
-      </GridItem>
+      <ShortCapacitySummary selectedAgents={selectedAgents} />
     </>
   );
 };

--- a/src/cim/components/ClusterDeployment/ClusterScaleUpAutoHostsSelection.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterScaleUpAutoHostsSelection.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Grid, GridItem } from '@patternfly/react-core';
+import { NumberInputField } from '../../../common';
+import LocationsSelector from './LocationsSelector';
+import ShortCapacitySummary from './ShortCapacitySummary';
+import { AgentK8sResource } from '../../types';
+import AgentsSelectionHostCountAlerts from '../Agent/AgentsSelectionHostCountAlerts';
+import AgentsSelectionHostCountLabelIcon from '../Agent/AgentsSelectionHostCountLabelIcon';
+import { useAgentsAutoSelection } from '../Agent/AgentsSelectionUtils';
+
+type ClusterScaleUpAutoHostsSelectionProps = {
+  availableAgents: AgentK8sResource[];
+};
+
+const ClusterScaleUpAutoHostsSelection: React.FC<ClusterScaleUpAutoHostsSelectionProps> = ({
+  availableAgents,
+}) => {
+  const { matchingAgents, selectedAgents, hostCount } = useAgentsAutoSelection(availableAgents);
+
+  return (
+    <>
+      <Grid hasGutter>
+        <GridItem span={12} lg={10} xl={9} xl2={7}>
+          <NumberInputField
+            label="Number of hosts"
+            labelIcon={<AgentsSelectionHostCountLabelIcon />}
+            idPostfix="hostcount"
+            name="hostCount"
+            minValue={1}
+            maxValue={matchingAgents.length}
+            isRequired
+          />
+        </GridItem>
+        <GridItem span={12} lg={10} xl={9} xl2={7}>
+          <LocationsSelector agents={availableAgents} />
+        </GridItem>
+      </Grid>
+
+      <AgentsSelectionHostCountAlerts
+        matchingAgentsCount={matchingAgents.length}
+        selectedAgentsCount={selectedAgents.length}
+        targetHostCount={hostCount}
+      />
+
+      <ShortCapacitySummary selectedAgents={selectedAgents} />
+    </>
+  );
+};
+
+export default ClusterScaleUpAutoHostsSelection;

--- a/src/cim/components/ClusterDeployment/LabelsSelector.tsx
+++ b/src/cim/components/ClusterDeployment/LabelsSelector.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import * as _ from 'lodash';
-import { Text, TextContent } from '@patternfly/react-core';
 import { MultiSelectField } from '../../../common';
 import { AgentK8sResource } from '../../types';
 import { MultiSelectOption } from '../../../common/components/ui/formik/types';
 import { AGENT_LOCATION_LABEL_KEY } from '../common';
-
-import './label-selector.css';
 
 const LabelsSelector: React.FC<{ agents: AgentK8sResource[] }> = ({ agents }) => {
   const agentLabelOptions = Array.from(
@@ -31,13 +28,7 @@ const LabelsSelector: React.FC<{ agents: AgentK8sResource[] }> = ({ agents }) =>
     <MultiSelectField
       idPostfix="agentLabels"
       name="agentLabels"
-      label={
-        <TextContent>
-          <Text component="h3">
-            <div className="label-selector__title">Labels matching hosts</div>
-          </Text>
-        </TextContent>
-      }
+      label="Labels matching hosts"
       placeholderText="app=frontend"
       helperText="Provide as many labels as you can to narrow the list to relevant hosts only."
       options={agentLabelOptions}

--- a/src/cim/components/ClusterDeployment/LocationsSelector.tsx
+++ b/src/cim/components/ClusterDeployment/LocationsSelector.tsx
@@ -1,34 +1,23 @@
 import React from 'react';
 import * as _ from 'lodash';
-import { TextContent, Text } from '@patternfly/react-core';
 import { MultiSelectField, PopoverIcon } from '../../../common';
 import { AGENT_LOCATION_LABEL_KEY, AGENT_NOLOCATION_VALUE } from '../common';
 import { AgentK8sResource } from '../../types';
 import { MultiSelectOption } from '../../../common/components/ui/formik/types';
 
-import './locations-selector.css';
-
-const LocationsLabel: React.FC = () => (
-  <TextContent>
-    <Text component="h3">
-      <div className="locations-selector__title">
-        Host locations
-        <PopoverIcon
-          buttonClassName="locations-selector__title-icon"
-          bodyContent={
-            <>
-              Select one or multiple locations to choose the hosts from.
-              <br />
-              Keep the field empty to match <b>any</b> location.
-              <br />
-              Set <b>{AGENT_LOCATION_LABEL_KEY}</b> label in Agent resource to specify it's
-              location.
-            </>
-          }
-        />
-      </div>
-    </Text>
-  </TextContent>
+const LocationsLabelIcon: React.FC = () => (
+  <PopoverIcon
+    position="right"
+    bodyContent={
+      <>
+        Select one or multiple locations to choose the hosts from.
+        <br />
+        Keep the field empty to match <b>any</b> location.
+        <br />
+        Set <b>{AGENT_LOCATION_LABEL_KEY}</b> label in Agent resource to specify it's location.
+      </>
+    }
+  />
 );
 
 const getNumOfHosts = (size: number) => {
@@ -60,7 +49,8 @@ const LocationsSelector: React.FC<{ agents: AgentK8sResource[] }> = ({ agents })
     <MultiSelectField
       idPostfix="locations"
       name="locations"
-      label={<LocationsLabel />}
+      label="Host locations"
+      labelIcon={<LocationsLabelIcon />}
       placeholderText="Type or select location(s)"
       helperText="Select one or more locations to view hosts"
       options={agentLocationOptions}

--- a/src/cim/components/ClusterDeployment/ScaleUpForm.tsx
+++ b/src/cim/components/ClusterDeployment/ScaleUpForm.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { useFormikContext } from 'formik';
+import { Form } from '@patternfly/react-core';
+import { getAgentsForSelection } from '../helpers/agents';
+import { AgentK8sResource } from '../../types/k8s/agent';
+import ClusterDeploymentHostsSelectionAdvanced from './ClusterDeploymentHostsSelectionAdvanced';
+import { ScaleUpFormValues } from './types';
+import SwitchField from '../../../common/components/ui/formik/SwitchField';
+import ClusterScaleUpAutoHostsSelection from './ClusterScaleUpAutoHostsSelection';
+
+type ScaleUpFormProps = {
+  agents: AgentK8sResource[];
+};
+
+const ScaleUpForm = ({ agents }: ScaleUpFormProps) => {
+  const { values } = useFormikContext<ScaleUpFormValues>();
+  const { autoSelectHosts } = values;
+  const availableAgents = React.useMemo(
+    () =>
+      getAgentsForSelection(agents).filter(
+        (agent) =>
+          !(
+            agent.spec?.clusterDeploymentName?.name || agent.spec?.clusterDeploymentName?.namespace
+          ),
+      ),
+    [agents],
+  );
+
+  return (
+    <Form>
+      <SwitchField name="autoSelectHosts" label="Auto-select hosts" />
+
+      {autoSelectHosts && <ClusterScaleUpAutoHostsSelection availableAgents={availableAgents} />}
+
+      {!autoSelectHosts && (
+        <ClusterDeploymentHostsSelectionAdvanced<ScaleUpFormValues>
+          availableAgents={availableAgents}
+        />
+      )}
+    </Form>
+  );
+};
+
+export default ScaleUpForm;

--- a/src/cim/components/ClusterDeployment/label-selector.css
+++ b/src/cim/components/ClusterDeployment/label-selector.css
@@ -1,3 +1,0 @@
-.label-selector__title {
-    margin-bottom: var(--pf-global--spacer--md)
-}

--- a/src/cim/components/ClusterDeployment/locations-selector.css
+++ b/src/cim/components/ClusterDeployment/locations-selector.css
@@ -1,7 +1,0 @@
-.locations-selector__title {
-    margin-bottom: var(--pf-global--spacer--md)
-}
-
-.locations-selector__title-icon {
-    margin-left: var(--pf-global--spacer--sm)
-}

--- a/src/cim/components/ClusterDeployment/types.ts
+++ b/src/cim/components/ClusterDeployment/types.ts
@@ -43,6 +43,7 @@ export type ClusterDeploymentHostsSelectionValues = {
   selectedHostIds: string[];
   autoSelectedHostIds: string[];
 };
+export type ScaleUpFormValues = Omit<ClusterDeploymentHostsSelectionValues, 'useMastersAsWorkers'>;
 
 export type ClusterDeploymentDetailsStepProps = ClusterDeploymentDetailsProps & {
   onSaveDetails: (values: ClusterDeploymentDetailsValues) => Promise<string | void>;

--- a/src/cim/components/helpers/agentClusterInstall.ts
+++ b/src/cim/components/helpers/agentClusterInstall.ts
@@ -1,0 +1,4 @@
+import { AgentClusterInstallK8sResource } from '../../types/k8s/agent-cluster-install';
+
+export const getIsSNOCluster = (agentClusterInstall: AgentClusterInstallK8sResource) =>
+  agentClusterInstall?.spec?.provisionRequirements?.controlPlaneAgents === 1;

--- a/src/cim/components/helpers/agents.ts
+++ b/src/cim/components/helpers/agents.ts
@@ -1,5 +1,20 @@
 import { Host } from '../../../common';
 import { AgentK8sResource } from '../../types';
+import { getAgentStatus } from './status';
+
+const AGENT_FOR_SELECTION_STATUSES: Host['status'][] = [
+  'known',
+  'known-unbound',
+  'insufficient',
+  'insufficient-unbound',
+  'pending-for-input',
+];
 
 export const hostToAgent = (agents: AgentK8sResource[] = [], host: Host) =>
   agents.find((a) => a.metadata?.uid === host.id) as AgentK8sResource;
+
+export const getAgentsForSelection = (agents: AgentK8sResource[]) =>
+  agents.filter((agent) => {
+    const [status] = getAgentStatus(agent);
+    return AGENT_FOR_SELECTION_STATUSES.includes(status) && agent.spec?.approved;
+  });

--- a/src/cim/components/helpers/clusterDeployment.ts
+++ b/src/cim/components/helpers/clusterDeployment.ts
@@ -22,7 +22,7 @@ export type ClusterDeploymentParams = {
 export const getAgentSelectorFieldsFromAnnotations = (
   annotations: ObjectMetadata['annotations'] = {},
 ): AgentSelectorChangeProps => {
-  const locations = annotations[AGENT_LOCATION_LABEL_KEY]?.split(',');
+  const locations = annotations[AGENT_LOCATION_LABEL_KEY]?.split(',') || [];
 
   const labels = Object.keys(annotations)
     .map((key) => {

--- a/src/cim/components/helpers/index.ts
+++ b/src/cim/components/helpers/index.ts
@@ -6,3 +6,4 @@ export * from './versions';
 export * from './labels';
 export * from './agents';
 export * from './clusterDeployment';
+export * from './agentClusterInstall';

--- a/src/cim/components/modals/ScaleUpModal.tsx
+++ b/src/cim/components/modals/ScaleUpModal.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import * as Yup from 'yup';
+import {
+  Modal,
+  ModalBoxBody,
+  ModalBoxFooter,
+  Button,
+  ButtonVariant,
+  Alert,
+  AlertVariant,
+  AlertActionCloseButton,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import { Formik, FormikConfig, FormikProps } from 'formik';
+import { AgentK8sResource } from '../../types/k8s/agent';
+import { ClusterDeploymentK8sResource } from '../../types/k8s/cluster-deployment';
+import ScaleUpForm from '../ClusterDeployment/ScaleUpForm';
+import { getAgentSelectorFieldsFromAnnotations } from '../helpers/clusterDeployment';
+import { ScaleUpFormValues } from '../ClusterDeployment/types';
+
+const getAgentsToAdd = (
+  selectedHostIds: ScaleUpFormValues['selectedHostIds'] | ScaleUpFormValues['autoSelectedHostIds'],
+  agents: AgentK8sResource[],
+) =>
+  agents.filter(
+    (agent) =>
+      selectedHostIds.includes(agent.metadata?.uid || '') &&
+      !(agent.spec?.clusterDeploymentName?.name || agent.spec?.clusterDeploymentName?.namespace),
+  );
+
+const getValidationSchema = (agentsCount: number) => {
+  return Yup.lazy<ScaleUpFormValues>((values) => {
+    return Yup.object<ScaleUpFormValues>().shape({
+      hostCount: Yup.number().min(1).max(agentsCount),
+      autoSelectedHostIds: values.autoSelectHosts
+        ? Yup.array<string>().min(1).max(agentsCount)
+        : Yup.array<string>(),
+      selectedHostIds: values.autoSelectHosts
+        ? Yup.array<string>()
+        : Yup.array<string>().min(1).max(agentsCount),
+    });
+  });
+};
+
+type ScaleUpModalProps = {
+  isOpen: boolean;
+  onClose: VoidFunction;
+  addHostsToCluster: (agentsToAdd: AgentK8sResource[]) => Promise<void>;
+  clusterDeployment: ClusterDeploymentK8sResource;
+  agents: AgentK8sResource[];
+};
+
+const ScaleUpModal = ({
+  isOpen,
+  onClose,
+  addHostsToCluster,
+  clusterDeployment,
+  agents,
+}: ScaleUpModalProps) => {
+  const [error, setError] = React.useState<string | undefined>();
+
+  const getInitialValues = (): ScaleUpFormValues => {
+    const agentSelector = getAgentSelectorFieldsFromAnnotations(
+      clusterDeployment?.metadata?.annotations,
+    );
+
+    const autoSelectHosts = agentSelector.autoSelect;
+    return {
+      autoSelectHosts,
+      hostCount: 1,
+      agentLabels: agentSelector.labels,
+      locations: agentSelector.locations,
+      selectedHostIds: [],
+      autoSelectedHostIds: [],
+    };
+  };
+
+  const validationSchema = React.useMemo(() => getValidationSchema(agents.length), [agents.length]);
+
+  const handleSubmit: FormikConfig<ScaleUpFormValues>['onSubmit'] = async (values) => {
+    const { autoSelectHosts, autoSelectedHostIds, selectedHostIds } = values;
+    try {
+      setError(undefined);
+      const agentsToAdd = getAgentsToAdd(
+        autoSelectHosts ? autoSelectedHostIds : selectedHostIds,
+        agents,
+      );
+      await addHostsToCluster(agentsToAdd);
+      onClose();
+    } catch (e) {
+      setError(e.message);
+    }
+  };
+
+  return (
+    <Modal
+      aria-label="Add worker host dialog"
+      title="Add worker hosts"
+      isOpen={isOpen}
+      onClose={onClose}
+      hasNoBodyWrapper
+      id="scale-up-modal"
+    >
+      <Formik
+        initialValues={getInitialValues()}
+        validationSchema={validationSchema}
+        onSubmit={handleSubmit}
+        validateOnMount
+      >
+        {({ isSubmitting, isValid, submitForm }: FormikProps<ScaleUpFormValues>) => {
+          return (
+            <>
+              <ModalBoxBody>
+                <Stack hasGutter>
+                  <StackItem>
+                    <ScaleUpForm agents={agents} />
+                  </StackItem>
+                  {error && (
+                    <StackItem>
+                      <Alert
+                        title="Failed to add hosts to the cluster"
+                        variant={AlertVariant.danger}
+                        actionClose={<AlertActionCloseButton onClose={() => setError(undefined)} />}
+                        isInline
+                      >
+                        {error}
+                      </Alert>
+                    </StackItem>
+                  )}
+                </Stack>
+              </ModalBoxBody>
+              <ModalBoxFooter>
+                <Button onClick={submitForm} isDisabled={isSubmitting || !isValid}>
+                  Submit
+                </Button>
+                <Button onClick={onClose} variant={ButtonVariant.secondary}>
+                  Cancel
+                </Button>
+              </ModalBoxFooter>
+            </>
+          );
+        }}
+      </Formik>
+    </Modal>
+  );
+};
+
+export default ScaleUpModal;

--- a/src/cim/components/modals/index.ts
+++ b/src/cim/components/modals/index.ts
@@ -1,4 +1,5 @@
 export { default as EditAgentModal } from './EditAgentModal';
 export { default as AddHostModal } from './AddHostModal';
 export { default as EditBMHModal } from './EditBMHModal';
+export { default as ScaleUpModal } from './ScaleUpModal';
 export * from './utils';

--- a/src/common/components/ui/formik/NumberInputField.tsx
+++ b/src/common/components/ui/formik/NumberInputField.tsx
@@ -12,17 +12,17 @@ const NumberInputField: React.FC<NumberInputFieldProps> = React.forwardRef(
       labelIcon,
       helperText,
       isRequired,
-      onChange,
       validate,
       idPostfix,
       minValue = 0,
       maxValue,
       children,
+      formatValue,
       ...props
     },
     ref: React.Ref<HTMLInputElement>,
   ) => {
-    const [field, { touched, error }] = useField({ name: props.name, validate });
+    const [field, { touched, error }, { setValue }] = useField({ name: props.name, validate });
     const fieldId = getFieldId(props.name, 'numberinput', idPostfix);
     const isValid = !(touched && error);
     const errorMessage = !isValid ? error : '';
@@ -30,7 +30,7 @@ const NumberInputField: React.FC<NumberInputFieldProps> = React.forwardRef(
     const doChange = (value: number) => {
       let newValue = value < minValue ? minValue : value;
       newValue = maxValue && newValue > maxValue ? maxValue : newValue;
-      onChange(newValue);
+      setValue(formatValue ? formatValue(newValue) : newValue);
     };
 
     const onPlus: NumberInputProps['onPlus'] = () => {
@@ -65,8 +65,8 @@ const NumberInputField: React.FC<NumberInputFieldProps> = React.forwardRef(
         <Split>
           <SplitItem isFilled>
             <NumberInput
-              {...field}
               {...props}
+              value={field.value}
               onMinus={onMinus}
               onChange={handleChange}
               onPlus={onPlus}

--- a/src/common/components/ui/formik/types.ts
+++ b/src/common/components/ui/formik/types.ts
@@ -64,7 +64,8 @@ export interface NumberInputFieldProps extends FieldProps {
   minusBtnAriaLabel?: string;
   plusBtnAriaLabel?: string;
   unit?: string;
-  onChange: (newValue: number) => void;
+  formatValue?: (newValue: number) => number;
+  onChange?: (event: React.FormEvent<HTMLInputElement>) => void;
   onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
   validate?: FieldValidator;
 }


### PR DESCRIPTION
- Introduce Modal and Form for adding hosts to the cluster
- Replicate Basic/Advanced functionality from Host selection wizard step
- Refactor Host selection code to allow for reusability in scale up process
- Enhance NumberInputField

![Screenshot from 2021-09-17 12-23-35](https://user-images.githubusercontent.com/1121740/133778108-d67a41c0-9359-42a8-99e5-51696d747b48.png)
![Screenshot from 2021-09-17 13-51-07](https://user-images.githubusercontent.com/1121740/133778117-d0993b22-1375-49e8-80ff-a1341eb4bc46.png)


