### PR TITLE
BZ-2000142 - Sorting by Host in Assisted Cluster does not work as expected

### DIFF
--- a/src/ocm/selectors/clusters.tsx
+++ b/src/ocm/selectors/clusters.tsx
@@ -8,7 +8,8 @@ import {
   Cluster,
   DASH,
   getDateTimeCell,
-  getReadyHostCount,
+  getEnabledHostCount,
+  getTotalHostCount,
   HostsCount,
   HumanizedSortable,
   ResourceUIState,
@@ -62,7 +63,8 @@ const clusterToClusterTableRow = (cluster: Cluster): IRow => {
       {
         title: <HostsCount cluster={cluster} />,
         props: { 'data-testid': `cluster-hosts-count-${name}` },
-        sortableValue: getReadyHostCount(cluster),
+        sortableValue:
+          'enabledHostCount' in cluster ? getEnabledHostCount(cluster) : getTotalHostCount(cluster),
       } as HumanizedSortable,
       {
         title: dateTimeCell.title,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2000142
The displayed host count is either from the `enabledHostCount` or `totalHostCount` field. Sorting value is now consistent with this.

Before:
![image](https://user-images.githubusercontent.com/87187179/143862887-1c565438-e757-46d0-b34d-f704bea946d7.png)
After:
![image](https://user-images.githubusercontent.com/87187179/143862409-9675a5d9-8010-4566-9c9b-d8936e119821.png)
