### PR TITLE
minor fix to grammar

### DIFF
--- a/src/common/components/hosts/HostRequirements.tsx
+++ b/src/common/components/hosts/HostRequirements.tsx
@@ -52,7 +52,7 @@ const HostRequirements: React.FC<HostRequirementsProps> = ({
           </>
         )}
         <ListItem>
-          Also note that each hosts' disk write speed should meet the minimum requirements to run
+          Also note that each host's disk write speed should meet the minimum requirements to run
           OpenShift.{' '}
           <ExternalLink href={'https://access.redhat.com/solutions/4885641'}>
             Learn more


### PR DESCRIPTION
The word "host" is singular in this sentence, so the apostrophe should
go before the "s".