### PR TITLE
BZ-2015471: The rows in the discovery table move up and down randomly every few seconds

### DIFF
--- a/src/common/components/hosts/HostsTable.tsx
+++ b/src/common/components/hosts/HostsTable.tsx
@@ -71,6 +71,7 @@ const HostsTable: React.FC<HostsTableProps & WithTestID> = ({
   selectedIDs,
 }) => {
   const data = (hosts || []).filter((host) => !skipDisabled || host.status != 'disabled');
+  data.sort((a, b) => (a.id < b.id ? -1 : 1));
 
   return (
     <AITable<Host>


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2015471

The hosts in the cluster object have a random order. Sorting them by `id` will prevent them from changing their order in the AITable until their name is changed.