### PR TITLE
Rename Discovered host status to discovered to align the status naming

### DIFF
--- a/src/cim/components/helpers/agents.ts
+++ b/src/cim/components/helpers/agents.ts
@@ -10,6 +10,8 @@ const AGENT_FOR_SELECTION_STATUSES: AgentStatus[] = [
   'insufficient',
   'pending-for-input',
   'binding',
+  'unbinding',
+  'discovering',
 ];
 
 export const hostToAgent = (agents: AgentK8sResource[] = [], host: Host) =>

--- a/src/cim/components/helpers/status.ts
+++ b/src/cim/components/helpers/status.ts
@@ -104,7 +104,7 @@ export const getAgentStatusFromConditions = (agent: AgentK8sResource): [Host['st
   return ['insufficient', 'Unexpected Agent conditions.'];
 };
 
-export type AgentStatus = Host['status'] | 'Discovered';
+export type AgentStatus = Host['status'] | 'discovered';
 
 const getInsufficientState = (agent: AgentK8sResource) =>
   agent?.spec?.clusterDeploymentName?.name ? 'insufficient' : 'insufficient-unbound';
@@ -130,7 +130,7 @@ export const getAgentStatus = (
   }
 
   if (!excludeDiscovered && !agent.spec.approved) {
-    state = 'Discovered';
+    state = 'discovered';
   } else if (
     !['binding', 'unbinding-pending-user-action'].includes(state) &&
     validationsInfo?.infrastructure &&

--- a/src/common/components/hosts/HostStatus.tsx
+++ b/src/common/components/hosts/HostStatus.tsx
@@ -48,10 +48,10 @@ import { toSentence } from '../ui/table/utils';
 import { RenderIf } from '../ui';
 import { HostStatusProps } from './types';
 
-const getStatusIcon = (status: Host['status'] | 'Discovered') => {
+const getStatusIcon = (status: Host['status'] | 'discovered') => {
   let icon = null;
   switch (status) {
-    case 'Discovered':
+    case 'discovered':
     case 'discovering':
     case 'discovering-unbound':
       icon = <ConnectedIcon />;
@@ -120,7 +120,7 @@ const withProgress = (
 };
 
 type HostStatusPopoverContentProps = ValidationInfoActionProps & {
-  statusOverride?: Host['status'] | 'Discovered';
+  statusOverride?: Host['status'] | 'discovered';
   validationsInfo: ValidationsInfo;
 };
 
@@ -286,7 +286,7 @@ const HostStatus: React.FC<HostStatusProps> = ({
       {icon && <FlexItem>{icon}</FlexItem>}
 
       <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsXs' }}>
-        {!sublabel && status !== 'Discovered' ? (
+        {!sublabel && status !== 'discovered' ? (
           <WithHostStatusPopover
             hideOnOutsideClick={!keepOnOutsideClick}
             host={host}

--- a/src/common/components/hosts/types.ts
+++ b/src/common/components/hosts/types.ts
@@ -54,6 +54,6 @@ export type HostStatusProps = AdditionNtpSourcePropsType & {
   host: Host;
   validationsInfo: ValidationsInfo;
   onEditHostname?: () => void;
-  statusOverride?: Host['status'] | 'Discovered';
+  statusOverride?: Host['status'] | 'discovered';
   sublabel?: string;
 };

--- a/src/common/config/constants.ts
+++ b/src/common/config/constants.ts
@@ -68,7 +68,7 @@ export const CLUSTER_STATUS_LABELS: { [key in Cluster['status']]: string } = {
   'adding-hosts': 'Adding hosts',
 };
 
-export const HOST_STATUS_LABELS: { [key in Host['status']]: string } = {
+export const HOST_STATUS_LABELS: { [key in Host['status'] | 'discovered']: string } = {
   'unbinding-pending-user-action': 'Removing from cluster',
   'preparing-failed': 'Preparing step failed',
   unbinding: 'Removing from cluster',
@@ -79,6 +79,7 @@ export const HOST_STATUS_LABELS: { [key in Host['status']]: string } = {
   'known-unbound': 'Ready',
   binding: 'Binding',
   discovering: 'Discovering',
+  discovered: 'Discovered',
   'pending-for-input': 'Pending input',
   known: 'Ready',
   disconnected: 'Disconnected',
@@ -110,7 +111,7 @@ export const CLUSTER_FIELD_LABELS: { [key in string]: string } = {
   SNODisclaimer: 'Single Node OpenShift disclaimer',
 };
 
-export const HOST_STATUS_DETAILS: { [key in Host['status']]: string } = {
+export const HOST_STATUS_DETAILS: { [key in Host['status'] | 'discovered']: string } = {
   'unbinding-pending-user-action':
     'This host is being removed from the cluster. To finish, reboot the host with the infrastructure environment ISO.',
   'preparing-failed': 'Preparing step failed',
@@ -128,6 +129,7 @@ export const HOST_STATUS_DETAILS: { [key in Host['status']]: string } = {
   binding: 'This host is being added to the cluster.',
   discovering:
     'This host is transmitting its hardware and networking information to the installer. Please wait while this information is received.',
+  discovered: 'The host has been discovered and needs to be approved to before further use.',
   'pending-for-input': '',
   known:
     'This host meets the minimum hardware and networking requirements and will be included in the cluster.',


### PR DESCRIPTION
- Rename `Discovered` host status to `discovered` to align the status naming
- Add unbinding and discovering status to states valid for host selection

Depends on https://github.com/openshift-assisted/assisted-ui-lib/pull/1017