### PR TITLE
MGMT-4551: Add 'Run workloads on control plane node' switch

### DIFF
--- a/src/common/components/clusterConfiguration/NetworkConfigurationTable.tsx
+++ b/src/common/components/clusterConfiguration/NetworkConfigurationTable.tsx
@@ -12,7 +12,7 @@ import {
 } from '../../../common/components/hosts/tableUtils';
 import { ActionsResolver } from '../../../common/components/hosts/AITable';
 import { HostDetail } from '../../../common/components/hosts/HostRowDetail';
-import { HostsTableActions } from '../hosts';
+import { getSchedulableMasters, HostsTableActions } from '../hosts';
 import { Cluster } from '../../api';
 import HostsTable from '../hosts/HostsTable';
 
@@ -44,7 +44,7 @@ const NetworkConfigurationTable: React.FC<NetworkConfigurationTableProps> = ({
   const content = React.useMemo(
     () => [
       hostnameColumn(onEditHost),
-      roleColumn(canEditRole, onEditRole),
+      roleColumn(canEditRole, onEditRole, getSchedulableMasters(cluster)),
       networkingStatusColumn(onEditHost),
       activeNICColumn(cluster),
       ipv4Column(cluster),

--- a/src/common/components/clusterConfiguration/utils.ts
+++ b/src/common/components/clusterConfiguration/utils.ts
@@ -3,7 +3,7 @@ import { Cluster, ClusterDefaultConfig, Inventory, stringToJSON } from '../../ap
 import { NO_SUBNET_SET } from '../../config';
 import { HostDiscoveryValues, HostSubnets } from '../../types/clusters';
 import { OpenshiftVersionOptionType } from '../../types/versions';
-import { getHostname } from '../hosts/utils';
+import { getHostname, getSchedulableMasters } from '../hosts/utils';
 
 export const getSubnet = (cidr: string): Address6 | Address4 | null => {
   if (Address4.isValid(cidr)) {
@@ -70,6 +70,7 @@ export const getHostDiscoveryInitialValues = (cluster: Cluster): HostDiscoveryVa
     useExtraDisksForLocalStorage: isOperatorEnabled('ocs'),
     useContainerNativeVirtualization: isOperatorEnabled('cnv'),
     usePlatformIntegration: cluster.platform?.type !== 'baremetal',
+    schedulableMasters: getSchedulableMasters(cluster),
   };
 };
 

--- a/src/common/components/hosts/RoleCell.tsx
+++ b/src/common/components/hosts/RoleCell.tsx
@@ -11,6 +11,10 @@ export type RoleCellProps = {
 };
 
 const RoleCell: React.FC<RoleCellProps> = ({ host, role, readonly = false, onEditRole }) =>
-  !readonly && onEditRole ? <RoleDropdown host={host} onEditRole={onEditRole} /> : <>{role}</>;
+  !readonly && onEditRole ? (
+    <RoleDropdown host={host} onEditRole={onEditRole} current={role} />
+  ) : (
+    <>{role}</>
+  );
 
 export default RoleCell;

--- a/src/common/components/hosts/RoleDropdown.tsx
+++ b/src/common/components/hosts/RoleDropdown.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
+import { HOST_ROLES } from '../../config/constants';
 import { Host } from '../../api';
-import { HOST_ROLES } from '../../config';
 import { SimpleDropdown } from '../ui';
-import { getHostRole } from './utils';
+import { useStateSafely } from '../../hooks';
 
 type RoleDropdownProps = {
   host: Host;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onEditRole: (role?: string) => Promise<any>;
+  current: string;
 };
 
-const RoleDropdown: React.FC<RoleDropdownProps> = ({ host, onEditRole }) => {
-  const [isDisabled, setDisabled] = React.useState(false);
-
+const RoleDropdown: React.FC<RoleDropdownProps> = ({ host, onEditRole, current }) => {
+  const [isDisabled, setDisabled] = useStateSafely(false);
   const setRole = async (role?: string) => {
     setDisabled(true);
     try {
@@ -25,7 +25,7 @@ const RoleDropdown: React.FC<RoleDropdownProps> = ({ host, onEditRole }) => {
   return (
     <SimpleDropdown
       defaultValue={HOST_ROLES[0].value}
-      current={getHostRole(host)}
+      current={current}
       items={HOST_ROLES}
       setValue={setRole}
       isDisabled={isDisabled}

--- a/src/common/components/hosts/tableUtils.tsx
+++ b/src/common/components/hosts/tableUtils.tsx
@@ -75,6 +75,7 @@ export const hostnameColumn = (
 export const roleColumn = (
   canEditRole?: HostsTableActions['canEditRole'],
   onEditRole?: HostsTableActions['onEditRole'],
+  schedulableMasters?: boolean,
 ): TableRow<Host> => {
   return {
     header: {
@@ -86,7 +87,7 @@ export const roleColumn = (
     },
     cell: (host) => {
       const editRole = onEditRole ? (role?: string) => onEditRole(host, role) : undefined;
-      const hostRole = getHostRole(host);
+      const hostRole = getHostRole(host, schedulableMasters);
       return {
         title: (
           <RoleCell

--- a/src/common/components/hosts/utils.ts
+++ b/src/common/components/hosts/utils.ts
@@ -120,10 +120,16 @@ export const canHostnameBeChanged = (hostStatus: Host['status']) =>
     'pending-for-input',
   ].includes(hostStatus);
 
-export const getHostRole = (host: Host): string =>
-  `${HOST_ROLES.find((role) => role.value === host.role)?.label || HOST_ROLES[0].label}${
-    host.bootstrap ? ' (bootstrap)' : ''
+export const getHostRole = (host: Host, schedulableMasters?: boolean): string => {
+  let roleLabel: string;
+  roleLabel = `${
+    HOST_ROLES.find((role) => role.value === host.role)?.label || HOST_ROLES[0].label
   }`;
+  if (schedulableMasters && host.role === 'master') {
+    roleLabel = 'Control Plane, Worker';
+  }
+  return roleLabel;
+};
 
 export const canDownloadHostLogs = (host: Host) =>
   !!host.logsCollectedAt && host.logsCollectedAt != TIME_ZERO;
@@ -161,3 +167,14 @@ export const fileSize: typeof filesize = (...args) =>
     .call(null, ...args)
     .toUpperCase()
     .replace(/I/, 'i');
+
+export const schedulableMastersAlwaysOn = (cluster: Cluster) => {
+  return cluster.hosts ? cluster.hosts.length < 5 : true;
+};
+
+export const getSchedulableMasters = (cluster: Cluster): boolean => {
+  if (schedulableMastersAlwaysOn(cluster)) {
+    return true;
+  }
+  return !!cluster.schedulableMasters;
+};

--- a/src/common/types/clusters.ts
+++ b/src/common/types/clusters.ts
@@ -32,6 +32,7 @@ export type HostDiscoveryValues = ClusterUpdateParams & {
   useExtraDisksForLocalStorage: boolean;
   useContainerNativeVirtualization: boolean;
   usePlatformIntegration: boolean;
+  schedulableMasters: boolean;
 };
 /* TODO: verify that this is really not needed
 export type ClusterDetailsValues = ClusterUpdateParams & {

--- a/src/ocm/components/clusterConfiguration/HostInventory.tsx
+++ b/src/ocm/components/clusterConfiguration/HostInventory.tsx
@@ -10,6 +10,9 @@ import {
   ClusterWizardStepHeader,
   DiscoveryTroubleshootingModal,
   SwitchField,
+  schedulableMastersAlwaysOn,
+  HostDiscoveryValues,
+  getSchedulableMasters,
 } from '../../../common';
 import HostsDiscoveryTable from '../hosts/HostsDiscoveryTable';
 import DiscoveryInstructions from './DiscoveryInstructions';
@@ -22,6 +25,7 @@ import {
 } from '../hosts/HostRequirementsContent';
 import ClusterWizardHeaderExtraActions from './ClusterWizardHeaderExtraActions';
 import useClusterSupportedPlatforms from '../../api/hooks/useClusterSupportedPlatforms';
+import { useFormikContext } from 'formik';
 
 const OCSLabel: React.FC = () => (
   <>
@@ -85,6 +89,23 @@ const PlatformIntegrationLabel: React.FC<{ isTooltipHidden: boolean }> = ({
   </>
 );
 
+const SchedulableMastersLabel: React.FC<{ isTooltipHidden: boolean }> = ({
+  isTooltipHidden = false,
+}) => (
+  <>
+    <Tooltip
+      hidden={isTooltipHidden}
+      content={'This toggle will be "On" and not editable when less than 5 hosts were discovered'}
+    >
+      <span>Run workloads on control plane nodes</span>
+    </Tooltip>{' '}
+    <PopoverIcon
+      variant={'plain'}
+      bodyContent={<p>Enables your control plane nodes to be used for running applications.</p>}
+    />
+  </>
+);
+
 const HostInventory: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
   const [isDiscoveryHintModalOpen, setDiscoveryHintModalOpen] = React.useState(false);
   const { isPlatformIntegrationSupported } = useClusterSupportedPlatforms(cluster.id);
@@ -94,7 +115,12 @@ const HostInventory: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
   const isOpenshiftClusterStorageEnabled = useFeature('ASSISTED_INSTALLER_OCS_FEATURE');
   const isContainerNativeVirtualizationEnabled = useFeature('ASSISTED_INSTALLER_CNV_FEATURE');
   const isSNO = isSingleNodeCluster(cluster);
-
+  const isSchedulableMastersEnabled = !schedulableMastersAlwaysOn(cluster);
+  const { setFieldValue } = useFormikContext<HostDiscoveryValues>();
+  React.useEffect(() => {
+    //update schedulable masters field to allign with changing number of hosts
+    setFieldValue('schedulableMasters', getSchedulableMasters(cluster));
+  }, [cluster, setFieldValue]);
   return (
     <Stack hasGutter>
       <StackItem>
@@ -140,6 +166,13 @@ const HostInventory: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
             label={<PlatformIntegrationLabel isTooltipHidden={isPlatformIntegrationSupported} />}
           />
         )}
+      </StackItem>
+      <StackItem>
+        <SwitchField
+          isDisabled={!isSchedulableMastersEnabled}
+          name={'schedulableMasters'}
+          label={<SchedulableMastersLabel isTooltipHidden={isSchedulableMastersEnabled} />}
+        />
       </StackItem>
       <StackItem>
         <TextContent>

--- a/src/ocm/components/hosts/ClusterHostsTable.tsx
+++ b/src/ocm/components/hosts/ClusterHostsTable.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ClusterHostsTableProps, Host } from '../../../common';
+import { ClusterHostsTableProps, getSchedulableMasters, Host } from '../../../common';
 import { AdditionalNTPSourcesDialogToggle } from './AdditionaNTPSourceDialogToggle';
 import {
   discoveredAtColumn,
@@ -37,7 +37,7 @@ const ClusterHostsTable: React.FC<ClusterHostsTableProps> = ({
   const content = React.useMemo(
     () => [
       hostnameColumn(onEditHost),
-      roleColumn(actionChecks.canEditRole, onEditRole),
+      roleColumn(actionChecks.canEditRole, onEditRole, getSchedulableMasters(cluster)),
       statusColumn(AdditionalNTPSourcesDialogToggle, onEditHost),
       discoveredAtColumn,
       cpuCoresColumn,

--- a/src/ocm/components/hosts/HostsDiscoveryTable.tsx
+++ b/src/ocm/components/hosts/HostsDiscoveryTable.tsx
@@ -17,6 +17,7 @@ import { HostDetail } from '../../../common/components/hosts/HostRowDetail';
 import { ExpandComponentProps } from '../../../common/components/hosts/AITable';
 import { AdditionalNTPSourcesDialogToggle } from './AdditionaNTPSourceDialogToggle';
 import { onDiskRoleType } from '../../../common/components/hosts/DiskRole';
+import { getSchedulableMasters } from '../../../common';
 
 const getExpandComponent = (onDiskRole: onDiskRoleType, canEditDisks: (host: Host) => boolean) => ({
   obj: host,
@@ -52,7 +53,7 @@ const HostsDiscoveryTable: React.FC<HostsDiscoveryTableProps> = ({
   const content = React.useMemo(
     () => [
       hostnameColumn(onEditHost),
-      roleColumn(actionChecks.canEditRole, onEditRole),
+      roleColumn(actionChecks.canEditRole, onEditRole, getSchedulableMasters(cluster)),
       hardwareStatusColumn(onEditHost),
       discoveredAtColumn,
       cpuCoresColumn,


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-4551

Added 'Run workloads on control plane nodes' switch
When there are less than 5 hosts - the switch is on and disabled
When there are 5 hosts and up - the switch is enabled and off by default

In the hosts table - if the switch is on, the role label is 'Control Plane, Worker' for master nodes

3 hosts:
![image](https://user-images.githubusercontent.com/22211154/140816500-e55e0c75-b09c-4b43-96cd-c90ab0ad1d7a.png)

5 hosts, switch is off:
![image](https://user-images.githubusercontent.com/22211154/140816287-09c844f4-3161-4eae-9ef6-2876794ab759.png)

5 hosts, switch is on: 
![image](https://user-images.githubusercontent.com/22211154/140816413-77493eb2-a2dd-423b-8da2-0246e99a687a.png)
