### PR TITLE
Revert "MGMT-8463: SNO checkbox and OpenShift version misbehavior"

### DIFF
--- a/src/common/components/clusterConfiguration/OpenShiftVersionSelect.tsx
+++ b/src/common/components/clusterConfiguration/OpenShiftVersionSelect.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import { useFormikContext } from 'formik';
 import { ExclamationTriangleIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens';
 import { OPENSHIFT_LIFE_CYCLE_DATES_LINK } from '../../config';
+import { ClusterCreateParams } from '../../api';
 import { OpenshiftVersionOptionType } from '../../types';
-import { SelectField } from '../ui';
+import { isSNOSupportedVersion, SelectField } from '../ui';
 
 const OpenShiftLifeCycleDatesLink = () => (
   <a href={OPENSHIFT_LIFE_CYCLE_DATES_LINK} target="_blank" rel="noopener noreferrer">
@@ -31,15 +33,32 @@ type OpenShiftVersionSelectProps = {
   versions: OpenshiftVersionOptionType[];
 };
 const OpenShiftVersionSelect: React.FC<OpenShiftVersionSelectProps> = ({ versions }) => {
+  const {
+    values: { highAvailabilityMode, openshiftVersion },
+    setFieldValue,
+  } = useFormikContext<ClusterCreateParams>();
+
+  const selectedVersion = versions.find((v) => v.value === openshiftVersion) || versions[0];
+  React.useEffect(() => {
+    if (highAvailabilityMode === 'None' && !isSNOSupportedVersion(selectedVersion)) {
+      const firstSupportedVersionValue = versions.find(isSNOSupportedVersion)?.value;
+      setFieldValue('openshiftVersion', firstSupportedVersionValue);
+    }
+  }, [highAvailabilityMode, selectedVersion, setFieldValue, versions]);
+
   const selectOptions = React.useMemo(
     () =>
       versions
-        .filter((version) => version.supportLevel !== 'maintenance')
+        .filter(
+          (version) =>
+            version.supportLevel !== 'maintenance' &&
+            (highAvailabilityMode !== 'None' || isSNOSupportedVersion(version)),
+        )
         .map((version) => ({
           label: version.label,
           value: version.value,
         })),
-    [versions],
+    [versions, highAvailabilityMode],
   );
 
   return (

--- a/src/common/components/clusterConfiguration/SNOControlGroup.tsx
+++ b/src/common/components/clusterConfiguration/SNOControlGroup.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { useFormikContext } from 'formik';
 import { ClusterDetailsValues } from '../../../common/components/clusterWizard/types';
-import { isSNOSupportedVersion, SingleNodeCheckbox } from '../ui';
+import { SingleNodeCheckbox } from '../ui';
 import { OpenshiftVersionOptionType } from '../../types';
 import SNODisclaimer from './SNODisclaimer';
 import { getSNOSupportLevel } from './utils';
-import { Tooltip } from '@patternfly/react-core';
 
 type SNOControlGroupProps = {
   isDisabled?: boolean;
@@ -14,32 +13,21 @@ type SNOControlGroupProps = {
 };
 
 const SNOControlGroup = ({ versions, highAvailabilityMode, isDisabled }: SNOControlGroupProps) => {
-  const { values, setFieldValue } = useFormikContext<ClusterDetailsValues>();
+  const { values } = useFormikContext<ClusterDetailsValues>();
   const selectedVersion = versions.find((version) => version.value === values.openshiftVersion);
-  const [disable, setDisable] = React.useState(isDisabled);
 
   // TODO(jtomasek): use getFeatureSupport('sno', selectedVersion.version) to get support level of SNO feature
   // for selected version once the API is available
   // https://issues.redhat.com/browse/MGMT-7787
   const snoSupportLevel = getSNOSupportLevel(selectedVersion?.version);
 
-  React.useEffect(() => {
-    setDisable(isDisabled || (selectedVersion && !isSNOSupportedVersion(selectedVersion)));
-    if (disable) {
-      setFieldValue('highAvailabilityMode', 'Full');
-    }
-  }, [disable, isDisabled, selectedVersion, setFieldValue]);
-
   return (
-    <Tooltip
-      hidden={!disable}
-      content={'Single-Node OpenShift is not supported in this OpenShift version'}
-    >
-      <SingleNodeCheckbox name="highAvailabilityMode" versions={versions} isDisabled={disable} />
+    <>
+      <SingleNodeCheckbox name="highAvailabilityMode" versions={versions} isDisabled={isDisabled} />
       {highAvailabilityMode === 'None' && (
-        <SNODisclaimer isDisabled={disable} snoSupportLevel={snoSupportLevel} />
+        <SNODisclaimer isDisabled={isDisabled} snoSupportLevel={snoSupportLevel} />
       )}
-    </Tooltip>
+    </>
   );
 };
 

--- a/src/common/components/clusterWizard/ClusterDetailsFormFields.tsx
+++ b/src/common/components/clusterWizard/ClusterDetailsFormFields.tsx
@@ -100,6 +100,11 @@ export const ClusterDetailsFormFields: React.FC<ClusterDetailsFormFieldsProps> =
           isRequired
         />
       )}
+      <SNOControlGroup
+        isDisabled={isSNOGroupDisabled}
+        versions={versions}
+        highAvailabilityMode={highAvailabilityMode}
+      />
       {forceOpenshiftVersion ? (
         <StaticTextField name="openshiftVersion" label="OpenShift version" isRequired>
           OpenShift {forceOpenshiftVersion}
@@ -107,11 +112,6 @@ export const ClusterDetailsFormFields: React.FC<ClusterDetailsFormFieldsProps> =
       ) : (
         <OpenShiftVersionSelect versions={versions} />
       )}
-      <SNOControlGroup
-        isDisabled={isSNOGroupDisabled}
-        versions={versions}
-        highAvailabilityMode={highAvailabilityMode}
-      />
       {extensionAfter?.['openshiftVersion'] && extensionAfter['openshiftVersion']}
       {canEditPullSecret && <PullSecret isOcm={isOcm} defaultPullSecret={defaultPullSecret} />}
       {extensionAfter?.['pullSecret'] && extensionAfter['pullSecret']}


### PR DESCRIPTION
Reverts openshift-assisted/assisted-ui-lib#1037

Reverting due to a bug introduced by this PR when dealing with an existing cluster. Details are included in the Jira issue.