### PR TITLE
BZ-1987340: issue with editing cluster ssh key

### DIFF
--- a/src/common/components/clusterConfiguration/ClusterSshKeyFields.tsx
+++ b/src/common/components/clusterConfiguration/ClusterSshKeyFields.tsx
@@ -28,7 +28,10 @@ const ClusterSshKeyFields: React.FC<ClusterSshKeyFieldsProps> = ({
   clusterSshKey,
   imageSshKey,
 }) => {
-  const [shareSshKey, setShareSshKey] = React.useState(false);
+  //shareSshKey shouldn't response to changes. imageSshKey stays the same, there's a loading state while it's requested
+  //clusterSshKey updating causes the textarea to disappear when the user clears it to edit it
+  const defaultShareSshKey = !!imageSshKey && (clusterSshKey === imageSshKey || !clusterSshKey);
+  const [shareSshKey, setShareSshKey] = React.useState(defaultShareSshKey);
   const { values, setFieldValue, errors, touched } = useFormikContext<
     Pick<NetworkConfigurationValues, 'sshPublicKey'>
   >();
@@ -40,12 +43,6 @@ const ClusterSshKeyFields: React.FC<ClusterSshKeyFieldsProps> = ({
       setFieldValue('sshPublicKey', trimSshPublicKey(values.sshPublicKey));
     }
   };
-
-  React.useEffect(() => {
-    if (imageSshKey && (clusterSshKey === imageSshKey || !clusterSshKey)) {
-      setShareSshKey(true);
-    }
-  }, [imageSshKey, clusterSshKey]);
 
   React.useEffect(() => {
     if (shareSshKey) {


### PR DESCRIPTION
[BZ-1987340](https://bugzilla.redhat.com/show_bug.cgi?id=1987340)

When trying to edit the cluster ssh key in the networking tab, if user clears it first to enter a new value, the text area disappears and reappears as false.
the root cause is that the UI unnecessarily responds to cluster polling
