### PR TITLE
OCPBUGSM-33526: fix ready status label in clusters table

### DIFF
--- a/src/common/config/constants.ts
+++ b/src/common/config/constants.ts
@@ -51,7 +51,7 @@ export const HOST_ROLES: HostRole[] = [
 export const CLUSTER_STATUS_LABELS: { [key in Cluster['status']]: string } = {
   'pending-for-input': 'Draft',
   insufficient: 'Draft',
-  ready: 'Draft',
+  ready: 'Ready',
   'preparing-for-installation': 'Preparing for installation',
   installing: 'Installing',
   'installing-pending-user-action': 'Installing (pending action)',


### PR DESCRIPTION
issue link: https://issues.redhat.com/browse/OCPBUGSM-33526