### PR TITLE
Ignore insufficinet agent status in case of SNO cluster

### DIFF
--- a/src/cim/components/Agent/tableUtils.tsx
+++ b/src/cim/components/Agent/tableUtils.tsx
@@ -161,12 +161,15 @@ export const infraEnvColumn = (agents: AgentK8sResource[]): TableRow<Host> => {
 
 export const networkingStatusColumn = (
   onEditHostname?: HostsTableActions['onEditHost'],
+  isSNOCluster?: boolean,
 ): TableRow<Host> => ({
   header: { title: 'Status', transforms: [sortable] },
   cell: (host) => {
     const editHostname = onEditHostname ? () => onEditHostname(host) : undefined;
     return {
-      title: <NetworkingStatus host={host} onEditHostname={editHostname} />,
+      title: (
+        <NetworkingStatus host={host} onEditHostname={editHostname} isSNOCluster={!!isSNOCluster} />
+      ),
       props: { 'data-testid': 'nic-status' },
       sortableValue: status,
     };

--- a/src/cim/components/ClusterDeployment/ClusterDeploymentHostsNetworkTable.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentHostsNetworkTable.tsx
@@ -52,14 +52,14 @@ const ClusterDeploymentHostsNetworkTable: React.FC<ClusterDeploymentHostsNetwork
       isSNOCluster
         ? [
             hostnameColumn(onEditHost, hosts),
-            networkingStatusColumn(onEditHost),
+            networkingStatusColumn(onEditHost, isSNOCluster),
             activeNICColumn(cluster),
             countColumn(cluster),
           ]
         : [
             hostnameColumn(onEditHost, hosts),
             roleColumn(canEditRole, onEditRole),
-            networkingStatusColumn(onEditHost),
+            networkingStatusColumn(onEditHost, isSNOCluster),
             activeNICColumn(cluster),
             countColumn(cluster),
           ],

--- a/src/cim/components/status/NetworkingStatus.tsx
+++ b/src/cim/components/status/NetworkingStatus.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Host, HostStatus, stringToJSON } from '../../../common';
+import { HostStatusProps } from '../../../common/components/hosts/types';
 import { ValidationsInfo } from '../../../common/types/hosts';
 import {
   getFailingClusterWizardSoftValidationIds,
@@ -11,11 +12,13 @@ import { AdditionalNTPSourcesDialogToggle } from '../../../ocm/components/hosts/
 type HostNetworkingStatusComponentProps = {
   host: Host;
   onEditHostname?: () => void;
+  isSNOCluster: boolean;
 };
 
 const NetworkingStatus: React.FC<HostNetworkingStatusComponentProps> = ({
   host,
   onEditHostname,
+  isSNOCluster,
 }) => {
   const validationsInfo = stringToJSON<ValidationsInfo>(host.validationsInfo) || {};
   const networkingStatus = getWizardStepHostStatus(host, 'networking');
@@ -24,11 +27,19 @@ const NetworkingStatus: React.FC<HostNetworkingStatusComponentProps> = ({
     ? 'Some validations failed'
     : undefined;
 
+  let statusOverride: HostStatusProps['statusOverride'] = networkingStatus;
+  if (
+    networkingStatus === 'pending-for-input' ||
+    (isSNOCluster && networkingStatus === 'insufficient')
+  ) {
+    statusOverride = 'Bound';
+  }
+
   return (
     <HostStatus
       host={host}
       onEditHostname={onEditHostname}
-      statusOverride={networkingStatus === 'pending-for-input' ? 'Bound' : networkingStatus}
+      statusOverride={statusOverride}
       validationsInfo={netValidationsInfo}
       sublabel={sublabel}
       AdditionalNTPSourcesDialogToggleComponent={AdditionalNTPSourcesDialogToggle}

--- a/src/common/components/hosts/HostStatus.tsx
+++ b/src/common/components/hosts/HostStatus.tsx
@@ -104,9 +104,21 @@ const withProgress = (
 
 type HostStatusPopoverContentProps = ValidationInfoActionProps & {
   validationsInfo: ValidationsInfo;
+  statusOverride: HostStatusProps['statusOverride'];
 };
 
-const HostStatusPopoverContent: React.FC<HostStatusPopoverContentProps> = (props) => {
+const HostStatusPopoverContent: React.FC<HostStatusPopoverContentProps> = ({
+  statusOverride,
+  ...props
+}) => {
+  if (statusOverride === 'Bound') {
+    return (
+      <TextContent>
+        <Text>This host is bound to the cluster.</Text>
+      </TextContent>
+    );
+  }
+
   const { host } = props;
   const { status, statusInfo } = host;
   const statusDetails = HOST_STATUS_DETAILS[status];
@@ -204,6 +216,7 @@ const WithHostStatusPopover = (
       title: string;
       validationsInfo: ValidationsInfo;
       isSmall?: ButtonProps['isSmall'];
+      statusOverride: HostStatusProps['statusOverride'];
     }>,
 ) => (
   <Popover
@@ -262,6 +275,7 @@ const HostStatus: React.FC<HostStatusProps> = ({
             AdditionalNTPSourcesDialogToggleComponent={AdditionalNTPSourcesDialogToggleComponent}
             title={title}
             validationsInfo={validationsInfo}
+            statusOverride={status}
           >
             {titleWithProgress}
           </WithHostStatusPopover>
@@ -281,6 +295,7 @@ const HostStatus: React.FC<HostStatusProps> = ({
               AdditionalNTPSourcesDialogToggleComponent={AdditionalNTPSourcesDialogToggleComponent}
               title={title}
               validationsInfo={validationsInfo}
+              statusOverride={status}
             >
               {sublabel}
             </WithHostStatusPopover>


### PR DESCRIPTION
Backend is currently reporting agent in SNO cluster as `insufficinet`.  This PR is a workaround until the backend behavior aligns with non-SNO cluster.
`insufficient` state is shown as `Bound`