### PR TITLE
preview badge improvements

### DIFF
--- a/src/common/components/featureSupportLevels/FeatureSupportLevelBadge.tsx
+++ b/src/common/components/featureSupportLevels/FeatureSupportLevelBadge.tsx
@@ -1,37 +1,18 @@
-import { Popover } from '@patternfly/react-core';
 import React from 'react';
-import { TECH_SUPPORT_LEVEL_LINK } from '../../config/constants';
 import { FeatureId, SupportLevel, isPreviewSupportLevel } from '../../types';
-import ExternalLink from '../ui/ExternalLink';
-import {
-  TechnologyPreview,
-  DeveloperPreview,
-  PreviewBadgePosition,
-  DeveloperPreviewProps,
-} from '../ui/PreviewBadge';
+import { TechnologyPreview, DeveloperPreview } from '../ui/PreviewBadge';
 import FeatureSupportLevelContext from './FeatureSupportLevelContext';
 
 export type SupportLevelBadgeProps = {
   featureId: FeatureId;
   openshiftVersion: string | undefined;
-} & DeveloperPreviewProps;
-
-const popoverTexts = {
-  'tech-preview': `Technology preview features provide early access to upcoming product innovations, 
-  enabling you to test functionality and provide feedback during the development process.`,
-  'dev-preview': `Developer Preview features provide early access to upcoming innovations and contain 
-  a functional set of features that Red Hat is encouraging customers to use and provide feedback on.`,
 };
 
 const FeatureSupportLevelBadge: React.FC<SupportLevelBadgeProps> = ({
   featureId,
   openshiftVersion,
-  className = 'pf-u-ml-md',
-  position = PreviewBadgePosition.inline,
-  ...props
 }) => {
   const featureSupportLevelData = React.useContext(FeatureSupportLevelContext);
-
   const supportLevel: SupportLevel | undefined = React.useMemo(() => {
     if (!openshiftVersion) {
       return undefined;
@@ -41,25 +22,7 @@ const FeatureSupportLevelBadge: React.FC<SupportLevelBadgeProps> = ({
   if (!isPreviewSupportLevel(supportLevel)) {
     return null;
   }
-  const Component = supportLevel === 'tech-preview' ? TechnologyPreview : DeveloperPreview;
-  const bodyContent = (
-    <>
-      <p>
-        {popoverTexts[supportLevel]}
-        {supportLevel === 'tech-preview' && (
-          <>
-            <br />
-            <ExternalLink href={TECH_SUPPORT_LEVEL_LINK}>Learn more</ExternalLink>
-          </>
-        )}
-      </p>
-    </>
-  );
-  return (
-    <Popover bodyContent={bodyContent}>
-      <Component position={position} className={className} {...props} />
-    </Popover>
-  );
+  return supportLevel === 'tech-preview' ? <TechnologyPreview /> : <DeveloperPreview />;
 };
 
 export default FeatureSupportLevelBadge;

--- a/src/common/components/ui/PreviewBadge.tsx
+++ b/src/common/components/ui/PreviewBadge.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import { Label, LabelProps } from '@patternfly/react-core';
+import { Label, Popover } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
+import { TECH_SUPPORT_LEVEL_LINK } from '../../config/constants';
+import ExternalLink from './ExternalLink';
 
 export enum PreviewBadgePosition {
   default,
@@ -7,15 +10,21 @@ export enum PreviewBadgePosition {
   inlineRight,
 }
 
-export type DeveloperPreviewProps = {
+type PreviewBadgeProps = {
   position?: PreviewBadgePosition;
   className?: string;
+  text: string;
+  externalLink?: string;
+  popoverText: string;
 };
-type TechnologyPreviewProps = DeveloperPreviewProps;
 
-const PreviewBadge: React.FC<
-  DeveloperPreviewProps & { text: string; color?: LabelProps['color'] }
-> = ({ position = PreviewBadgePosition.inlineRight, className = '', color = 'orange', text }) => {
+const PreviewBadge: React.FC<PreviewBadgeProps> = ({
+  position = PreviewBadgePosition.inline,
+  className = 'pf-u-ml-md',
+  text,
+  popoverText,
+  externalLink,
+}) => {
   let clsName = className;
   switch (position) {
     case PreviewBadgePosition.inlineRight:
@@ -25,22 +34,52 @@ const PreviewBadge: React.FC<
       clsName += ' pf-u-display-inline';
       break;
   }
+  const bodyContent = (
+    <>
+      <div style={{ marginBottom: 'var(--pf-global--spacer--sm)' }}>{popoverText}</div>
+      {externalLink && (
+        <>
+          <ExternalLink href={externalLink}>Learn more</ExternalLink>
+        </>
+      )}
+    </>
+  );
 
   return (
-    <Label
-      className={clsName}
-      color={color}
-      onClick={(e) => e.preventDefault()}
-      style={{ cursor: 'pointer' }}
-    >
-      {text}
-    </Label>
+    <Popover bodyContent={bodyContent} position="top">
+      <Label
+        style={{ cursor: 'pointer' }}
+        color="orange"
+        onClick={(e) => e.preventDefault()}
+        icon={<InfoCircleIcon color="var(--pf-c-label__content--Color)" />}
+        className={clsName}
+      >
+        {text}
+      </Label>
+    </Popover>
   );
 };
 
+export type DeveloperPreviewProps = Pick<PreviewBadgeProps, 'className' | 'position'>;
+
+export type TechnologyPreviewProps = DeveloperPreviewProps;
+
+const popoverTexts = {
+  'tech-preview': `Technology preview features provide early access to upcoming product innovations, 
+  enabling you to test functionality and provide feedback during the development process.`,
+  'dev-preview': `Developer Preview features provide early access to upcoming innovations and contain 
+  a functional set of features that Red Hat is encouraging customers to use and provide feedback on.`,
+};
+
 export const DeveloperPreview: React.FC<DeveloperPreviewProps> = (props) => (
-  <PreviewBadge {...props} text="Developer Preview" />
+  <PreviewBadge text="Developer Preview" popoverText={popoverTexts['dev-preview']} {...props} />
 );
+
 export const TechnologyPreview: React.FC<TechnologyPreviewProps> = (props) => (
-  <PreviewBadge {...props} text="Technology Preview" />
+  <PreviewBadge
+    text="Technology Preview"
+    popoverText={popoverTexts['tech-preview']}
+    externalLink={TECH_SUPPORT_LEVEL_LINK}
+    {...props}
+  />
 );

--- a/src/ocm/components/clusters/ClusterPage.tsx
+++ b/src/ocm/components/clusters/ClusterPage.tsx
@@ -15,7 +15,6 @@ import {
   LoadingState,
   AlertsContextProvider,
   AddHostsContextProvider,
-  PreviewBadgePosition,
   TechnologyPreview,
 } from '../../../common';
 import ClusterDetail from '../clusterDetail/ClusterDetail';
@@ -91,7 +90,7 @@ const ClusterPage: React.FC<RouteComponentProps<MatchParams>> = ({ match }) => {
               <Text component="h1" className="pf-u-display-inline">
                 Install OpenShift with the Assisted Installer
               </Text>
-              <TechnologyPreview className="pf-u-ml-md" position={PreviewBadgePosition.inline} />
+              <TechnologyPreview />
             </TextContent>
           </PageSection>
           <PageSection variant={PageSectionVariants.light}>

--- a/src/ocm/components/clusters/NewClusterPage.tsx
+++ b/src/ocm/components/clusters/NewClusterPage.tsx
@@ -8,7 +8,12 @@ import {
   ButtonVariant,
   PageSection,
 } from '@patternfly/react-core';
-import { AlertsContextProvider, ErrorState, LoadingState } from '../../../common';
+import {
+  AlertsContextProvider,
+  ErrorState,
+  LoadingState,
+  TechnologyPreview,
+} from '../../../common';
 import ClusterBreadcrumbs from './ClusterBreadcrumbs';
 import { ClusterDefaultConfigurationProvider } from '../clusterConfiguration/ClusterDefaultConfigurationContext';
 import NewClusterWizard from '../clusterWizard/NewClusterWizard';
@@ -45,7 +50,10 @@ const NewClusterPage: React.FC = () => {
           <ClusterBreadcrumbs clusterName="New cluster" />
           <PageSection variant={PageSectionVariants.light}>
             <TextContent>
-              <Text component="h1">Install OpenShift with the Assisted Installer</Text>
+              <Text component="h1" className="pf-u-display-inline">
+                Install OpenShift with the Assisted Installer
+              </Text>
+              <TechnologyPreview />
             </TextContent>
           </PageSection>
           <PageSection variant={PageSectionVariants.light} isFilled>


### PR DESCRIPTION
Small improvements to tech/dev preview badges:

1. Added an 'i' icon to the badge
2. Added the tech preview badge to the new cluster page title
3. Added a popover to the tech preview badge in the cluster page title

Before:

![image](https://user-images.githubusercontent.com/22211154/144312977-6ebaa258-5cc8-444c-ae41-493ce2ee8cb3.png)

After:

![image](https://user-images.githubusercontent.com/22211154/144312731-b33e7d73-698d-49cc-b923-2ad30f5d0149.png)
