### PR TITLE
Fix link to ACM docs.

### DIFF
--- a/src/cim/components/InfraEnv/AgentAlerts.tsx
+++ b/src/cim/components/InfraEnv/AgentAlerts.tsx
@@ -1,0 +1,39 @@
+import { Alert, AlertVariant } from '@patternfly/react-core';
+import * as React from 'react';
+import { INFRAENV_AGENTINSTALL_LABEL_KEY, getInfraEnvDocs } from '../common/constants';
+import { BareMetalHostK8sResource, InfraEnvK8sResource } from '../../types';
+
+type AgentAlertsProps = {
+  docVersion: string;
+  infraEnv: InfraEnvK8sResource;
+  bareMetalHosts: BareMetalHostK8sResource[];
+};
+
+const AgentAlerts: React.FC<AgentAlertsProps> = ({ infraEnv, bareMetalHosts, docVersion }) => {
+  const infraBMHs =
+    infraEnv &&
+    bareMetalHosts?.filter(
+      (h) =>
+        h.metadata?.namespace === infraEnv.metadata?.namespace &&
+        h.metadata?.labels?.[INFRAENV_AGENTINSTALL_LABEL_KEY] === infraEnv.metadata?.name,
+    );
+
+  return infraBMHs?.some((bmh) => !bmh.status) ? (
+    <Alert
+      title="Metal3 operator is not configured"
+      variant={AlertVariant.warning}
+      isInline
+      className="cim-resource-alerts"
+      actionLinks={
+        <a href={getInfraEnvDocs(docVersion)} target="_blank" rel="noopener noreferrer">
+          Open documentation
+        </a>
+      }
+    >
+      It seems the Metal3 operator is missing configuration which will prevent it to find bare metal
+      hosts in this namespace. Please refer to the documentation for the first time setup steps.
+    </Alert>
+  ) : null;
+};
+
+export default AgentAlerts;

--- a/src/cim/components/InfraEnv/EnvironmentErrors.tsx
+++ b/src/cim/components/InfraEnv/EnvironmentErrors.tsx
@@ -3,12 +3,14 @@ import { getFailingResourceConditions } from '../helpers';
 import { InfraEnvK8sResource } from '../../types';
 import { SingleResourceAlerts } from '../common/ResourceAlerts';
 import { Alert, AlertVariant } from '@patternfly/react-core';
+import { getInfraEnvDocs } from '../common/constants';
 
 export type EnvironmentErrorsProps = {
   infraEnv: InfraEnvK8sResource;
+  docVersion: string;
 };
 
-export const EnvironmentErrors: React.FC<EnvironmentErrorsProps> = ({ infraEnv }) => {
+export const EnvironmentErrors: React.FC<EnvironmentErrorsProps> = ({ infraEnv, docVersion }) => {
   const infraEnvAlerts = getFailingResourceConditions(infraEnv, undefined /* For ALL */);
 
   return (
@@ -20,11 +22,7 @@ export const EnvironmentErrors: React.FC<EnvironmentErrorsProps> = ({ infraEnv }
           isInline
           className="cim-resource-alerts"
           actionLinks={
-            <a
-              href="https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
+            <a href={getInfraEnvDocs(docVersion)} target="_blank" rel="noopener noreferrer">
               Open documentation
             </a>
           }

--- a/src/cim/components/InfraEnv/index.ts
+++ b/src/cim/components/InfraEnv/index.ts
@@ -1,6 +1,7 @@
 export { default as EnvironmentDetails } from './EnvironmentDetails';
 export { default as InfraEnvAgentTable } from './InfraEnvAgentTable';
 export { default as InfraEnvHostsTabAgentsWarning } from './InfraEnvHostsTabAgentsWarning';
+export { default as AgentAlerts } from './AgentAlerts';
 
 export * from './EnvironmentErrors';
 export * from './InfraEnvFormPage';

--- a/src/cim/components/common/constants.ts
+++ b/src/cim/components/common/constants.ts
@@ -12,3 +12,6 @@ export const INFRAENV_AGENTINSTALL_LABEL_KEY = 'infraenvs.agent-install.openshif
 export const AGENT_BMH_HOSTNAME_LABEL_KEY = 'agent-install.openshift.io/bmh';
 
 export const INFRAENV_GENERATED_AI_FLOW = 'agentBareMetal-generated-infraenv-ai-flow'; // mind ai-template.hbs in ACM when changed here
+
+export const getInfraEnvDocs = (docVersion: string) =>
+  `https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/${docVersion}/html-single/clusters/index#infra-env-prerequisites`;


### PR DESCRIPTION
Add detection for metal3 operator configuration

![Screenshot from 2021-11-16 10-23-45](https://user-images.githubusercontent.com/2078045/141979318-0e5d4edc-bce4-41b8-8b2c-81b02120993f.png)
.

the alert message got updated to 
```
It seems the Metal3 operator is missing configuration which will prevent it to find bare metal
      hosts in this namespace. Please refer to the documentation for the first time setup steps.
```