### PR TITLE
MGMT-8412 - The events modal is not correctly formatted in Firefox

### DIFF
--- a/src/common/components/ui/table/wrappable.css
+++ b/src/common/components/ui/table/wrappable.css
@@ -1,3 +1,3 @@
 .table-no-padding {
-  --pf-c-table-cell--PaddingLeft: 0 !important;
+  --pf-c-table--m-compact--cell--first-last-child--PaddingLeft: 0 !important;
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-8412
Screenshots from Firefox:

before:
![image](https://user-images.githubusercontent.com/87187179/144877503-63b5ec81-f2cc-4076-a964-fb69d8882b73.png)

after:
![image](https://user-images.githubusercontent.com/87187179/144877376-46a2dcf2-84dd-4f71-8f4f-e0312ecd6bd8.png)
