### PR TITLE
MGMT-7489: fixed behavior of a long hostname in hosts table to become multiline like in cluster table

### DIFF
--- a/src/common/components/hosts/tableUtils.tsx
+++ b/src/common/components/hosts/tableUtils.tsx
@@ -1,4 +1,4 @@
-import { expandable, sortable } from '@patternfly/react-table';
+import { breakWord, expandable, sortable } from '@patternfly/react-table';
 import * as React from 'react';
 import { Address4, Address6 } from 'ip-address';
 import HardwareStatus from '../../../ocm/components/hosts/HardwareStatus';
@@ -47,7 +47,12 @@ export const hostnameColumn = (
   hosts?: Host[],
 ): TableRow<Host> => {
   return {
-    header: { title: 'Hostname', transforms: [sortable], cellFormatters: [expandable] },
+    header: {
+      title: 'Hostname',
+      transforms: [sortable],
+      cellFormatters: [expandable],
+      cellTransforms: [breakWord],
+    },
     cell: (host) => {
       const { inventory: inventoryString = '' } = host;
       const inventory = stringToJSON<Inventory>(inventoryString) || {};


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-7489

before:
![image](https://user-images.githubusercontent.com/22211154/135742609-29ce3f61-ae8b-4f49-8cc5-531030803927.png)

after: 

![image](https://user-images.githubusercontent.com/22211154/135742678-7d465d88-75d8-461e-9a89-144f0850c444.png)

