### PR TITLE
Revert "BZ-1987340: Incorrect handling of Host SSH Public Key for tro…

### DIFF
--- a/src/common/components/clusterConfiguration/ClusterSshKeyFields.tsx
+++ b/src/common/components/clusterConfiguration/ClusterSshKeyFields.tsx
@@ -38,7 +38,7 @@ const ClusterSshKeyFields: React.FC<ClusterSshKeyFieldsProps> = ({
   };
 
   React.useEffect(() => {
-    if (imageSshKey && clusterSshKey === imageSshKey) {
+    if (imageSshKey && (clusterSshKey === imageSshKey || !clusterSshKey)) {
       setShareSshKey(true);
     }
   }, [imageSshKey, clusterSshKey]);


### PR DESCRIPTION
…ubleshooting after installation when entering an empty value"

This reverts commit e9f8e4bf93a92ae2c8ff9e73547a0f2c310d2600.

The revert is needed because this commit breaks the default behavior of checking the "Use the same host discovery SSH key" when there's an image ssh key
