### PR TITLE
BZ-1995038: Typo: resolve.conf

### DIFF
--- a/src/common/components/clusterDetail/ConsoleModal.tsx
+++ b/src/common/components/clusterDetail/ConsoleModal.tsx
@@ -122,7 +122,7 @@ export const WebConsoleHint: React.FC<WebConsoleHintProps> = ({ cluster, console
         optionalList={aRecordsOptional}
       />
       <ModalExpandableSection
-        toggleText="Option 2: Update your local /etc/hosts or /etc/resolve.conf files"
+        toggleText="Option 2: Update your local /etc/hosts or /etc/resolv.conf files"
         className="pf-u-pb-md"
         isExpanded={!isDNSExpanded}
         onToggle={handleToggle}


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1995038

resolved typo in "Launch Openshift console" dialog: resolve.conf - > resolv.conf 