### PR TITLE
BZ-1978297: Removing "NTP status" field after the cluster installation begins

### DIFF
--- a/src/common/components/hosts/AITable.tsx
+++ b/src/common/components/hosts/AITable.tsx
@@ -42,6 +42,7 @@ export type TableRow<R> = {
 export type ActionsResolver<R> = (obj: R) => (IAction | ISeparator)[];
 export type ExpandComponentProps<R> = {
   obj: R;
+  showNTP?: boolean;
 };
 
 type HostsTable<R> = {

--- a/src/common/components/hosts/AITable.tsx
+++ b/src/common/components/hosts/AITable.tsx
@@ -42,7 +42,6 @@ export type TableRow<R> = {
 export type ActionsResolver<R> = (obj: R) => (IAction | ISeparator)[];
 export type ExpandComponentProps<R> = {
   obj: R;
-  showNTP?: boolean;
 };
 
 type HostsTable<R> = {

--- a/src/common/components/hosts/HostRowDetail.tsx
+++ b/src/common/components/hosts/HostRowDetail.tsx
@@ -29,7 +29,7 @@ type HostDetailProps = {
   onDiskRole?: onDiskRoleType;
   host: Host;
   AdditionalNTPSourcesDialogToggleComponent: ValidationInfoActionProps['AdditionalNTPSourcesDialogToggleComponent'];
-  showNTP?: boolean;
+  hideNTPStatus?: boolean;
 };
 
 type SectionTitleProps = {
@@ -202,7 +202,7 @@ export const HostDetail: React.FC<HostDetailProps> = ({
   onDiskRole,
   host,
   AdditionalNTPSourcesDialogToggleComponent,
-  showNTP = true,
+  hideNTPStatus = false,
 }) => {
   const { id, installationDiskId, inventory: inventoryString = '' } = host;
   const inventory = stringToJSON<Inventory>(inventoryString) || {};
@@ -228,11 +228,6 @@ export const HostDetail: React.FC<HostDetailProps> = ({
     ),
     [AdditionalNTPSourcesDialogToggleComponent, validationsInfo],
   );
-
-  let NTPdetail;
-  if (showNTP) {
-    NTPdetail = <DetailItem testId={'ntp-status'} title="NTP status" value={ntpValidationStatus} />;
-  }
 
   return (
     <Grid hasGutter>
@@ -288,7 +283,12 @@ export const HostDetail: React.FC<HostDetailProps> = ({
             value={inventory.boot?.pxeInterface}
           />
         )}
-        {NTPdetail}
+        <DetailItem
+          isHidden={hideNTPStatus}
+          testId={'ntp-status'}
+          title="NTP status"
+          value={ntpValidationStatus}
+        />
       </SectionColumn>
       <SectionTitle
         testId={'disks-section'}

--- a/src/common/components/hosts/HostRowDetail.tsx
+++ b/src/common/components/hosts/HostRowDetail.tsx
@@ -29,6 +29,7 @@ type HostDetailProps = {
   onDiskRole?: onDiskRoleType;
   host: Host;
   AdditionalNTPSourcesDialogToggleComponent: ValidationInfoActionProps['AdditionalNTPSourcesDialogToggleComponent'];
+  showNTP?: boolean;
 };
 
 type SectionTitleProps = {
@@ -201,6 +202,7 @@ export const HostDetail: React.FC<HostDetailProps> = ({
   onDiskRole,
   host,
   AdditionalNTPSourcesDialogToggleComponent,
+  showNTP = true,
 }) => {
   const { id, installationDiskId, inventory: inventoryString = '' } = host;
   const inventory = stringToJSON<Inventory>(inventoryString) || {};
@@ -226,6 +228,11 @@ export const HostDetail: React.FC<HostDetailProps> = ({
     ),
     [AdditionalNTPSourcesDialogToggleComponent, validationsInfo],
   );
+
+  let NTPdetail;
+  if (showNTP) {
+    NTPdetail = <DetailItem testId={'ntp-status'} title="NTP status" value={ntpValidationStatus} />;
+  }
 
   return (
     <Grid hasGutter>
@@ -281,9 +288,8 @@ export const HostDetail: React.FC<HostDetailProps> = ({
             value={inventory.boot?.pxeInterface}
           />
         )}
-        <DetailItem testId={'ntp-status'} title="NTP status" value={ntpValidationStatus} />
+        {NTPdetail}
       </SectionColumn>
-
       <SectionTitle
         testId={'disks-section'}
         title={`${disks.length} Disk${disks.length === 1 ? '' : 's'}`}

--- a/src/ocm/components/hosts/ClusterHostsTable.tsx
+++ b/src/ocm/components/hosts/ClusterHostsTable.tsx
@@ -21,7 +21,7 @@ const ExpandComponent: React.FC<ExpandComponentProps<Host>> = ({ obj }) => {
     <HostDetail
       host={obj}
       AdditionalNTPSourcesDialogToggleComponent={AdditionalNTPSourcesDialogToggle}
-      showNTP={false}
+      hideNTPStatus
     />
   );
 };

--- a/src/ocm/components/hosts/ClusterHostsTable.tsx
+++ b/src/ocm/components/hosts/ClusterHostsTable.tsx
@@ -21,6 +21,7 @@ const ExpandComponent: React.FC<ExpandComponentProps<Host>> = ({ obj }) => {
     <HostDetail
       host={obj}
       AdditionalNTPSourcesDialogToggleComponent={AdditionalNTPSourcesDialogToggle}
+      showNTP={false}
     />
   );
 };


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1978297

The NTP status of the host will not appear after the installation starts but remains before that. 

![image](https://user-images.githubusercontent.com/69599321/144081385-0e80fb2d-37c8-4033-9421-cb26ffae3793.png)

![image](https://user-images.githubusercontent.com/69599321/144081533-1c392935-9d13-40d9-a1e6-326798f4ac00.png)
