### PR TITLE
BZ-2013158: new cluster form contains validation errors on first render

### DIFF
--- a/src/common/components/clusterWizard/ClusterDetailsFormFields.tsx
+++ b/src/common/components/clusterWizard/ClusterDetailsFormFields.tsx
@@ -20,9 +20,7 @@ export type ClusterDetailsFormFieldsProps = {
   isBaseDnsDomainDisabled?: boolean;
   defaultPullSecret?: string;
   isOcm: boolean;
-
   extensionAfter?: { [key: string]: React.ReactElement };
-
   managedDomains?: ManagedDomain[];
   versions: OpenshiftVersionOptionType[];
   toggleRedHatDnsService?: (checked: boolean) => void;

--- a/src/ocm/components/clusterWizard/ClusterDetailsForm.tsx
+++ b/src/ocm/components/clusterWizard/ClusterDetailsForm.tsx
@@ -82,20 +82,7 @@ const ClusterDetailsForm: React.FC<ClusterDetailsFormProps> = (props) => {
       validationSchema={validationSchema}
       onSubmit={handleSubmit}
     >
-      {({
-        submitForm,
-        isSubmitting,
-        isValid,
-        dirty,
-        setFieldValue,
-        setFieldTouched,
-        errors,
-        touched,
-      }) => {
-        if (!touched.name) {
-          setFieldTouched('name');
-        }
-
+      {({ submitForm, isSubmitting, isValid, dirty, setFieldValue, errors, touched }) => {
         const errorFields = getFormikErrorFields(errors, touched);
         const toggleRedHatDnsService = (checked: boolean) =>
           setFieldValue('baseDnsDomain', checked ? managedDomains.map((d) => d.domain)[0] : '');


### PR DESCRIPTION
[BZ-2013158](https://bugzilla.redhat.com/show_bug.cgi?id=2013158)
![Peek 2021-10-21 17-35](https://user-images.githubusercontent.com/77008341/138300583-3db7e225-7c55-40ea-9626-fcb21869b723.gif)
