### PR TITLE
BZ-1978297: Shows N/A NTP status after the installation begins

### DIFF
--- a/src/common/components/hosts/NtpValidationStatus.tsx
+++ b/src/common/components/hosts/NtpValidationStatus.tsx
@@ -10,7 +10,7 @@ const getLabel = (validationStatus?: Validation['status']) => {
     case 'success':
       return 'Synced';
     default:
-      return 'Pending';
+      return 'Not available';
   }
 };
 


### PR DESCRIPTION
[BZ-1978297](https://bugzilla.redhat.com/show_bug.cgi?id=1978297)

The NTP status is not checked after the installation begins. Therefore the BE can no longer provide its status.
![image](https://user-images.githubusercontent.com/77008341/141389201-8cad154b-ca09-4b07-8fca-f10f28121c31.png)

The UI hardcoded the pending value which is incorrect since it will never be changed to anything else.
![image](https://user-images.githubusercontent.com/77008341/141389387-88eb73c9-77dc-43be-b1f4-d9fe4c8bb208.png)
