### PR TITLE
BZ-1986596 - SSH Key does not show up in active 'Generate Discovery ISO' modal after Generating Discovery ISO, followed by Edit ISO Configuration

### DIFF
--- a/src/ocm/components/clusterConfiguration/DiscoveryImageForm.tsx
+++ b/src/ocm/components/clusterConfiguration/DiscoveryImageForm.tsx
@@ -7,7 +7,9 @@ import {
   Cluster,
   DiscoveryImageConfigForm,
   DiscoveryImageFormValues,
+  ErrorState,
   InfraEnv,
+  LoadingState,
 } from '../../../common';
 import { updateCluster, forceReload } from '../../reducers/clusters';
 import { usePullSecret } from '../../hooks';
@@ -25,7 +27,7 @@ const DiscoveryImageForm: React.FC<DiscoveryImageFormProps> = ({
   onCancel,
   onSuccess,
 }) => {
-  const { infraEnv } = useInfraEnv(cluster.id);
+  const { infraEnv, error: infraEnvError, isLoading } = useInfraEnv(cluster.id);
   const cancelSourceRef = React.useRef<CancelTokenSource>();
   const dispatch = useDispatch();
   const ocmPullSecret = usePullSecret();
@@ -67,6 +69,12 @@ const DiscoveryImageForm: React.FC<DiscoveryImageFormProps> = ({
       }
     }
   };
+
+  if (isLoading) {
+    return <LoadingState></LoadingState>;
+  } else if (infraEnvError) {
+    return <ErrorState></ErrorState>;
+  }
 
   return (
     <DiscoveryImageConfigForm

--- a/src/ocm/services/DiscoveryImageFormService.ts
+++ b/src/ocm/services/DiscoveryImageFormService.ts
@@ -20,7 +20,7 @@ const DiscoveryImageFormService = {
       httpsProxy: formValues.httpsProxy,
       noProxy: formValues.noProxy,
       // TODO(mlibra): Does the user need to change pull-secret?
-      pullSecret: ocmPullSecret,
+      pullSecret: ocmPullSecret || undefined,
       sshPublicKey: formValues.sshPublicKey,
     };
 
@@ -31,7 +31,7 @@ const DiscoveryImageFormService = {
         noProxy: formValues.noProxy,
       },
       sshAuthorizedKey: formValues.sshPublicKey,
-      pullSecret: ocmPullSecret,
+      pullSecret: ocmPullSecret || undefined,
       staticNetworkConfig: formValues.staticNetworkConfig,
       imageType: formValues.imageType,
     };


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1986596

Default values for the `DiscoveryImageConfigForm` are taken from the infraEnv. Loading or Error components will get displayed in corresponding states.

Also, let's not set the `pullSecret` to an empty string, it causes too many issues. :slightly_smiling_face:

https://user-images.githubusercontent.com/87187179/144851877-3540b0ba-1aec-4f7b-a4e2-1c06b9302ad8.mp4

