### PR TITLE
MGMT-8565: "Edit pull secret" checked by default in OCM

### DIFF
--- a/src/ocm/hooks/usePullSecret.ts
+++ b/src/ocm/hooks/usePullSecret.ts
@@ -3,7 +3,7 @@ import { getErrorMessage, handleApiError, ocmClient } from '../api';
 import { useAlerts } from '../../common';
 
 export default function usePullSecret() {
-  const [pullSecret, setPullSecret] = React.useState<string>('');
+  const [pullSecret, setPullSecret] = React.useState<string>();
   const { addAlert } = useAlerts();
 
   const getPullSecret = React.useCallback(async () => {


### PR DESCRIPTION
root cause: loading state didn't apply while pull secret was requested since the default was an empty string instead of undefined