### PR TITLE
MGMT-7406: Add virt-install usage warning when discovering libvirt hosts

### DIFF
--- a/src/ocm/components/hosts/VMRebootConfigurationInfo.tsx
+++ b/src/ocm/components/hosts/VMRebootConfigurationInfo.tsx
@@ -10,7 +10,7 @@ import {
 import { InfoCircleIcon } from '@patternfly/react-icons';
 import { Host, stringToJSON, Inventory, PrismCode } from '../../../common';
 
-const Hint = () => (
+const HintOnReboot = () => (
   <TextContent>
     <Text component={TextVariants.p}>
       Your libvirt virtual machines should be configured to restart automatically after a reboot.
@@ -26,6 +26,17 @@ const Hint = () => (
   </TextContent>
 );
 
+const HintVirtInstall = () => (
+  <TextContent>
+    <Text component={TextVariants.p}>When using virt-install, please run:</Text>
+    <PrismCode code="virt-install --wait -1 <rest of the command>" />
+    <Text component={TextVariants.p}>
+      Otherwise, machines will not be able to reboot in the middle of installation, and will stay
+      shut down.
+    </Text>
+  </TextContent>
+);
+
 const VMRebootConfigurationInfo: React.FC<{ hosts: Host[] }> = ({ hosts }) => {
   const isVM = React.useMemo(
     () =>
@@ -38,10 +49,17 @@ const VMRebootConfigurationInfo: React.FC<{ hosts: Host[] }> = ({ hosts }) => {
 
   return isVM ? (
     <Text component="p">
-      <Popover bodyContent={<Hint />} minWidth="30rem">
+      <Popover bodyContent={<HintOnReboot />} minWidth="30rem">
         <Button variant={ButtonVariant.link} isInline>
           <InfoCircleIcon size="sm" />
           &nbsp;Check your VM reboot configuration
+        </Button>
+      </Popover>
+      &ensp;
+      <Popover bodyContent={<HintVirtInstall />} minWidth="35rem">
+        <Button variant={ButtonVariant.link} isInline>
+          <InfoCircleIcon size="sm" />
+          &nbsp;Using virt-install? Please read this!
         </Button>
       </Popover>
     </Text>

--- a/src/ocm/components/hosts/VMRebootConfigurationInfo.tsx
+++ b/src/ocm/components/hosts/VMRebootConfigurationInfo.tsx
@@ -10,7 +10,7 @@ import {
 import { InfoCircleIcon } from '@patternfly/react-icons';
 import { Host, stringToJSON, Inventory, PrismCode } from '../../../common';
 
-const HintOnReboot = () => (
+const Hint = () => (
   <TextContent>
     <Text component={TextVariants.p}>
       Your libvirt virtual machines should be configured to restart automatically after a reboot.
@@ -23,16 +23,12 @@ const HintOnReboot = () => (
       If not, please start your VMs with the following configuration:
     </Text>
     <PrismCode code="--events on_reboot=restart" />
-  </TextContent>
-);
-
-const HintVirtInstall = () => (
-  <TextContent>
-    <Text component={TextVariants.p}>When using virt-install, please run:</Text>
+    <Text component={TextVariants.p}>
+      When using <code>virt-install</code>, please run:
+    </Text>
     <PrismCode code="virt-install --wait -1 <rest of the command>" />
     <Text component={TextVariants.p}>
-      Otherwise, machines will not be able to reboot in the middle of installation, and will stay
-      shut down.
+      Otherwise, the VMs will not be able to reboot during the installation process.
     </Text>
   </TextContent>
 );
@@ -49,17 +45,10 @@ const VMRebootConfigurationInfo: React.FC<{ hosts: Host[] }> = ({ hosts }) => {
 
   return isVM ? (
     <Text component="p">
-      <Popover bodyContent={<HintOnReboot />} minWidth="30rem">
+      <Popover bodyContent={<Hint />} minWidth="35rem">
         <Button variant={ButtonVariant.link} isInline>
           <InfoCircleIcon size="sm" />
           &nbsp;Check your VM reboot configuration
-        </Button>
-      </Popover>
-      &ensp;
-      <Popover bodyContent={<HintVirtInstall />} minWidth="35rem">
-        <Button variant={ButtonVariant.link} isInline>
-          <InfoCircleIcon size="sm" />
-          &nbsp;Using virt-install? Please read this!
         </Button>
       </Popover>
     </Text>


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-7406

When using virt-install the user needs to run: **virt-install --wait -1 <rest of the command>**
Otherwise, machines will not be able to reboot in the middle of installation, and will stay shut down. 
I added a warning for the user that tells him to do so (in the host discovery step):

![image](https://user-images.githubusercontent.com/69599321/142228954-650eaeb0-4506-4986-90d2-323e23b45a92.png)
