### PR TITLE
BZ-1980801: fixed disappearing error messages for invalid fields in network form

### DIFF
--- a/src/ocm/components/clusterConfiguration/NetworkConfigurationForm.tsx
+++ b/src/ocm/components/clusterConfiguration/NetworkConfigurationForm.tsx
@@ -47,6 +47,10 @@ const NetworkConfigurationForm: React.FC<{
     [], // just once, Formik does not reinitialize
   );
 
+  const initialTouched = React.useMemo(() => _.mapValues(initialValues, () => true), [
+    initialValues,
+  ]);
+
   const memoizedValidationSchema = React.useMemo(
     () => getNetworkConfigurationValidationSchema(initialValues, hostSubnets),
     [hostSubnets, initialValues],
@@ -120,7 +124,7 @@ const NetworkConfigurationForm: React.FC<{
       initialValues={initialValues}
       validationSchema={memoizedValidationSchema}
       onSubmit={handleSubmit}
-      initialTouched={_.mapValues(initialValues, () => true)}
+      initialTouched={initialTouched}
       validateOnMount
     >
       {({ isSubmitting, dirty, errors, touched }: FormikProps<NetworkConfigurationValues>) => {


### PR DESCRIPTION
URL https://bugzilla.redhat.com/show_bug.cgi?id=1980801

Root caused by formik invoking validation on the initialValues prop when the intialTouched prop changes. The fix is to memoise the initialTouched prop
