### PR TITLE
Removing EditHostModal after cluster installation

### DIFF
--- a/src/common/components/hosts/Hostname.tsx
+++ b/src/common/components/hosts/Hostname.tsx
@@ -14,6 +14,7 @@ type HostnameProps = {
   inventory?: Inventory;
   title?: string;
   hosts?: Host[];
+  readonly?: boolean;
 };
 
 const Hostname: React.FC<HostnameProps> = ({
@@ -23,6 +24,7 @@ const Hostname: React.FC<HostnameProps> = ({
   title,
   className,
   hosts,
+  readonly = false,
 }) => {
   const hostname = title || getHostname(host, inventory) || DASH;
   const isHostnameChangeRequested = !title && host.requestedHostname !== inventory.hostname;
@@ -53,9 +55,18 @@ const Hostname: React.FC<HostnameProps> = ({
 
   return onEditHostname ? (
     isValid ? (
-      <Button variant={ButtonVariant.link} isInline onClick={onEditHostname} className={className}>
-        {body}
-      </Button>
+      !readonly ? (
+        <Button
+          variant={ButtonVariant.link}
+          isInline
+          onClick={onEditHostname}
+          className={className}
+        >
+          {body}
+        </Button>
+      ) : (
+        body
+      )
     ) : (
       <Popover
         headerContent={

--- a/src/common/components/hosts/Hostname.tsx
+++ b/src/common/components/hosts/Hostname.tsx
@@ -53,20 +53,11 @@ const Hostname: React.FC<HostnameProps> = ({
     </Flex>
   );
 
-  return onEditHostname ? (
+  return !readonly && onEditHostname ? (
     isValid ? (
-      !readonly ? (
-        <Button
-          variant={ButtonVariant.link}
-          isInline
-          onClick={onEditHostname}
-          className={className}
-        >
-          {body}
-        </Button>
-      ) : (
-        body
-      )
+      <Button variant={ButtonVariant.link} isInline onClick={onEditHostname} className={className}>
+        {body}
+      </Button>
     ) : (
       <Popover
         headerContent={

--- a/src/common/components/hosts/tableUtils.tsx
+++ b/src/common/components/hosts/tableUtils.tsx
@@ -45,6 +45,7 @@ export const getSelectedNic = (nics: Interface[], currentSubnet: Address4 | Addr
 export const hostnameColumn = (
   onEditHostname?: HostsTableActions['onEditHost'],
   hosts?: Host[],
+  readonly = false,
 ): TableRow<Host> => {
   return {
     header: {
@@ -63,7 +64,13 @@ export const hostnameColumn = (
       const computedHostname = getHostname(host, inventory);
       return {
         title: (
-          <Hostname host={host} inventory={inventory} onEditHostname={editHostname} hosts={hosts} />
+          <Hostname
+            host={host}
+            inventory={inventory}
+            onEditHostname={editHostname}
+            hosts={hosts}
+            readonly={readonly}
+          />
         ),
         props: { 'data-testid': 'host-name' },
         sortableValue: computedHostname || '',

--- a/src/common/components/hosts/tableUtils.tsx
+++ b/src/common/components/hosts/tableUtils.tsx
@@ -45,7 +45,7 @@ export const getSelectedNic = (nics: Interface[], currentSubnet: Address4 | Addr
 export const hostnameColumn = (
   onEditHostname?: HostsTableActions['onEditHost'],
   hosts?: Host[],
-  readonly = false,
+  canEditHostname?: HostsTableActions['canEditHostname'],
 ): TableRow<Host> => {
   return {
     header: {
@@ -69,7 +69,7 @@ export const hostnameColumn = (
             inventory={inventory}
             onEditHostname={editHostname}
             hosts={hosts}
-            readonly={readonly}
+            readonly={canEditHostname ? !canEditHostname() : false}
           />
         ),
         props: { 'data-testid': 'host-name' },

--- a/src/common/components/hosts/types.ts
+++ b/src/common/components/hosts/types.ts
@@ -39,6 +39,7 @@ export type HostsTableActions = {
   onEditBMH?: (host: Host) => void;
   canEditBMH?: (host: Host) => boolean;
   onSelect?: (host: Host, selected: boolean) => void;
+  canEditHostname?: () => boolean;
 };
 
 export type HostNetworkingStatusComponentProps = {

--- a/src/common/components/hosts/utils.ts
+++ b/src/common/components/hosts/utils.ts
@@ -81,6 +81,9 @@ export const canEditHost = (clusterStatus: Cluster['status'], status: Host['stat
     'pending-for-input',
   ].includes(status);
 
+export const canEditHostname = (clusterStatus: Cluster['status']) =>
+  ['insufficient', 'adding-hosts', 'ready'].includes(clusterStatus);
+
 export const canEditDisks = canEditHost;
 
 export const canDownloadKubeconfig = (clusterStatus: Cluster['status']) =>

--- a/src/ocm/components/hosts/ClusterHostsTable.tsx
+++ b/src/ocm/components/hosts/ClusterHostsTable.tsx
@@ -36,7 +36,7 @@ const ClusterHostsTable: React.FC<ClusterHostsTableProps> = ({
 
   const content = React.useMemo(
     () => [
-      hostnameColumn(onEditHost),
+      hostnameColumn(onEditHost, undefined, !actionChecks.canEditHostname()),
       roleColumn(actionChecks.canEditRole, onEditRole),
       statusColumn(AdditionalNTPSourcesDialogToggle, onEditHost),
       discoveredAtColumn,
@@ -45,7 +45,7 @@ const ClusterHostsTable: React.FC<ClusterHostsTableProps> = ({
       disksColumn,
       countColumn(cluster),
     ],
-    [onEditHost, onEditRole, actionChecks.canEditRole, cluster],
+    [onEditHost, actionChecks, onEditRole, cluster],
   );
 
   return (

--- a/src/ocm/components/hosts/ClusterHostsTable.tsx
+++ b/src/ocm/components/hosts/ClusterHostsTable.tsx
@@ -36,7 +36,7 @@ const ClusterHostsTable: React.FC<ClusterHostsTableProps> = ({
 
   const content = React.useMemo(
     () => [
-      hostnameColumn(onEditHost, undefined, !actionChecks.canEditHostname()),
+      hostnameColumn(onEditHost, undefined, actionChecks.canEditHostname),
       roleColumn(actionChecks.canEditRole, onEditRole),
       statusColumn(AdditionalNTPSourcesDialogToggle, onEditHost),
       discoveredAtColumn,

--- a/src/ocm/components/hosts/HostsDiscoveryTable.tsx
+++ b/src/ocm/components/hosts/HostsDiscoveryTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { HostsNotShowingLinkProps } from '../../../common/components/clusterConfiguration/DiscoveryTroubleshootingModal';
-import { Cluster, Host } from '../../../common/api/types';
+import { HostsNotShowingLinkProps } from '../../../common';
+import { Cluster, Host } from '../../../common';
 import { HostsTableModals, useHostsTable } from './use-hosts-table';
 import {
   countColumn,
@@ -51,7 +51,7 @@ const HostsDiscoveryTable: React.FC<HostsDiscoveryTableProps> = ({
 
   const content = React.useMemo(
     () => [
-      hostnameColumn(onEditHost, undefined, !actionChecks.canEditHostname()),
+      hostnameColumn(onEditHost, undefined, actionChecks.canEditHostname),
       roleColumn(actionChecks.canEditRole, onEditRole),
       hardwareStatusColumn(onEditHost),
       discoveredAtColumn,
@@ -60,7 +60,7 @@ const HostsDiscoveryTable: React.FC<HostsDiscoveryTableProps> = ({
       disksColumn,
       countColumn(cluster),
     ],
-    [onEditHost, onEditRole, actionChecks.canEditRole, cluster],
+    [onEditHost, actionChecks.canEditHostname, actionChecks.canEditRole, onEditRole, cluster],
   );
 
   return (

--- a/src/ocm/components/hosts/HostsDiscoveryTable.tsx
+++ b/src/ocm/components/hosts/HostsDiscoveryTable.tsx
@@ -51,7 +51,7 @@ const HostsDiscoveryTable: React.FC<HostsDiscoveryTableProps> = ({
 
   const content = React.useMemo(
     () => [
-      hostnameColumn(onEditHost),
+      hostnameColumn(onEditHost, undefined, !actionChecks.canEditHostname()),
       roleColumn(actionChecks.canEditRole, onEditRole),
       hardwareStatusColumn(onEditHost),
       discoveredAtColumn,

--- a/src/ocm/components/hosts/use-hosts-table.tsx
+++ b/src/ocm/components/hosts/use-hosts-table.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useDispatch } from 'react-redux';
 import {
   AlertsContext,
+  canEditHostname,
   Cluster,
   ClusterUpdateParams,
   Disk,
@@ -38,6 +39,7 @@ import {
   canDisable as canDisableUtil,
   canDelete as canDeleteUtil,
   canEditHost as canEditHostUtil,
+  canEditHostname as canEditHostnameUtil,
   canDownloadHostLogs,
   canReset as canResetUtil,
   EditHostModal,
@@ -173,6 +175,7 @@ export const useHostsTable = (cluster: Cluster) => {
       canDelete: (host: Host) => canDeleteUtil(cluster.status, host.status),
       canEditHost: (host: Host) => canEditHostUtil(cluster.status, host.status),
       canReset: (host: Host) => canResetUtil(cluster.status, host.status),
+      canEditHostname: () => canEditHostnameUtil(cluster.status),
     }),
     [cluster],
   );

--- a/src/ocm/components/hosts/use-hosts-table.tsx
+++ b/src/ocm/components/hosts/use-hosts-table.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { useDispatch } from 'react-redux';
 import {
   AlertsContext,
-  canEditHostname,
   Cluster,
   ClusterUpdateParams,
   Disk,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2000646

If the cluster is installed or in the process of installation the hostname won't be clickable and won't open the EditHostModal. 

![image](https://user-images.githubusercontent.com/69599321/140954846-472c141c-0ba5-415d-880f-f7ca1acb87ea.png)
