### PR TITLE
Add managedDomains prop to the ClusterDetailsFormFields

### DIFF
--- a/src/ocm/components/clusterWizard/ClusterDetailsForm.tsx
+++ b/src/ocm/components/clusterWizard/ClusterDetailsForm.tsx
@@ -106,6 +106,7 @@ const ClusterDetailsForm: React.FC<ClusterDetailsFormProps> = (props) => {
                   isSNOGroupDisabled={!!cluster}
                   defaultPullSecret={pullSecret}
                   isOcm={!!ocmClient}
+                  managedDomains={managedDomains}
                 />
               </GridItem>
             </Grid>


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-8537

A cluster with managed domains made the base domain field in the cluster details page to be rendered as an empty dropdown list.
The `managedDomains` data wasn't being passed down to the component.