### PR TITLE
MGMT-8160: Add onUnbindHost action

### DIFF
--- a/src/cim/components/Agent/tableUtils.tsx
+++ b/src/cim/components/Agent/tableUtils.tsx
@@ -302,7 +302,7 @@ export const useAgentsTable = (
         canUnbindHost: canUnbindHost
           ? (host: Host) => {
               const agent = agents.find((a) => a.metadata?.uid === host.id);
-              return agent ? canUnbindHost(agent) : false;
+              return agent ? canUnbindHost(agent) : ['false'];
             }
           : undefined,
       },

--- a/src/cim/components/Agent/tableUtils.tsx
+++ b/src/cim/components/Agent/tableUtils.tsx
@@ -7,8 +7,8 @@ import AgentStatus from './AgentStatus';
 import { ActionsResolver, TableRow } from '../../../common/components/hosts/AITable';
 import { ClusterDeploymentHostsTablePropsActions } from '../ClusterDeployment/types';
 import { hostActionResolver } from '../../../common/components/hosts/tableUtils';
-import { getAIHosts } from '../helpers';
-import { AGENT_BMH_HOSTNAME_LABEL_KEY, INFRAENV_AGENTINSTALL_LABEL_KEY } from '../common';
+import { getAIHosts, getInfraEnvNameOfAgent } from '../helpers';
+import { AGENT_BMH_HOSTNAME_LABEL_KEY } from '../common';
 import { BareMetalHostK8sResource } from '../../types/k8s/bare-metal-host';
 import NetworkingStatus from '../status/NetworkingStatus';
 import { getAgentStatus, getBMHStatus } from '../helpers/status';
