### PR TITLE
BZ-1987340: Incorrect handling of Host SSH Public Key for troubleshoo…

### DIFF
--- a/src/common/components/clusterConfiguration/ClusterSshKeyFields.tsx
+++ b/src/common/components/clusterConfiguration/ClusterSshKeyFields.tsx
@@ -38,7 +38,7 @@ const ClusterSshKeyFields: React.FC<ClusterSshKeyFieldsProps> = ({
   };
 
   React.useEffect(() => {
-    if (imageSshKey && (clusterSshKey === imageSshKey || !clusterSshKey)) {
+    if (imageSshKey && clusterSshKey === imageSshKey) {
       setShareSshKey(true);
     }
   }, [imageSshKey, clusterSshKey]);


### PR DESCRIPTION
…ting after installation when entering an empty value

After setting the checkbox to False, when deleting the default ssh key to enter a new one, the textarea will disappear and the checkbox will turn to true. The root cause is an incorrect condition that doesn't handle empty values of the ssh key correctly.