### PR TITLE
BZ-1978297: Fix for disabled "Download installation logs" button

### DIFF
--- a/src/common/components/hosts/utils.ts
+++ b/src/common/components/hosts/utils.ts
@@ -135,9 +135,10 @@ export const getHostRole = (host: Host, schedulableMasters?: boolean): string =>
 };
 
 export const canDownloadHostLogs = (host: Host) =>
-  !!host.logsCollectedAt && host.logsCollectedAt != TIME_ZERO;
+  !!host.logsCollectedAt && host.logsCollectedAt !== TIME_ZERO;
 
 export const canDownloadClusterLogs = (cluster: Cluster) =>
+  cluster.controllerLogsCollectedAt !== TIME_ZERO ||
   !!(cluster.hosts || []).find((host) => canDownloadHostLogs(host));
 
 export const getReadyHostCount = (cluster: Cluster) => cluster.readyHostCount || 0;


### PR DESCRIPTION
- We checked only the hosts, but the controller logs might be available even though the hosts logs are not.

Signed-off-by: Jonathan Kilzi <jkilzi@redhat.com>
