### PR TITLE
fix: Updates toAssisted.ts

### DIFF
--- a/src/cim/components/helpers/toAssisted.ts
+++ b/src/cim/components/helpers/toAssisted.ts
@@ -21,12 +21,8 @@ export const getAIHosts = (
       // TODO(mlibra) Remove that workaround once https://issues.redhat.com/browse/MGMT-7052 is fixed
       const inventory: Inventory = _.cloneDeep(agent.status?.inventory || {});
       inventory.interfaces?.forEach((intf) => {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-        // @ts-ignore
-        intf.ipv4Addresses = _.cloneDeep(intf.ipV4Addresses);
-        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-        // @ts-ignore
-        intf.ipv6Addresses = _.cloneDeep(intf.ipV6Addresses);
+        intf.ipv4Addresses = _.cloneDeep(intf.ipv4Addresses);
+        intf.ipv6Addresses = _.cloneDeep(intf.ipv6Addresses);
       });
 
       if (agent.metadata?.labels?.[AGENT_BMH_HOSTNAME_LABEL_KEY]) {


### PR DESCRIPTION
Interface type has no member called `ipV4Addresses` or `ipV6Addresses`, but `ipv4Addresses` and `ipv6Addresses` instead