### PR TITLE
Improve OCP versions listing in the ACM

### DIFF
--- a/src/cim/components/helpers/versions.ts
+++ b/src/cim/components/helpers/versions.ts
@@ -1,12 +1,52 @@
-import { OpenshiftVersionOptionType } from '../../../common';
+import { OpenshiftVersionOptionType, OpenshiftVersion } from '../../../common';
 import { ClusterImageSetK8sResource } from '../../types/k8s/cluster-image-set';
+
+export const getSimplifiedImageName = (releaseImage = '') => {
+  const match = /.+:(.*)-/gm.exec(releaseImage);
+  if (match && match[1]) {
+    return `OpenShift ${match[1]}`;
+  }
+};
+
+const getSupportLevelFromChannel = (channel?: string): OpenshiftVersion['supportLevel'] => {
+  if (!channel) {
+    return 'custom';
+  }
+
+  if (channel.startsWith('fast')) {
+    return 'beta'; // TODO(mlibra): Is this correct?
+  }
+
+  if (channel.startsWith('stable')) {
+    return 'production';
+  }
+
+  return 'beta';
+};
 
 export const getOCPVersions = (
   clusterImageSets: ClusterImageSetK8sResource[],
-): OpenshiftVersionOptionType[] =>
-  clusterImageSets.map((clusterImageSet, index) => ({
-    label: clusterImageSet.metadata?.name as string,
-    value: clusterImageSet.metadata?.name as string, // TODO(mlibra): probably wrong but what is expected here?
-    default: index === 0,
-    supportLevel: 'beta', // TODO(mlibra): Map from label "channel"
-  }));
+): OpenshiftVersionOptionType[] => {
+  const versions = clusterImageSets
+    .filter((clusterImageSet) => clusterImageSet.metadata?.labels?.visible !== 'false')
+    .map(
+      (clusterImageSet): OpenshiftVersionOptionType => ({
+        label:
+          getSimplifiedImageName(clusterImageSet.spec?.releaseImage) ||
+          (clusterImageSet.metadata?.name as string),
+        value: clusterImageSet.metadata?.name as string,
+        default: false,
+        supportLevel: getSupportLevelFromChannel(clusterImageSet.metadata?.labels?.channel),
+      }),
+    )
+    .sort(
+      (versionA, versionB) => /* descending */ -1 * versionA.label.localeCompare(versionB.label),
+    );
+
+  if (versions.length) {
+    // make sure that the pre-selected one is the first-one after sorting
+    versions[0].default = true;
+  }
+
+  return versions;
+};


### PR DESCRIPTION
Changes:
- sorted (descending)
- version label aligned with ACM wording
- non-available versions are filtered out
- fixed channel to support level mapping

Idea for future enhancement:
Add descriptions (sublabels) with full image name. To do so, the `FormSelect` and it's `FormOption` will need to be replaced by the PF's `Dropdown` component. Such change has wider impact on other existing flows.