### PR TITLE
MGMT-8521: Host progress step popover displays 'undefined' in beginning of installation

### DIFF
--- a/src/common/components/hosts/utils.ts
+++ b/src/common/components/hosts/utils.ts
@@ -97,7 +97,13 @@ export const canInstallHost = (cluster: Cluster, hostStatus: Host['status']) =>
 export const getHostProgressStages = (host: Host) => host.progressStages || [];
 
 export const getHostProgress = (host: Host) =>
-  host.progress || { currentStage: 'Starting installation', progressInfo: undefined };
+  host.progress?.currentStage
+    ? host.progress
+    : {
+        currentStage: 'Starting installation',
+        progressInfo: undefined,
+        installationPercentage: undefined,
+      };
 
 export const getHostProgressStageNumber = (host: Host) => {
   const stages = getHostProgressStages(host);


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-8521
bug caused by the progress field of the host not being empty but not containing the currentStage.
this happens in the beginning of installation.
this fix is just to return to behavior before v2.
the proper behavior is that the popover doesn't appear at all in this case, which will take longer to implement.