### PR TITLE
useStateSafely

### DIFF
--- a/src/common/components/hosts/DiskRole.tsx
+++ b/src/common/components/hosts/DiskRole.tsx
@@ -3,6 +3,7 @@ import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core';
 import { CaretDownIcon } from '@patternfly/react-icons';
 import { Disk, DiskRole as DiskRoleValue, Host } from '../../api';
 import { DISK_ROLE_LABELS } from '../../config';
+import { useStateSafely } from '../../hooks';
 
 const getCurrentDiskRoleLabel = (disk: Disk, installationDiskId: Host['installationDiskId']) =>
   disk.id === installationDiskId ? DISK_ROLE_LABELS.install : DISK_ROLE_LABELS.none;
@@ -54,8 +55,8 @@ const DiskRoleDropdown: React.FC<DiskRoleDropdownProps> = ({
   installationDiskId,
   onDiskRole,
 }) => {
-  const [isOpen, setOpen] = React.useState(false);
-  const [isDisabled, setDisabled] = React.useState(false);
+  const [isOpen, setOpen] = useStateSafely(false);
+  const [isDisabled, setDisabled] = useStateSafely(false);
 
   const dropdownItems = [
     <DropdownItem
@@ -83,7 +84,7 @@ const DiskRoleDropdown: React.FC<DiskRoleDropdownProps> = ({
       };
       asyncFunc();
     },
-    [setOpen, disk.id, host.id, onDiskRole],
+    [setOpen, setDisabled, onDiskRole, host.id, disk.id],
   );
 
   const currentRoleLabel = getCurrentDiskRoleLabel(disk, installationDiskId);

--- a/src/common/hooks/index.ts
+++ b/src/common/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useStateSafely } from './useStateSafely';

--- a/src/common/hooks/useStateSafely.ts
+++ b/src/common/hooks/useStateSafely.ts
@@ -1,0 +1,21 @@
+import type { Dispatch, SetStateAction } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export default function useStateSafely<S>(initialState: S): [S, Dispatch<SetStateAction<S>>] {
+  const mountedRef = useRef(false);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const [state, setState] = useState(initialState);
+  const setStateSafely: Dispatch<SetStateAction<S>> = useCallback((arg) => {
+    if (mountedRef.current) {
+      setState(arg);
+    }
+  }, []);
+
+  return [state, setStateSafely];
+}

--- a/src/common/hooks/useStateSafely.ts
+++ b/src/common/hooks/useStateSafely.ts
@@ -1,7 +1,6 @@
-import type { Dispatch, SetStateAction } from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { Dispatch, SetStateAction, useCallback, useEffect, useRef, useState } from 'react';
 
-export default function useStateSafely<S>(initialState: S): [S, Dispatch<SetStateAction<S>>] {
+export const useStateSafely = <S>(initialState: S): [S, Dispatch<SetStateAction<S>>] => {
   const mountedRef = useRef(false);
   useEffect(() => {
     mountedRef.current = true;
@@ -18,4 +17,6 @@ export default function useStateSafely<S>(initialState: S): [S, Dispatch<SetStat
   }, []);
 
   return [state, setStateSafely];
-}
+};
+
+export default useStateSafely;

--- a/src/ocm/components/clusterConfiguration/ReviewStep.tsx
+++ b/src/ocm/components/clusterConfiguration/ReviewStep.tsx
@@ -15,11 +15,12 @@ import ClusterWizardFooter from '../clusterWizard/ClusterWizardFooter';
 import ClusterWizardNavigation from '../clusterWizard/ClusterWizardNavigation';
 import ReviewCluster from './ReviewCluster';
 import ClusterWizardHeaderExtraActions from './ClusterWizardHeaderExtraActions';
+import { useStateSafely } from '../../../common/hooks';
 
 const ReviewStep: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
   const { addAlert } = useAlerts();
   const { setCurrentStepId } = React.useContext(ClusterWizardContext);
-  const [isStartingInstallation, setIsStartingInstallation] = React.useState(false);
+  const [isStartingInstallation, setIsStartingInstallation] = useStateSafely(false);
   const dispatch = useDispatch();
 
   const handleClusterInstall = async () => {


### PR DESCRIPTION
This new hook is a drop-in replacement for `React.useState`.

Should be used when:

- The internal state of a component is altered by delegating the operation to a nested component.
- The internal state changes inside an async operation.

In general, this hook prevents changing the state of an unmounted component.