### PR TITLE
BZ1937518 - Generating Discovery ISO fails using Drag&Drop feature

### DIFF
--- a/src/common/components/clusterConfiguration/UploadSSH.tsx
+++ b/src/common/components/clusterConfiguration/UploadSSH.tsx
@@ -19,6 +19,7 @@ const UploadSSH: React.FC = () => {
         maxSize: 2048,
         onDropRejected: ({ setError }) => () => setError('File not supported.'),
       }}
+      transformValue={trimSshPublicKey}
     />
   );
 };

--- a/src/common/components/ui/formik/UploadField.tsx
+++ b/src/common/components/ui/formik/UploadField.tsx
@@ -4,7 +4,6 @@ import { FormGroup, FileUpload } from '@patternfly/react-core';
 import { UploadFieldProps } from './types';
 import { getFieldId } from './utils';
 import HelperText from './HelperText';
-import { trimSshPublicKey } from '.';
 
 const UploadField: React.FC<UploadFieldProps> = ({
   label,
@@ -19,6 +18,7 @@ const UploadField: React.FC<UploadFieldProps> = ({
   onBlur,
   allowEdittingUploadedText = true,
   dropzoneProps,
+  transformValue,
 }) => {
   const [filename, setFilename] = React.useState<string>();
   const [isFileUploading, setIsFileUploading] = React.useState(false);
@@ -72,7 +72,9 @@ const UploadField: React.FC<UploadFieldProps> = ({
         onChange={(value, filename) => {
           setFilename(filename);
           helpers.setTouched(true);
-          typeof value === 'string' && helpers.setValue(trimSshPublicKey(value));
+          transformValue && typeof value === 'string'
+            ? helpers.setValue(transformValue(value))
+            : helpers.setValue(value);
         }}
         onBlur={(e) => {
           field.onBlur(e);

--- a/src/common/components/ui/formik/UploadField.tsx
+++ b/src/common/components/ui/formik/UploadField.tsx
@@ -4,6 +4,7 @@ import { FormGroup, FileUpload } from '@patternfly/react-core';
 import { UploadFieldProps } from './types';
 import { getFieldId } from './utils';
 import HelperText from './HelperText';
+import { trimSshPublicKey } from '.';
 
 const UploadField: React.FC<UploadFieldProps> = ({
   label,
@@ -71,7 +72,7 @@ const UploadField: React.FC<UploadFieldProps> = ({
         onChange={(value, filename) => {
           setFilename(filename);
           helpers.setTouched(true);
-          helpers.setValue(value);
+          typeof value === 'string' && helpers.setValue(trimSshPublicKey(value));
         }}
         onBlur={(e) => {
           field.onBlur(e);

--- a/src/common/components/ui/formik/types.ts
+++ b/src/common/components/ui/formik/types.ts
@@ -88,6 +88,7 @@ export interface UploadFieldProps extends FieldProps {
   dropzoneProps?: Omit<DropzoneProps, 'onDropRejected'> & {
     onDropRejected?: (helpers: FieldHelperProps<string>) => DropFileEventHandler;
   };
+  transformValue?: (key: string) => void;
 }
 
 export interface TextAreaSecretProps extends TextAreaFieldProps {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1937518

The `trimSshPublicKey()` function was only called on the `blur` event which doesn't occur when the Drag&Drop feature is used. I opted to pass the transformation function with props in case we wanted to use the `UploadField` component for something different than SSH keys.