### PR TITLE
Add CIM and OCM exports to the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,22 @@
   "license": "Apache-2.0",
   "repository": "openshift-assisted/assisted-ui-lib",
   "main": "dist/index.js",
+  "exports": {
+    ".": "./dist/index.js",
+    "./index.css": "./dist/index.css",
+    "./cim": "./dist/cim/index.js",
+    "./ocm": "./dist/ocm/index.js"
+  },
+  "typesVersions": {
+    "*": {
+      "cim": [
+        "./dist/src/cim/index.d.ts"
+      ],
+      "ocm": [
+        "./dist/src/ocm/index.d.ts"
+      ]
+    }
+  },
   "module": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/src/index.d.ts",

--- a/scripts/esbuild/common-config.js
+++ b/scripts/esbuild/common-config.js
@@ -3,7 +3,7 @@ const { dtsPlugin } = require('esbuild-plugin-d.ts');
 const pkg = require('../../package.json');
 
 module.exports = {
-  entryPoints: ['src/index.ts'],
+  entryPoints: ['src/index.ts', 'src/cim/index.ts', 'src/ocm/index.ts'],
   // don't bundle dependences and peerDependencies https://github.com/evanw/esbuild/issues/727#issuecomment-771743582
   external: [...Object.keys(pkg.dependencies), ...Object.keys(pkg.peerDependencies || {})],
   bundle: true,


### PR DESCRIPTION
This allows importing the CIM and OCM modules directly as
`import { SomeComponent } from 'openshift-assisted-ui-lib/cim';`
and improves developer experience as it correctly infers types
in consuming application editor when 'yarn link'ing the library.