### PR TITLE
NO-ISSUE: Replaces hard-coded SNO support level with feature support level API

### DIFF
--- a/src/common/components/clusterConfiguration/SNOControlGroup.tsx
+++ b/src/common/components/clusterConfiguration/SNOControlGroup.tsx
@@ -4,7 +4,7 @@ import { ClusterDetailsValues } from '../../../common/components/clusterWizard/t
 import { SingleNodeCheckbox } from '../ui';
 import { OpenshiftVersionOptionType } from '../../types';
 import SNODisclaimer from './SNODisclaimer';
-import { getSNOSupportLevel } from './utils';
+import { FeatureSupportLevelContext } from '../featureSupportLevels';
 
 type SNOControlGroupProps = {
   isDisabled?: boolean;
@@ -14,12 +14,14 @@ type SNOControlGroupProps = {
 
 const SNOControlGroup = ({ versions, highAvailabilityMode, isDisabled }: SNOControlGroupProps) => {
   const { values } = useFormikContext<ClusterDetailsValues>();
+  const featureSupportLevels = React.useContext(FeatureSupportLevelContext);
   const selectedVersion = versions.find((version) => version.value === values.openshiftVersion);
-
   // TODO(jtomasek): use getFeatureSupport('sno', selectedVersion.version) to get support level of SNO feature
   // for selected version once the API is available
   // https://issues.redhat.com/browse/MGMT-7787
-  const snoSupportLevel = getSNOSupportLevel(selectedVersion?.version);
+  const snoSupportLevel = selectedVersion
+    ? featureSupportLevels.getFeatureSupportLevel(selectedVersion.value, 'SNO')
+    : undefined;
 
   return (
     <>

--- a/src/common/components/clusterConfiguration/SNODisclaimer.tsx
+++ b/src/common/components/clusterConfiguration/SNODisclaimer.tsx
@@ -1,16 +1,17 @@
 import React from 'react';
 import { Alert, AlertVariant, List, ListItem, Stack, StackItem } from '@patternfly/react-core';
 import { CheckboxField } from '../ui';
+import { SupportLevel } from '../../types';
 
 type SNODisclaimerProps = {
   isDisabled?: boolean;
-  snoSupportLevel?: string;
+  snoSupportLevel?: SupportLevel;
 };
 const SNODisclaimer = ({
   isDisabled = false,
   snoSupportLevel = 'supported',
 }: SNODisclaimerProps) => {
-  const isUnsupported = snoSupportLevel !== 'supported';
+  const isUnsupported = snoSupportLevel === 'dev-preview';
   const generalSNOFacts = (
     <>
       <ListItem>

--- a/src/common/components/clusterConfiguration/utils.ts
+++ b/src/common/components/clusterConfiguration/utils.ts
@@ -8,7 +8,6 @@ import {
   ValidationGroup,
   ValidationsInfo,
 } from '../../types/clusters';
-import { OpenshiftVersionOptionType } from '../../types/versions';
 import { getHostname, getSchedulableMasters } from '../hosts/utils';
 import {
   selectClusterNetworkCIDR,
@@ -83,16 +82,6 @@ export const getHostDiscoveryInitialValues = (cluster: Cluster): HostDiscoveryVa
     usePlatformIntegration: cluster.platform?.type !== 'baremetal',
     schedulableMasters: getSchedulableMasters(cluster),
   };
-};
-
-// TODO(jtomasek): use getFeatureSupport('sno', selectedVersion.version) to get support level of SNO feature
-// for selected version once the API is available. This function will be obsolete then and can be removed.
-// https://issues.redhat.com/browse/MGMT-7787
-export const getSNOSupportLevel = (version: OpenshiftVersionOptionType['version'] = '') => {
-  if (version.startsWith('4.9')) {
-    return 'supported';
-  }
-  return 'dev-preview';
 };
 
 export function filterValidationsInfoByGroup(

--- a/src/common/components/clusterWizard/clusterDetailsValidation.ts
+++ b/src/common/components/clusterWizard/clusterDetailsValidation.ts
@@ -1,7 +1,7 @@
 import * as Yup from 'yup';
 import { Cluster, ManagedDomain } from '../../api';
 import { OpenshiftVersionOptionType } from '../../types';
-import { getSNOSupportLevel } from '../clusterConfiguration/utils';
+import { FeatureSupportLevelData } from '../featureSupportLevels/FeatureSupportLevelContext';
 import {
   dnsNameValidationSchema,
   getDefaultOpenShiftVersion,
@@ -43,6 +43,7 @@ export const getClusterDetailsInitialValues = ({
 
 export const getClusterDetailsValidationSchema = (
   usedClusterNames: string[],
+  featureSupportLevels: FeatureSupportLevelData,
   cluster?: Cluster,
   ocpVersions?: OpenshiftVersionOptionType[],
 ) =>
@@ -63,7 +64,9 @@ export const getClusterDetailsValidationSchema = (
           const selectedVersion = (ocpVersions || []).find((v) => v.value === openshiftVersion);
           return (
             highAvailabilityMode === 'None' &&
-            getSNOSupportLevel(selectedVersion?.version) !== 'supported'
+            selectedVersion &&
+            featureSupportLevels.getFeatureSupportLevel(selectedVersion.value, 'SNO') ===
+              'dev-preview'
           );
         },
         then: Yup.bool().oneOf([true], 'Confirm the Single Node OpenShift disclaimer to continue.'),

--- a/src/common/components/ui/formik/SingleNodeCheckbox.tsx
+++ b/src/common/components/ui/formik/SingleNodeCheckbox.tsx
@@ -7,7 +7,7 @@ import { getFieldId } from './utils';
 import HelperText from './HelperText';
 import { CheckboxFieldProps } from './types';
 import { isSNOSupportedVersion } from '../utils';
-import { FeatureSupportLevelBadge } from '../../featureSupportLevels';
+import { FeatureSupportLevelBadge, FeatureSupportLevelContext } from '../../featureSupportLevels';
 import { ClusterCreateParams } from '../../../api/types';
 
 type SingleNodeCheckboxProps = CheckboxFieldProps & { versions: OpenshiftVersionOptionType[] };
@@ -23,12 +23,15 @@ const SingleNodeCheckbox: React.FC<SingleNodeCheckboxProps> = ({
   } = useFormikContext<ClusterCreateParams>();
   const isSingleNodeOpenshiftEnabled = useFeature('ASSISTED_INSTALLER_SNO_FEATURE');
   const [field, meta, helpers] = useField<'None' | 'Full'>({ name: props.name, validate });
+  const featureSupportLevels = React.useContext(FeatureSupportLevelContext);
   const fieldId = getFieldId(props.name, 'input', idPostfix);
 
   const { value } = meta;
   const { setValue } = helpers;
 
-  const isSupportedVersionAvailable = !!versions.find(isSNOSupportedVersion);
+  const isSupportedVersionAvailable = !!versions.find((version) =>
+    isSNOSupportedVersion(featureSupportLevels, version),
+  );
 
   if (isSingleNodeOpenshiftEnabled && isSupportedVersionAvailable) {
     return (

--- a/src/common/components/ui/utils.ts
+++ b/src/common/components/ui/utils.ts
@@ -1,6 +1,6 @@
-import { SNO_SUPPORT_MIN_VERSION } from '../../config';
 import { OpenshiftVersionOptionType } from '../../types';
 import { DASH } from '../constants';
+import { FeatureSupportLevelData } from '../featureSupportLevels/FeatureSupportLevelContext';
 
 export const getHumanizedDateTime = (dateTime?: string) => {
   if (!dateTime) return DASH;
@@ -14,16 +14,9 @@ export const getHumanizedTime = (dateTime?: string) => {
   return date.toLocaleTimeString();
 };
 
-const isSNOSupportedVersionString = (version: OpenshiftVersionOptionType['version']) => {
-  let parsed = parseFloat(version);
-  if (isNaN(parsed)) {
-    // openshift-v4.8.0
-    parsed = parseFloat(version?.split('-v')?.[1]);
-  }
-  return parsed >= SNO_SUPPORT_MIN_VERSION;
-};
-
-export const isSNOSupportedVersion = (version: OpenshiftVersionOptionType) => {
-  // NOTE(jtomasek): Note that the version.value format is different in OCM and ACM
-  return isSNOSupportedVersionString(version.version);
+export const isSNOSupportedVersion = (
+  featureSupportlevels: FeatureSupportLevelData,
+  version: OpenshiftVersionOptionType,
+) => {
+  return featureSupportlevels.getFeatureSupportLevel(version.value, 'SNO') !== 'unsupported';
 };

--- a/src/ocm/components/clusterWizard/ClusterDetailsForm.tsx
+++ b/src/ocm/components/clusterWizard/ClusterDetailsForm.tsx
@@ -19,6 +19,7 @@ import { OpenshiftVersionOptionType, getFormikErrorFields } from '../../../commo
 import ClusterWizardFooter from './ClusterWizardFooter';
 import ClusterWizardHeaderExtraActions from '../clusterConfiguration/ClusterWizardHeaderExtraActions';
 import { ocmClient } from '../../api';
+import { FeatureSupportLevelContext } from '../../../common/components/featureSupportLevels';
 
 type ClusterDetailsFormProps = {
   cluster?: Cluster;
@@ -47,6 +48,7 @@ const ClusterDetailsForm: React.FC<ClusterDetailsFormProps> = (props) => {
     navigation,
   } = props;
 
+  const featureSupportLevels = React.useContext(FeatureSupportLevelContext);
   const handleSubmit = async (values: ClusterDetailsValues) => {
     const params: ClusterCreateParams = _.omit(values, ['useRedHatDnsService', 'SNODisclaimer']);
     if (cluster) {
@@ -72,6 +74,7 @@ const ClusterDetailsForm: React.FC<ClusterDetailsFormProps> = (props) => {
   const initialValues = getClusterDetailsInitialValues(props);
   const validationSchema = getClusterDetailsValidationSchema(
     usedClusterNames,
+    featureSupportLevels,
     cluster,
     ocpVersions,
   );


### PR DESCRIPTION
This code breaks CIM. Requires adding a FeatureSupportLevelContextProvider in CIM that'll implement the sno support level information hard coded

Related to #1014 