### PR TITLE
MGMT-7447: UI Step 2: Consume cluster network data from the new fields

### DIFF
--- a/src/common/components/clusterConfiguration/networkConfigurationValidation.ts
+++ b/src/common/components/clusterConfiguration/networkConfigurationValidation.ts
@@ -9,20 +9,28 @@ import {
 } from '../ui';
 
 import { getSubnetFromMachineNetworkCidr } from './utils';
+import {
+  selectClusterNetworkCIDR,
+  selectClusterNetworkHostPrefix,
+  selectMachineNetworkCIDR,
+  selectServiceNetworkCIDR,
+} from '../../../ocm/selectors/clusterSelectors';
 
 export const getNetworkInitialValues = (
   cluster: Cluster,
   defaultNetworkSettings: ClusterDefaultConfig,
 ): NetworkConfigurationValues => {
   return {
-    clusterNetworkCidr: cluster.clusterNetworkCidr || defaultNetworkSettings.clusterNetworkCidr,
+    clusterNetworkCidr:
+      selectClusterNetworkCIDR(cluster) || defaultNetworkSettings.clusterNetworkCidr,
     clusterNetworkHostPrefix:
-      cluster.clusterNetworkHostPrefix || defaultNetworkSettings.clusterNetworkHostPrefix,
-    serviceNetworkCidr: cluster.serviceNetworkCidr || defaultNetworkSettings.serviceNetworkCidr,
+      selectClusterNetworkHostPrefix(cluster) || defaultNetworkSettings.clusterNetworkHostPrefix,
+    serviceNetworkCidr:
+      selectServiceNetworkCIDR(cluster) || defaultNetworkSettings.serviceNetworkCidr,
     apiVip: cluster.apiVip || '',
     ingressVip: cluster.ingressVip || '',
     sshPublicKey: cluster.sshPublicKey || '',
-    hostSubnet: getSubnetFromMachineNetworkCidr(cluster.machineNetworkCidr),
+    hostSubnet: getSubnetFromMachineNetworkCidr(selectMachineNetworkCIDR(cluster)),
     vipDhcpAllocation: cluster.vipDhcpAllocation,
     managedNetworkingType: cluster.userManagedNetworking ? 'userManaged' : 'clusterManaged',
     networkType: cluster.networkType || 'OpenShiftSDN',

--- a/src/common/components/clusterConfiguration/utils.ts
+++ b/src/common/components/clusterConfiguration/utils.ts
@@ -4,6 +4,11 @@ import { NO_SUBNET_SET } from '../../config';
 import { HostDiscoveryValues, HostSubnets } from '../../types/clusters';
 import { OpenshiftVersionOptionType } from '../../types/versions';
 import { getHostname, getSchedulableMasters } from '../hosts/utils';
+import {
+  selectClusterNetworkCIDR,
+  selectClusterNetworkHostPrefix,
+  selectServiceNetworkCIDR,
+} from '../../../ocm/selectors/clusterSelectors';
 
 export const getSubnet = (cidr: string): Address6 | Address4 | null => {
   if (Address4.isValid(cidr)) {
@@ -57,9 +62,9 @@ export const getSubnetFromMachineNetworkCidr = (machineNetworkCidr?: string) => 
 };
 
 export const isAdvNetworkConf = (cluster: Cluster, defaultNetworkSettings: ClusterDefaultConfig) =>
-  cluster.clusterNetworkCidr !== defaultNetworkSettings.clusterNetworkCidr ||
-  cluster.clusterNetworkHostPrefix !== defaultNetworkSettings.clusterNetworkHostPrefix ||
-  cluster.serviceNetworkCidr !== defaultNetworkSettings.serviceNetworkCidr ||
+  selectClusterNetworkCIDR(cluster) !== defaultNetworkSettings.clusterNetworkCidr ||
+  selectClusterNetworkHostPrefix(cluster) !== defaultNetworkSettings.clusterNetworkHostPrefix ||
+  selectServiceNetworkCIDR(cluster) !== defaultNetworkSettings.serviceNetworkCidr ||
   (Boolean(cluster.networkType) && cluster.networkType !== 'OpenShiftSDN');
 
 export const getHostDiscoveryInitialValues = (cluster: Cluster): HostDiscoveryValues => {

--- a/src/common/components/hosts/tableUtils.tsx
+++ b/src/common/components/hosts/tableUtils.tsx
@@ -17,6 +17,7 @@ import { HostsTableActions } from './types';
 import HostStatus from './HostStatus';
 import RoleCell from './RoleCell';
 import { getHostname, getHostRole } from './utils';
+import { selectMachineNetworkCIDR } from '../../../ocm/selectors/clusterSelectors';
 
 export const getSelectedNic = (nics: Interface[], currentSubnet: Address4 | Address6) => {
   return nics.find((nic) => {
@@ -303,7 +304,8 @@ export const activeNICColumn = (cluster: Cluster): TableRow<Host> => ({
     const inventory = stringToJSON<Inventory>(inventoryString) || {};
     const nics = inventory.interfaces || [];
 
-    const currentSubnet = cluster.machineNetworkCidr ? getSubnet(cluster.machineNetworkCidr) : null;
+    const machineNetworkCidr = selectMachineNetworkCIDR(cluster);
+    const currentSubnet = machineNetworkCidr ? getSubnet(machineNetworkCidr) : null;
     const selectedNic = currentSubnet ? getSelectedNic(nics, currentSubnet) : null;
     return {
       title: selectedNic?.name || DASH,
@@ -321,7 +323,8 @@ export const ipv4Column = (cluster: Cluster): TableRow<Host> => ({
     const inventory = stringToJSON<Inventory>(inventoryString) || {};
     const nics = inventory.interfaces || [];
 
-    const currentSubnet = cluster.machineNetworkCidr ? getSubnet(cluster.machineNetworkCidr) : null;
+    const machineNetworkCidr = selectMachineNetworkCIDR(cluster);
+    const currentSubnet = machineNetworkCidr ? getSubnet(machineNetworkCidr) : null;
     const selectedNic = currentSubnet ? getSelectedNic(nics, currentSubnet) : null;
     return {
       title: (selectedNic?.ipv4Addresses || []).join(', ') || DASH,
@@ -339,7 +342,8 @@ export const ipv6Column = (cluster: Cluster): TableRow<Host> => ({
     const inventory = stringToJSON<Inventory>(inventoryString) || {};
     const nics = inventory.interfaces || [];
 
-    const currentSubnet = cluster.machineNetworkCidr ? getSubnet(cluster.machineNetworkCidr) : null;
+    const machineNetworkCidr = selectMachineNetworkCIDR(cluster);
+    const currentSubnet = machineNetworkCidr ? getSubnet(machineNetworkCidr) : null;
     const selectedNic = currentSubnet ? getSelectedNic(nics, currentSubnet) : null;
     return {
       title: (selectedNic?.ipv6Addresses || []).join(', ') || DASH,
@@ -357,7 +361,8 @@ export const macAddressColumn = (cluster: Cluster): TableRow<Host> => ({
     const inventory = stringToJSON<Inventory>(inventoryString) || {};
     const nics = inventory.interfaces || [];
 
-    const currentSubnet = cluster.machineNetworkCidr ? getSubnet(cluster.machineNetworkCidr) : null;
+    const machineNetworkCidr = selectMachineNetworkCIDR(cluster);
+    const currentSubnet = machineNetworkCidr ? getSubnet(machineNetworkCidr) : null;
     const selectedNic = currentSubnet ? getSelectedNic(nics, currentSubnet) : null;
     return {
       title: selectedNic?.macAddress || DASH,

--- a/src/ocm/components/clusterConfiguration/ReviewCluster.tsx
+++ b/src/ocm/components/clusterConfiguration/ReviewCluster.tsx
@@ -18,6 +18,7 @@ import { ClusterValidations, HostsValidations } from './ReviewValidations';
 import { VSPHERE_CONFIG_LINK } from '../../../common';
 
 import './ReviewCluster.css';
+import { selectClusterNetworkCIDR } from '../../selectors/clusterSelectors';
 
 const ReviewHostsInventory: React.FC<{ hosts?: Host[] }> = ({ hosts = [] }) => {
   const rows = React.useMemo(() => {
@@ -87,7 +88,7 @@ const ReviewCluster: React.FC<{ cluster: Cluster }> = ({ cluster }) => (
   <DetailList>
     <DetailItem title="Cluster address" value={`${cluster.name}.${cluster.baseDnsDomain}`} />
     <DetailItem title="OpenShift version" value={cluster.openshiftVersion} />
-    <DetailItem title="Management network CIDR" value={cluster.clusterNetworkCidr} />
+    <DetailItem title="Management network CIDR" value={selectClusterNetworkCIDR(cluster)} />
     <DetailItem title="Cluster summary" value={<ReviewHostsInventory hosts={cluster.hosts} />} />
     <DetailItem
       title="Cluster validations"

--- a/src/ocm/components/clusterDetail/ClusterProperties.tsx
+++ b/src/ocm/components/clusterDetail/ClusterProperties.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { GridItem, TextContent, Text } from '@patternfly/react-core';
 import { Cluster, isSingleNodeCluster, DetailList, DetailItem } from '../../../common';
+import {
+  selectClusterNetworkCIDR,
+  selectClusterNetworkHostPrefix,
+  selectServiceNetworkCIDR,
+} from '../../selectors/clusterSelectors';
 
 type ClusterPropertiesProps = {
   cluster: Cluster;
@@ -51,9 +56,12 @@ const ClusterProperties: React.FC<ClusterPropertiesProps> = ({ cluster }) => (
     <GridItem md={6}>
       <DetailList>
         <DetailItem title="UUID" value={cluster.id} />
-        <DetailItem title="Cluster network CIDR" value={cluster.clusterNetworkCidr} />
-        <DetailItem title="Cluster network host prefix" value={cluster.clusterNetworkHostPrefix} />
-        <DetailItem title="Service network CIDR" value={cluster.serviceNetworkCidr} />
+        <DetailItem title="Cluster network CIDR" value={selectClusterNetworkCIDR(cluster)} />
+        <DetailItem
+          title="Cluster network host prefix"
+          value={selectClusterNetworkHostPrefix(cluster)}
+        />
+        <DetailItem title="Service network CIDR" value={selectServiceNetworkCIDR(cluster)} />
         <DetailItem
           title="Network management type"
           value={getManagementType(cluster.userManagedNetworking)}

--- a/src/ocm/selectors/clusterSelectors.ts
+++ b/src/ocm/selectors/clusterSelectors.ts
@@ -1,0 +1,19 @@
+import _ from 'lodash/fp';
+import { Cluster } from '../../common/api/types';
+
+export const selectMachineNetworkCIDR = ({
+  machineNetworks,
+  machineNetworkCidr,
+}: Partial<Cluster>) => _.head(machineNetworks)?.cidr ?? machineNetworkCidr;
+export const selectClusterNetworkCIDR = ({
+  clusterNetworks,
+  clusterNetworkCidr,
+}: Partial<Cluster>) => _.head(clusterNetworks)?.cidr ?? clusterNetworkCidr;
+export const selectClusterNetworkHostPrefix = ({
+  clusterNetworks,
+  clusterNetworkHostPrefix,
+}: Partial<Cluster>) => _.head(clusterNetworks)?.hostPrefix ?? clusterNetworkHostPrefix;
+export const selectServiceNetworkCIDR = ({
+  serviceNetworks,
+  serviceNetworkCidr,
+}: Partial<Cluster>) => _.head(serviceNetworks)?.cidr ?? serviceNetworkCidr;

--- a/src/ocm/selectors/index.ts
+++ b/src/ocm/selectors/index.ts
@@ -1,2 +1,3 @@
 export * from './currentCluster';
 export * from './clusters';
+export * from './clusterSelectors';


### PR DESCRIPTION
- The selector for the new fields fallback to the old fields for backwards compatibility
- The old fields should be removed once they are deprecated in the REST API  
  - [MGMT-7527](https://issues.redhat.com/browse/MGMT-7527) sets the context for this task