@@ -161,7 +161,7 @@ export const infraEnvColumn = (
     },
     cell: (host) => {
       const agent = agents.find((a) => a.metadata?.uid === host.id) as AgentK8sResource;
-      const infraEnvName = agent.metadata?.labels?.[INFRAENV_AGENTINSTALL_LABEL_KEY];
+      const infraEnvName = getInfraEnvNameOfAgent(agent);
 
       let title: React.ReactNode = infraEnvName || 'N/A';
       if (infraEnvName && getInfraEnvLink) {
@@ -230,6 +230,8 @@ export const useAgentsTable = (
     canEditRole,
     onSelect,
     onEditBMH,
+    onUnbindHost,
+    canUnbindHost,
   }: ClusterDeploymentHostsTablePropsActions,
   { agents, bmhs, infraEnv }: AgentsTableResources,
 ): [Host[], HostsTableActions, ActionsResolver<Host>] => {
@@ -290,6 +292,19 @@ export const useAgentsTable = (
             }
           : undefined,
         canEditBMH: (host: Host) => !!bmhs?.find((h) => h.metadata?.uid === host.id),
+        onUnbindHost: onUnbindHost
+          ? (host: Host) => {
+              const agent = agents.find((a) => a.metadata?.uid === host.id) as AgentK8sResource;
+              // const bmh = bmhs?.find((a) => a.metadata?.uid === host.id);
+              return onUnbindHost(agent);
+            }
+          : undefined,
+        canUnbindHost: canUnbindHost
+          ? (host: Host) => {
+              const agent = agents.find((a) => a.metadata?.uid === host.id);
+              return agent ? canUnbindHost(agent) : false;
+            }
+          : undefined,
       },
     ],
     [
@@ -302,6 +317,8 @@ export const useAgentsTable = (
       agents,
       onSelect,
       onEditBMH,
+      onUnbindHost,
+      canUnbindHost,
       bmhs,
       infraEnv,
     ],

--- a/src/cim/components/ClusterDeployment/ClusterDeploymentHostsDiscoveryStep.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentHostsDiscoveryStep.tsx
@@ -13,7 +13,7 @@ import {
   ClusterDeploymentHostsDiscoveryValues,
 } from './types';
 import ClusterDeploymentHostsDiscovery from './ClusterDeploymentHostsDiscovery';
-import { isAgentOfCluster } from './helpers';
+import { isAgentOfInfraEnv } from './helpers';
 
 type UseHostsDiscoveryFormikArgs = {
   agents: AgentK8sResource[];
@@ -55,24 +55,21 @@ export const useHostsDiscoveryFormik = ({
 const ClusterDeploymentHostsDiscoveryStep: React.FC<ClusterDeploymentHostsDiscoveryStepProps> = ({
   onClose,
   onSaveHostsDiscovery,
-  clusterDeployment,
   agentClusterInstall,
   agents: allAgents,
+  infraEnv,
   ...restProps
 }) => {
   const { addAlert } = useAlerts();
   const { setCurrentStepId } = React.useContext(ClusterDeploymentWizardContext);
 
-  const cdName = clusterDeployment?.metadata?.name;
-  const cdNamespace = clusterDeployment?.metadata?.namespace;
-
-  const clusterAgents = React.useMemo(
-    () => allAgents.filter((a) => isAgentOfCluster(a, cdName, cdNamespace)),
-    [allAgents, cdName, cdNamespace],
+  const infraEnvAgents = React.useMemo(
+    () => allAgents.filter((a) => isAgentOfInfraEnv(infraEnv, a)),
+    [allAgents, infraEnv],
   );
 
   const [initialValues, validationSchema] = useHostsDiscoveryFormik({
-    agents: clusterAgents,
+    agents: infraEnvAgents,
     agentClusterInstall,
   });
 
@@ -98,7 +95,7 @@ const ClusterDeploymentHostsDiscoveryStep: React.FC<ClusterDeploymentHostsDiscov
         const footer = (
           <ClusterDeploymentWizardFooter
             agentClusterInstall={agentClusterInstall}
-            agents={clusterAgents}
+            agents={infraEnvAgents}
             errorFields={getFormikErrorFields(errors, touched)}
             isSubmitting={isSubmitting}
             isNextDisabled={!isValid || isValidating || isSubmitting}
@@ -118,7 +115,8 @@ const ClusterDeploymentHostsDiscoveryStep: React.FC<ClusterDeploymentHostsDiscov
               <GridItem>
                 <ClusterDeploymentHostsDiscovery
                   agentClusterInstall={agentClusterInstall}
-                  agents={clusterAgents}
+                  agents={infraEnvAgents}
+                  infraEnv={infraEnv}
                   {...restProps}
                 />
               </GridItem>

--- a/src/cim/components/ClusterDeployment/helpers.ts
+++ b/src/cim/components/ClusterDeployment/helpers.ts
@@ -42,6 +42,16 @@ export const shouldShowClusterInstallationProgress = (
   ].includes(clusterStatus);
 };
 
+export const isInstallationInProgress = (agentClusterInstall: AgentClusterInstallK8sResource) => {
+  const [clusterStatus] = getClusterStatus(agentClusterInstall);
+  return [
+    'preparing-for-installation',
+    'installing',
+    'finalizing',
+    'installing-pending-user-action',
+  ].includes(clusterStatus);
+};
+
 export const isInstallationReady = (agentClusterInstall: AgentClusterInstallK8sResource) => {
   const [clusterStatus] = getClusterStatus(agentClusterInstall);
   return [

--- a/src/cim/components/ClusterDeployment/helpers.ts
+++ b/src/cim/components/ClusterDeployment/helpers.ts
@@ -4,9 +4,10 @@ import { EventList } from '../../../common/api/types';
 import { AgentClusterInstallK8sResource, InfraEnvK8sResource } from '../../types/k8s';
 import { getClusterStatus } from '../helpers/status';
 import { getK8sProxyURL } from '../helpers/proxy';
+import { getInfraEnvNameOfAgent } from '../helpers/agents';
 import { EventListFetchProps } from '../../../common';
 import { ClusterDeploymentK8sResource, AgentK8sResource } from '../../types';
-import { INFRAENV_GENERATED_AI_FLOW, INFRAENV_AGENTINSTALL_LABEL_KEY } from '../common/constants';
+import { INFRAENV_GENERATED_AI_FLOW } from '../common/constants';
 
 export const shouldShowClusterDeploymentValidationOverview = (
   agentClusterInstall?: AgentClusterInstallK8sResource,
@@ -103,7 +104,7 @@ export const isCIMFlow = (clusterDeployment?: ClusterDeploymentK8sResource) =>
   ];
 
 export const isAgentOfInfraEnv = (infraEnv?: InfraEnvK8sResource, agent?: AgentK8sResource) =>
-  agent?.metadata?.labels?.[INFRAENV_AGENTINSTALL_LABEL_KEY] === infraEnv?.metadata?.name &&
+  getInfraEnvNameOfAgent(agent) === infraEnv?.metadata?.name &&
   agent?.metadata?.namespace === infraEnv?.metadata?.namespace;
 
 export const isAgentOfCluster = (agent: AgentK8sResource, cdName?: string, cdNamespace?: string) =>

--- a/src/cim/components/ClusterDeployment/types.ts
+++ b/src/cim/components/ClusterDeployment/types.ts
@@ -23,6 +23,8 @@ export type ClusterDeploymentHostsTablePropsActions = {
   onApprove?: (agent: AgentK8sResource) => void;
   onSelect?: (agent: AgentK8sResource, selected: boolean) => void;
   onEditBMH?: (bmh: BareMetalHostK8sResource) => void;
+  canUnbindHost?: (agent: AgentK8sResource) => boolean;
+  onUnbindHost?: (agent: AgentK8sResource) => void;
 };
 
 export type ClusterDeploymentWizardStepsType =
@@ -90,7 +92,7 @@ export type ClusterDeploymentHostsDiscoveryStepProps = Omit<
   ClusterDeploymentHostsDiscoveryProps,
   'onValuesChanged'
 > & {
-  clusterDeployment: ClusterDeploymentK8sResource;
+  // clusterDeployment: ClusterDeploymentK8sResource;
 
   onSaveHostsDiscovery: (values: ClusterDeploymentHostsDiscoveryValues) => Promise<string | void>;
   onClose: () => void;

--- a/src/cim/components/ClusterDeployment/types.ts
+++ b/src/cim/components/ClusterDeployment/types.ts
@@ -23,7 +23,7 @@ export type ClusterDeploymentHostsTablePropsActions = {
   onApprove?: (agent: AgentK8sResource) => void;
   onSelect?: (agent: AgentK8sResource, selected: boolean) => void;
   onEditBMH?: (bmh: BareMetalHostK8sResource) => void;
-  canUnbindHost?: (agent: AgentK8sResource) => [enabled: boolean, reason: string];
+  canUnbindHost?: (agent: AgentK8sResource) => [/* enabled */ boolean, /* reason */ string];
   onUnbindHost?: (agent: AgentK8sResource) => void;
 };
 

--- a/src/cim/components/ClusterDeployment/types.ts
+++ b/src/cim/components/ClusterDeployment/types.ts
@@ -23,7 +23,7 @@ export type ClusterDeploymentHostsTablePropsActions = {
   onApprove?: (agent: AgentK8sResource) => void;
   onSelect?: (agent: AgentK8sResource, selected: boolean) => void;
   onEditBMH?: (bmh: BareMetalHostK8sResource) => void;
-  canUnbindHost?: (agent: AgentK8sResource) => boolean;
+  canUnbindHost?: (agent: AgentK8sResource) => [enabled: boolean, reason: string];
   onUnbindHost?: (agent: AgentK8sResource) => void;
 };
 

--- a/src/cim/components/InfraEnv/AgentAlerts.tsx
+++ b/src/cim/components/InfraEnv/AgentAlerts.tsx
@@ -1,6 +1,7 @@
 import { Alert, AlertVariant } from '@patternfly/react-core';
 import * as React from 'react';
-import { INFRAENV_AGENTINSTALL_LABEL_KEY, getInfraEnvDocs } from '../common/constants';
+import { getInfraEnvDocs } from '../common/constants';
+import { getInfraEnvNameOfAgent } from '../helpers';
 import { BareMetalHostK8sResource, InfraEnvK8sResource } from '../../types';
 
 type AgentAlertsProps = {
@@ -15,7 +16,7 @@ const AgentAlerts: React.FC<AgentAlertsProps> = ({ infraEnv, bareMetalHosts, doc
     bareMetalHosts?.filter(
       (h) =>
         h.metadata?.namespace === infraEnv.metadata?.namespace &&
-        h.metadata?.labels?.[INFRAENV_AGENTINSTALL_LABEL_KEY] === infraEnv.metadata?.name,
+        getInfraEnvNameOfAgent(h) === infraEnv.metadata?.name,
     );
 
   return infraBMHs?.some((bmh) => !bmh.status) ? (

--- a/src/cim/components/InfraEnv/utils.ts
+++ b/src/cim/components/InfraEnv/utils.ts
@@ -48,6 +48,7 @@ export const getAgentClusterInstall = ({
       namespace,
     },
     spec: {
+      holdInstallation: true,
       clusterDeploymentRef: clusterDeploymentName
         ? {
             name: clusterDeploymentName,

--- a/src/cim/components/helpers/agentClusterInstall.ts
+++ b/src/cim/components/helpers/agentClusterInstall.ts
@@ -1,4 +1,26 @@
-import { AgentClusterInstallK8sResource } from '../../types/k8s/agent-cluster-install';
+import { AgentClusterInstallK8sResource, AgentK8sResource } from '../../types/k8s';
+import { getClusterNameOfAgent } from './agents';
 
 export const getIsSNOCluster = (agentClusterInstall: AgentClusterInstallK8sResource) =>
   agentClusterInstall?.spec?.provisionRequirements?.controlPlaneAgents === 1;
+
+export const getAgentClusterInstallOfAgent = (
+  agentClusterInstalls: AgentClusterInstallK8sResource[],
+  agent?: AgentK8sResource,
+) => {
+  if (!agent) {
+    return undefined;
+  }
+
+  const cdName = getClusterNameOfAgent(agent);
+  if (!cdName) {
+    return undefined;
+  }
+
+  return agentClusterInstalls.find((aci) => {
+    const ownerReference = aci.metadata?.ownerReferences?.find(
+      (or) => or.kind === 'ClusterDeployment' && or.name === cdName,
+    );
+    return !!ownerReference;
+  });
+};

--- a/src/cim/components/helpers/agents.ts
+++ b/src/cim/components/helpers/agents.ts
@@ -1,7 +1,8 @@
 import { AgentStatus } from './status';
 import { Host, HostStage } from '../../../common/api/types';
-import { AgentK8sResource } from '../../types';
+import { AgentK8sResource, BareMetalHostK8sResource } from '../../types';
 import { getAgentStatus } from './status';
+import { INFRAENV_AGENTINSTALL_LABEL_KEY } from '../common';
 
 const AGENT_FOR_SELECTION_STATUSES: AgentStatus[] = [
   'known',
@@ -69,3 +70,9 @@ export const getAgentProgressStages = (agent: AgentK8sResource): HostStage[] => 
 };
 
 export const getAgentProgress = (agent: AgentK8sResource) => agent.status?.progress;
+
+export const getInfraEnvNameOfAgent = (resource?: AgentK8sResource | BareMetalHostK8sResource) =>
+  resource?.metadata?.labels?.[INFRAENV_AGENTINSTALL_LABEL_KEY];
+
+export const getClusterNameOfAgent = (agent?: AgentK8sResource) =>
+  agent?.spec?.clusterDeploymentName?.name;

--- a/src/cim/components/helpers/agents.ts
+++ b/src/cim/components/helpers/agents.ts
@@ -9,6 +9,7 @@ const AGENT_FOR_SELECTION_STATUSES: AgentStatus[] = [
   'known-unbound',
   'insufficient',
   'pending-for-input',
+  'binding',
 ];
 
 export const hostToAgent = (agents: AgentK8sResource[] = [], host: Host) =>

--- a/src/cim/components/helpers/index.ts
+++ b/src/cim/components/helpers/index.ts
@@ -8,3 +8,4 @@ export * from './agents';
 export * from './clusterDeployment';
 export * from './agentClusterInstall';
 export * from './clusterDeployment';
+export * from './infraEnv';

--- a/src/cim/components/helpers/infraEnv.ts
+++ b/src/cim/components/helpers/infraEnv.ts
@@ -1,0 +1,4 @@
+import { InfraEnvK8sResource } from '../../types';
+
+export const isAIFlowInfraEnv = (infraEnv?: InfraEnvK8sResource): boolean =>
+  !!infraEnv?.spec?.clusterRef?.name;

--- a/src/cim/components/helpers/status.ts
+++ b/src/cim/components/helpers/status.ts
@@ -116,7 +116,7 @@ export const getAgentStatus = (
   let state: AgentStatus = agent.status?.debugInfo?.state || getInsufficientState(agent);
 
   const conditions = getFailingResourceConditions(agent, REQUIRED_AGENT_CONDITION_TYPES);
-  let validationsInfo = agent.status?.hostValidationInfo;
+  let validationsInfo = agent.status?.validationsInfo;
   if (conditions?.length) {
     validationsInfo = {
       infrastructure: conditions.map(

--- a/src/cim/components/helpers/status.ts
+++ b/src/cim/components/helpers/status.ts
@@ -128,17 +128,17 @@ export const getAgentStatus = (
       ),
     };
   }
+
   if (!excludeDiscovered && !agent.spec.approved) {
-    // TODO(mlibra): Add icon
     state = 'Discovered';
   } else if (
-    state !== 'binding' &&
+    !['binding', 'unbinding-pending-user-action'].includes(state) &&
     validationsInfo?.infrastructure &&
-    /* state === disconnected for this condition already, so let's keep it */
     !validationsInfo.infrastructure.find((c) => c.id.toLowerCase() === 'connected')
   ) {
     state = getInsufficientState(agent);
   }
+
   return [state, agent.status?.debugInfo?.stateInfo || '', validationsInfo || {}];
 };
 

--- a/src/cim/components/helpers/toAssisted.ts
+++ b/src/cim/components/helpers/toAssisted.ts
@@ -6,8 +6,13 @@ import { AgentClusterInstallK8sResource } from '../../types/k8s/agent-cluster-in
 import { getAgentStatus, getClusterStatus } from './status';
 import { getHostNetworks } from './network';
 import { BareMetalHostK8sResource, InfraEnvK8sResource } from '../../types';
-import { AGENT_BMH_HOSTNAME_LABEL_KEY, INFRAENV_AGENTINSTALL_LABEL_KEY } from '../common';
-import { getAgentProgress, getAgentProgressStages, getAgentRole } from './agents';
+import { AGENT_BMH_HOSTNAME_LABEL_KEY } from '../common';
+import {
+  getAgentProgress,
+  getAgentProgressStages,
+  getAgentRole,
+  getInfraEnvNameOfAgent,
+} from './agents';
 
 export const getAIHosts = (
   agents: AgentK8sResource[],
@@ -62,7 +67,7 @@ export const getAIHosts = (
       ? bmhs
           ?.filter((h) =>
             h.metadata?.namespace === infraEnv.metadata?.namespace &&
-            h.metadata?.labels?.[INFRAENV_AGENTINSTALL_LABEL_KEY] === infraEnv.metadata?.name &&
+            getInfraEnvNameOfAgent(h) === infraEnv.metadata?.name &&
             h.metadata?.name
               ? !bmhAgents.includes(h.metadata.name)
               : true,

--- a/src/common/components/hosts/HostStatus.tsx
+++ b/src/common/components/hosts/HostStatus.tsx
@@ -88,6 +88,7 @@ const getStatusIcon = (status: Host['status'] | 'Discovered') => {
     case 'installing-in-progress':
     case 'resetting':
     case 'unbinding':
+    case 'unbinding-pending-user-action':
       icon = <InProgressIcon />;
       break;
     case 'added-to-existing-cluster':
@@ -167,6 +168,15 @@ const HostStatusPopoverContent: React.FC<HostStatusPopoverContentProps> = ({ ...
       <TextContent>
         <Text>{statusDetails}</Text>
         <HostProgress host={host} />
+      </TextContent>
+    );
+  }
+
+  if (['unbinding-pending-user-action'].includes(status)) {
+    // No additional error messages shown
+    return (
+      <TextContent>
+        <Text>{statusDetails}</Text>
       </TextContent>
     );
   }
@@ -262,7 +272,10 @@ const HostStatus: React.FC<HostStatusProps> = ({
 
   sublabel =
     sublabel ||
-    (['installing-pending-user-action', 'disconnected'].includes(status) && 'Action required') ||
+    (['installing-pending-user-action', 'disconnected', 'unbinding-pending-user-action'].includes(
+      status,
+    ) &&
+      'Action required') ||
     (status === 'added-to-existing-cluster' && 'Finish in console') ||
     undefined;
 

--- a/src/common/components/hosts/tableUtils.tsx
+++ b/src/common/components/hosts/tableUtils.tsx
@@ -491,7 +491,7 @@ export const hostActionResolver = ({
           <ActionTitle
             disabled={isDisabled}
             description={canUnbindHostResult?.[1]}
-            title="Unbind host"
+            title="Remove from the cluster"
           />
         ),
         id: `button-unbind-host-${hostname}`,

--- a/src/common/components/hosts/tableUtils.tsx
+++ b/src/common/components/hosts/tableUtils.tsx
@@ -374,6 +374,22 @@ export const macAddressColumn = (cluster: Cluster): TableRow<Host> => ({
   },
 });
 
+const ActionTitle: React.FC<{ disabled: boolean; description?: string; title: string }> = ({
+  title,
+  description,
+  disabled,
+}) => (
+  <>
+    {title}
+    {disabled && (
+      <>
+        <br />
+        {description}
+      </>
+    )}
+  </>
+);
+
 export const hostActionResolver = ({
   onInstallHost,
   canInstallHost,
@@ -464,11 +480,23 @@ export const hostActionResolver = ({
         onClick: () => onEditBMH(host),
       });
     }
-    if (onUnbindHost && canUnbindHost?.(host)) {
+
+    if (canUnbindHost) {
+      // skip at all if the callback is not provided
+      const canUnbindHostResult = canUnbindHost(host);
+      const isDisabled = !canUnbindHostResult?.[0];
+
       actions.push({
-        title: 'Unbind host',
+        title: (
+          <ActionTitle
+            disabled={isDisabled}
+            description={canUnbindHostResult?.[1]}
+            title="Unbind host"
+          />
+        ),
         id: `button-unbind-host-${hostname}`,
-        onClick: () => onUnbindHost(host),
+        onClick: () => !isDisabled && onUnbindHost && onUnbindHost(host),
+        disabled: isDisabled,
       });
     }
   }

--- a/src/common/components/hosts/tableUtils.tsx
+++ b/src/common/components/hosts/tableUtils.tsx
@@ -392,6 +392,8 @@ export const hostActionResolver = ({
   canDelete,
   onEditBMH,
   canEditBMH,
+  canUnbindHost,
+  onUnbindHost,
 }: HostsTableActions): ActionsResolver<Host> => (host) => {
   const actions = [];
   if (host) {
@@ -460,6 +462,13 @@ export const hostActionResolver = ({
         title: 'Edit BMC',
         id: `button-edit-bmh-host-${hostname}`,
         onClick: () => onEditBMH(host),
+      });
+    }
+    if (onUnbindHost && canUnbindHost?.(host)) {
+      actions.push({
+        title: 'Unbind host',
+        id: `button-unbind-host-${hostname}`,
+        onClick: () => onUnbindHost(host),
       });
     }
   }

--- a/src/common/components/hosts/types.ts
+++ b/src/common/components/hosts/types.ts
@@ -40,7 +40,7 @@ export type HostsTableActions = {
   canEditBMH?: (host: Host) => boolean;
   onSelect?: (host: Host, selected: boolean) => void;
   canEditHostname?: () => boolean;
-  canUnbindHost?: (host: Host) => boolean;
+  canUnbindHost?: (host: Host) => [enabled: boolean, reason: string];
   onUnbindHost?: (host: Host) => void;
 };
 

--- a/src/common/components/hosts/types.ts
+++ b/src/common/components/hosts/types.ts
@@ -40,7 +40,7 @@ export type HostsTableActions = {
   canEditBMH?: (host: Host) => boolean;
   onSelect?: (host: Host, selected: boolean) => void;
   canEditHostname?: () => boolean;
-  canUnbindHost?: (host: Host) => [enabled: boolean, reason: string];
+  canUnbindHost?: (host: Host) => [/* enabled */ boolean, /* reason */ string];
   onUnbindHost?: (host: Host) => void;
 };
 

--- a/src/common/components/hosts/types.ts
+++ b/src/common/components/hosts/types.ts
@@ -40,6 +40,8 @@ export type HostsTableActions = {
   canEditBMH?: (host: Host) => boolean;
   onSelect?: (host: Host, selected: boolean) => void;
   canEditHostname?: () => boolean;
+  canUnbindHost?: (host: Host) => boolean;
+  onUnbindHost?: (host: Host) => void;
 };
 
 export type HostNetworkingStatusComponentProps = {

--- a/src/common/config/constants.ts
+++ b/src/common/config/constants.ts
@@ -69,9 +69,9 @@ export const CLUSTER_STATUS_LABELS: { [key in Cluster['status']]: string } = {
 };
 
 export const HOST_STATUS_LABELS: { [key in Host['status']]: string } = {
-  'unbinding-pending-user-action': 'Unbinding',
+  'unbinding-pending-user-action': 'Removing from cluster',
   'preparing-failed': 'Preparing step failed',
-  unbinding: 'Unbinding',
+  unbinding: 'Removing from cluster',
   'disabled-unbound': 'Disabled',
   'disconnected-unbound': 'Disconnected',
   'discovering-unbound': 'Discovering',
@@ -114,9 +114,9 @@ export const HOST_STATUS_DETAILS: { [key in Host['status']]: string } = {
   'unbinding-pending-user-action':
     'This host is being removed from the cluster. To finish, reboot the host with the infrastructure environment ISO.',
   'preparing-failed': 'Preparing step failed',
-  unbinding: 'This host is being unbound from the cluster.',
+  unbinding: 'This host is being removed from the cluster.',
   'disabled-unbound':
-    'This host was manually disabled and can not be included in the cluster. Enable this host to make it available again.',
+    'This host was manually removed from a cluster and can not be included in another one. Enable this host to make it available again.',
   'disconnected-unbound':
     'This host has lost its connection to the installer and can not be included in the cluster unless connectivity is restored.',
   'discovering-unbound':
@@ -125,7 +125,7 @@ export const HOST_STATUS_DETAILS: { [key in Host['status']]: string } = {
     'This host does not meet the minimum hardware or networking requirements and can not be included in the cluster.',
   'known-unbound':
     'This host meets the minimum hardware and networking requirements and can be included in the cluster.',
-  binding: 'This host is being bound to the cluster.',
+  binding: 'This host is being added to the cluster.',
   discovering:
     'This host is transmitting its hardware and networking information to the installer. Please wait while this information is received.',
   'pending-for-input': '',

--- a/src/common/config/constants.ts
+++ b/src/common/config/constants.ts
@@ -69,7 +69,7 @@ export const CLUSTER_STATUS_LABELS: { [key in Cluster['status']]: string } = {
 };
 
 export const HOST_STATUS_LABELS: { [key in Host['status']]: string } = {
-  'unbinding-pending-user-action': 'Unbinding, pending user action',
+  'unbinding-pending-user-action': 'Unbinding',
   'preparing-failed': 'Preparing step failed',
   unbinding: 'Unbinding',
   'disabled-unbound': 'Disabled',
@@ -111,7 +111,8 @@ export const CLUSTER_FIELD_LABELS: { [key in string]: string } = {
 };
 
 export const HOST_STATUS_DETAILS: { [key in Host['status']]: string } = {
-  'unbinding-pending-user-action': 'Unbinding, pending user action',
+  'unbinding-pending-user-action':
+    'This host is being removed from the cluster. To finish, reboot the host with the infrastructure environment ISO.',
   'preparing-failed': 'Preparing step failed',
   unbinding: 'This host is being unbound from the cluster.',
   'disabled-unbound':


### PR DESCRIPTION
Depends on:
- [ ] #1025 

TODO:
- [x] Tweak host statuses and their description
- [x] implement `canUnbindHost`
- [x] discuss/handle Node deletion via cluster's API - on Slack; will be handled by backend
- [x] List all infraEnv agents (not only clusterDeploymentRef) on the Edit AI Discovery page
- [x] `canDeleteHost` should be `false` during host's installation
- [ ] verify on Bare Metal
- [x] Clarify naming - to use `Unbind host` or `Remove host`? Mind existing `Delete host` action;
  - [x] _Resolution_: We have `Delete host` and `Remove from cluster` actions 
  - [x] show disabled `Unbind action` with additional description of **why**
- [x] enhance `canUnbindAgent` for master-node/worker-node count check (3 masters, no single worker)
- [x] reset Agent's role on Unbind
- [ ] fix setting of  agentClusterInstalls' provisionRequirements - test for >3 hosts (so far failing on expecting exactly 3 agents only) - agentClusterInstall?.spec?.provisionRequirements?.workerAgents -- **deferred to a follow-up**
