### PR TITLE
MGMT-8678: Deprecate the "Developer Preview" badge in assisted installer

### DIFF
--- a/src/common/components/featureSupportLevels/FeatureSupportLevelBadge.tsx
+++ b/src/common/components/featureSupportLevels/FeatureSupportLevelBadge.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FeatureId, SupportLevel, isPreviewSupportLevel } from '../../types';
-import { TechnologyPreview, DeveloperPreview } from '../ui/PreviewBadge';
+import { TechnologyPreview } from '../ui/PreviewBadge';
 import FeatureSupportLevelContext from './FeatureSupportLevelContext';
 
 export type SupportLevelBadgeProps = {
@@ -23,11 +23,7 @@ const FeatureSupportLevelBadge: React.FC<SupportLevelBadgeProps> = ({
     return null;
   }
   const testId = `${featureId}-support-level`;
-  return supportLevel === 'tech-preview' ? (
-    <TechnologyPreview testId={testId} />
-  ) : (
-    <DeveloperPreview testId={testId} />
-  );
+  return <TechnologyPreview testId={testId} />;
 };
 
 export default FeatureSupportLevelBadge;

--- a/src/common/components/ui/PreviewBadge.tsx
+++ b/src/common/components/ui/PreviewBadge.tsx
@@ -5,12 +5,10 @@ import { TECH_SUPPORT_LEVEL_LINK } from '../../config/constants';
 import ExternalLink from './ExternalLink';
 import { WithTestID } from '../../types';
 
-export type DeveloperPreviewProps = {
+export type TechnologyPreviewProps = {
   position?: PreviewBadgePosition;
   className?: string;
 } & WithTestID;
-
-export type TechnologyPreviewProps = DeveloperPreviewProps;
 
 export enum PreviewBadgePosition {
   default,
@@ -18,7 +16,7 @@ export enum PreviewBadgePosition {
   inlineRight,
 }
 
-type PreviewBadgeProps = DeveloperPreviewProps & {
+type PreviewBadgeProps = TechnologyPreviewProps & {
   text: string;
   externalLink?: string;
   popoverText: string;
@@ -68,21 +66,13 @@ const PreviewBadge: React.FC<PreviewBadgeProps> = ({
   );
 };
 
-const popoverTexts = {
-  'tech-preview': `Technology preview features provide early access to upcoming product innovations, 
-  enabling you to test functionality and provide feedback during the development process.`,
-  'dev-preview': `Developer Preview features provide early access to upcoming innovations and contain 
-  a functional set of features that Red Hat is encouraging customers to use and provide feedback on.`,
-};
-
-export const DeveloperPreview: React.FC<DeveloperPreviewProps> = (props) => (
-  <PreviewBadge text="Developer Preview" popoverText={popoverTexts['dev-preview']} {...props} />
-);
+const popoverText = `Technology preview features provide early access to upcoming product innovations, 
+  enabling you to test functionality and provide feedback during the development process.`;
 
 export const TechnologyPreview: React.FC<TechnologyPreviewProps> = (props) => (
   <PreviewBadge
     text="Technology Preview"
-    popoverText={popoverTexts['tech-preview']}
+    popoverText={popoverText}
     externalLink={TECH_SUPPORT_LEVEL_LINK}
     {...props}
   />

--- a/src/ocm/components/featureSupportLevels/ReviewClusterFeatureSupportLevels.tsx
+++ b/src/ocm/components/featureSupportLevels/ReviewClusterFeatureSupportLevels.tsx
@@ -29,40 +29,25 @@ const getFeatureReviewText = (featureId: FeatureId): string => {
   }
 };
 
-const getPreviewSupportLevelTitle = (supportLevel: PreviewSupportLevel) => {
-  if (supportLevel === 'dev-preview') {
-    return 'Developer Preview Features';
-  }
+const getPreviewSupportLevelTitle = () => {
   return <ExternalLink href={TECH_SUPPORT_LEVEL_LINK}>Technology Preview Features</ExternalLink>;
 };
 
 const getPreviewFeatureList = (supportLevelMap: FeatureIdToSupportLevel) => {
-  const previewSupportLevels: { [key in PreviewSupportLevel]: FeatureId[] } = {
-    'tech-preview': [],
-    'dev-preview': [],
-  };
+  const previewFeatureIds: FeatureId[] = [];
   for (const [featureId, supportLevel] of Object.entries(supportLevelMap)) {
     if (!isPreviewSupportLevel(supportLevel)) {
       continue;
     }
-    previewSupportLevels[supportLevel].push(featureId as FeatureId);
+    previewFeatureIds.push(featureId as FeatureId);
   }
-  let supportLevel: PreviewSupportLevel;
-  //Show only one preview support level list, first priority to developer preview features
-  if (previewSupportLevels['dev-preview'].length) {
-    supportLevel = 'dev-preview';
-  } else if (previewSupportLevels['tech-preview'].length) {
-    supportLevel = 'tech-preview';
-  } else {
-    return null;
-  }
-  const featureList = previewSupportLevels[supportLevel].map((featureId: FeatureId) => (
+  const featureList = previewFeatureIds.map((featureId: FeatureId) => (
     <TextListItem key={featureId}>{getFeatureReviewText(featureId)}</TextListItem>
   ));
   return (
     <>
       <TextListItem>
-        {getPreviewSupportLevelTitle(supportLevel)}
+        {getPreviewSupportLevelTitle()}
         <TextList>{featureList}</TextList>
       </TextListItem>
     </>


### PR DESCRIPTION
Following discussion with PM we agreed to treat developer preview features as technology preview in the UI