### PR TITLE
BZ-1959700 - When clicking on "install ready hosts" in day2 - the GUI shows no feedback for a long time

### DIFF
--- a/src/ocm/components/AddHosts/AddHosts.tsx
+++ b/src/ocm/components/AddHosts/AddHosts.tsx
@@ -72,7 +72,7 @@ const AddHosts: React.FC = () => {
                 variant={ButtonVariant.primary}
                 name="install"
                 onClick={handleHostsInstall}
-                isDisabled={getReadyHostCount(cluster) <= 0 || isSubmitting}
+                isDisabled={isSubmitting || getReadyHostCount(cluster) <= 0}
               >
                 Install ready hosts
               </ToolbarButton>


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1959700