### PR TITLE
BZ-1927737: Fixes a confusing instruction when adding host to an OS cluster

### DIFF
--- a/src/common/components/hosts/HostStatus.tsx
+++ b/src/common/components/hosts/HostStatus.tsx
@@ -137,8 +137,8 @@ const HostStatusPopoverContent: React.FC<HostStatusPopoverContentProps> = ({
         <Text>
           This host was successfully installed.
           <br />
-          To finish adding it to the cluster, approve its request to join. Note that it may take a
-          few minutes for the join request to appear in the Nodes section.
+          To finish adding it to the cluster, approve its join request inside OpenShift Console's Nodes section.
+          Note that it may take a  few minutes for the join request to appear.
         </Text>
       </TextContent>
     );

--- a/src/common/components/hosts/HostStatus.tsx
+++ b/src/common/components/hosts/HostStatus.tsx
@@ -137,8 +137,8 @@ const HostStatusPopoverContent: React.FC<HostStatusPopoverContentProps> = ({
         <Text>
           This host was successfully installed.
           <br />
-          To finish adding it to the cluster, approve its request to join in the Nodes section of
-          the OpenShift console. It might take a few minutes till the node request gets available.
+          To finish adding it to the cluster, approve its request to join. Note that it may take a
+          few minutes for the join request to appear in the Nodes section.
         </Text>
       </TextContent>
     );

--- a/src/common/components/hosts/HostStatus.tsx
+++ b/src/common/components/hosts/HostStatus.tsx
@@ -137,8 +137,8 @@ const HostStatusPopoverContent: React.FC<HostStatusPopoverContentProps> = ({
         <Text>
           This host was successfully installed.
           <br />
-          To finish adding it to the cluster, approve its join request inside OpenShift Console's Nodes section.
-          Note that it may take a few minutes for the join request to appear.
+          To finish adding it to the cluster, approve its join request inside OpenShift Console's
+          Nodes section. Note that it may take a few minutes for the join request to appear.
         </Text>
       </TextContent>
     );

--- a/src/common/components/hosts/HostStatus.tsx
+++ b/src/common/components/hosts/HostStatus.tsx
@@ -138,7 +138,7 @@ const HostStatusPopoverContent: React.FC<HostStatusPopoverContentProps> = ({
           This host was successfully installed.
           <br />
           To finish adding it to the cluster, approve its join request inside OpenShift Console's Nodes section.
-          Note that it may take a  few minutes for the join request to appear.
+          Note that it may take a few minutes for the join request to appear.
         </Text>
       </TextContent>
     );


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1927737

When a new day2 host completes the installation, the instruction should explicitly state that the join request can take some time to appear in the Nodes section.

**Previous instruction:**
> To finish adding it to the cluster, approve its request to join in the Nodes section of the OpenShift console. It might take a few minutes till the node request gets available.

**New instruction (as suggested by UX):**
> To finish adding it to the cluster, approve its request to join. Note that it may take a few minutes for the join request to appear in the Nodes section.

