### PR TITLE
MGMT-8077: Add "disk encryption" to cluster details

### DIFF
--- a/src/ocm/components/clusterDetail/ClusterProperties.tsx
+++ b/src/ocm/components/clusterDetail/ClusterProperties.tsx
@@ -35,7 +35,7 @@ const getManagementType = (clusterManagementType: boolean | undefined): string =
   return managementType;
 };
 
-const getDiskEncryptionType = (diskEncryption: DiskEncryption['enableOn']) => {
+const getDiskEncryptionEnabledOnStatus = (diskEncryption: DiskEncryption['enableOn']) => {
   let diskEncryptionType = null;
   switch (diskEncryption) {
     case 'all':

--- a/src/ocm/components/clusterDetail/ClusterProperties.tsx
+++ b/src/ocm/components/clusterDetail/ClusterProperties.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { GridItem, TextContent, Text } from '@patternfly/react-core';
-import { Cluster, isSingleNodeCluster, DetailList, DetailItem } from '../../../common';
+import {
+  Cluster,
+  isSingleNodeCluster,
+  DetailList,
+  DetailItem,
+  DiskEncryption,
+} from '../../../common';
 import {
   selectClusterNetworkCIDR,
   selectClusterNetworkHostPrefix,
@@ -29,20 +35,24 @@ const getManagementType = (clusterManagementType: boolean | undefined): string =
   return managementType;
 };
 
-const getDiskEncryptionType = (diskEncryption: string | undefined): string => {
-  let diskEncryptionType = '-';
+const getDiskEncryptionType = (diskEncryption: DiskEncryption['enableOn']) => {
+  let diskEncryptionType = null;
   switch (diskEncryption) {
     case 'all':
-      diskEncryptionType = 'Enabled on control plane nodes & workers';
+      diskEncryptionType = (
+        <>
+          Enabled on control plane nodes
+          <br />
+          Enabled on workers
+        </>
+      );
       break;
     case 'masters':
-      diskEncryptionType = 'Enabled on control plane nodes';
+      diskEncryptionType = <>Enabled on control plane nodes</>;
       break;
     case 'workers':
-      diskEncryptionType = 'Enabled on workers';
+      diskEncryptionType = <>Enabled on workers</>;
       break;
-    case 'none':
-      diskEncryptionType = 'Disabled';
   }
   return diskEncryptionType;
 };
@@ -63,7 +73,6 @@ const ClusterProperties: React.FC<ClusterPropertiesProps> = ({ cluster }) => (
           value={cluster.apiVip}
           isHidden={isSingleNodeCluster(cluster)}
         />
-
         <DetailItem
           title="Ingress virtual IP"
           value={cluster.ingressVip}
@@ -72,6 +81,7 @@ const ClusterProperties: React.FC<ClusterPropertiesProps> = ({ cluster }) => (
         <DetailItem
           title="Disk encryption"
           value={getDiskEncryptionType(cluster.diskEncryption?.enableOn)}
+          isHidden={cluster.diskEncryption?.enableOn === 'none'}
         />
       </DetailList>
     </GridItem>

--- a/src/ocm/components/clusterDetail/ClusterProperties.tsx
+++ b/src/ocm/components/clusterDetail/ClusterProperties.tsx
@@ -80,7 +80,7 @@ const ClusterProperties: React.FC<ClusterPropertiesProps> = ({ cluster }) => (
         />
         <DetailItem
           title="Disk encryption"
-          value={getDiskEncryptionType(cluster.diskEncryption?.enableOn)}
+          value={getDiskEncryptionEnabledOnStatus(cluster.diskEncryption?.enableOn)}
           isHidden={cluster.diskEncryption?.enableOn === 'none'}
         />
       </DetailList>

--- a/src/ocm/components/clusterDetail/ClusterProperties.tsx
+++ b/src/ocm/components/clusterDetail/ClusterProperties.tsx
@@ -29,6 +29,24 @@ const getManagementType = (clusterManagementType: boolean | undefined): string =
   return managementType;
 };
 
+const getDiskEncryptionType = (diskEncryption: string | undefined): string => {
+  let diskEncryptionType = '-';
+  switch (diskEncryption) {
+    case 'all':
+      diskEncryptionType = 'Enabled on control plane nodes & workers';
+      break;
+    case 'masters':
+      diskEncryptionType = 'Enabled on control plane nodes';
+      break;
+    case 'workers':
+      diskEncryptionType = 'Enabled on workers';
+      break;
+    case 'none':
+      diskEncryptionType = 'Disabled';
+  }
+  return diskEncryptionType;
+};
+
 const ClusterProperties: React.FC<ClusterPropertiesProps> = ({ cluster }) => (
   <>
     <GridItem>
@@ -50,6 +68,10 @@ const ClusterProperties: React.FC<ClusterPropertiesProps> = ({ cluster }) => (
           title="Ingress virtual IP"
           value={cluster.ingressVip}
           isHidden={isSingleNodeCluster(cluster)}
+        />
+        <DetailItem
+          title="Disk encryption"
+          value={getDiskEncryptionType(cluster.diskEncryption?.enableOn)}
         />
       </DetailList>
     </GridItem>


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-8077

I added info about the disk encryption in the cluster details. 

***Please note** I had to make a small change in comparison to the mock (image of the mock can be found in the jira link above). 
 In the mock, in case the diskEncyription is enabled for workers and masters the information is divided into two lines. 
In the project file trying to use <br> converts '<' to &lt and '>' to &gt, separating DetailsItem creates too big of a gap and using '\n' is not possible.

I'll be happy to hear if that's OK or other suggestions. 

![image](https://user-images.githubusercontent.com/69599321/145278277-95f71c91-d521-42ca-bb10-8809195f8338.png)
