### PR TITLE
[CIM] Use progress from k8s resources

### DIFF
--- a/src/cim/components/ClusterDeployment/ClusterDeploymentProgress.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentProgress.tsx
@@ -3,28 +3,8 @@ import ClusterProgress from '../../../common/components/clusterDetail/ClusterPro
 import { AgentK8sResource } from '../../types/k8s/agent';
 import { AgentClusterInstallK8sResource } from '../../types/k8s/agent-cluster-install';
 import { ClusterDeploymentK8sResource } from '../../types/k8s/cluster-deployment';
-import { getAgentProgress, getAgentProgressStages } from '../helpers/agents';
 import { EventListFetchProps } from '../../../common';
 import { getAICluster } from '../helpers/toAssisted';
-
-export const getAgentProgressStageNumber = (agent: AgentK8sResource) => {
-  const stages = getAgentProgressStages(agent);
-  const progress = getAgentProgress(agent);
-  const currentStage = progress?.currentStage;
-  return stages.findIndex((s) => currentStage?.match(s)) + 1;
-};
-
-const getAgentsProgressPercent = (agents: AgentK8sResource[] = []) => {
-  const totalSteps = agents.reduce(
-    (steps, agent) => steps + getAgentProgressStages(agent).length,
-    0,
-  );
-  const completedSteps = agents.reduce(
-    (steps, agent) => steps + getAgentProgressStageNumber(agent),
-    0,
-  );
-  return totalSteps ? Math.round((completedSteps / totalSteps) * 100) : 100;
-};
 
 type ClusterDeploymentProgressProps = {
   clusterDeployment: ClusterDeploymentK8sResource;
@@ -41,12 +21,10 @@ const ClusterDeploymentProgress = ({
   onFetchEvents,
   fallbackEventsURL,
 }: ClusterDeploymentProgressProps) => {
-  const agentsProgressPercent = React.useMemo(() => getAgentsProgressPercent(agents), [agents]);
-
   const cluster = getAICluster({ clusterDeployment, agentClusterInstall, agents });
   return (
     <ClusterProgress
-      totalPercentage={agentsProgressPercent}
+      totalPercentage={agentClusterInstall.status?.progress.totalPercentage || 0}
       cluster={cluster}
       onFetchEvents={onFetchEvents}
       fallbackEventsURL={fallbackEventsURL}

--- a/src/cim/components/helpers/agents.ts
+++ b/src/cim/components/helpers/agents.ts
@@ -1,5 +1,5 @@
 import { AgentStatus } from './status';
-import { Host, HostStage } from '../../../common/api/types';
+import { Host } from '../../../common/api/types';
 import { AgentK8sResource, BareMetalHostK8sResource } from '../../types';
 import { getAgentStatus } from './status';
 import { INFRAENV_AGENTINSTALL_LABEL_KEY } from '../common';
@@ -22,53 +22,6 @@ export const getAgentsForSelection = (agents: AgentK8sResource[]) =>
   });
 
 export const getAgentRole = (agent: AgentK8sResource) => agent.spec.role || agent.status?.role;
-
-// NOTE: based host stages defined in https://github.com/openshift/assisted-service/blob/master/internal/host/host.go
-// TODO(jtomasek): Use this until agent resource does not expose host.progressStages array
-export const getAgentProgressStages = (agent: AgentK8sResource): HostStage[] => {
-  const isBootstrap = agent.status?.bootstrap;
-  const role = getAgentRole(agent);
-
-  const bootstrapHostStages: HostStage[] = [
-    'Starting installation',
-    'Installing',
-    'Writing image to disk',
-    'Waiting for control plane',
-    'Waiting for bootkube',
-    'Waiting for controller',
-    'Rebooting',
-    'Configuring',
-    'Joined',
-    'Done',
-  ];
-
-  const masterHostStages: HostStage[] = [
-    'Starting installation',
-    'Installing',
-    'Writing image to disk',
-    'Rebooting',
-    'Configuring',
-    'Joined',
-    'Done',
-  ];
-
-  const workerHostStages: HostStage[] = [
-    'Starting installation',
-    'Installing',
-    'Writing image to disk',
-    'Waiting for control plane',
-    'Rebooting',
-    'Waiting for ignition',
-    'Configuring',
-    'Joined',
-    'Done',
-  ];
-
-  if (isBootstrap) return bootstrapHostStages;
-  if (role === 'master') return masterHostStages;
-  if (role === 'worker') return workerHostStages;
-  return [];
-};
 
 export const getAgentProgress = (agent: AgentK8sResource) => agent.status?.progress;
 

--- a/src/cim/components/helpers/toAssisted.ts
+++ b/src/cim/components/helpers/toAssisted.ts
@@ -7,12 +7,7 @@ import { getAgentStatus, getClusterStatus } from './status';
 import { getHostNetworks } from './network';
 import { BareMetalHostK8sResource, InfraEnvK8sResource } from '../../types';
 import { AGENT_BMH_HOSTNAME_LABEL_KEY } from '../common';
-import {
-  getAgentProgress,
-  getAgentProgressStages,
-  getAgentRole,
-  getInfraEnvNameOfAgent,
-} from './agents';
+import { getAgentProgress, getAgentRole, getInfraEnvNameOfAgent } from './agents';
 
 export const getAIHosts = (
   agents: AgentK8sResource[],
@@ -52,11 +47,12 @@ export const getAIHosts = (
         inventory: JSON.stringify(inventory),
         progress: agentProgress && {
           currentStage: agentProgress.currentStage,
+          installationPercentage: agentProgress.installationPercentage,
           progressInfo: agentProgress.progressInfo,
           stageStartedAt: agentProgress.stageStartTime,
           stageUpdatedAt: agentProgress.stageUpdateTime,
         },
-        progressStages: getAgentProgressStages(agent),
+        progressStages: agentProgress?.progressStages,
         bootstrap: agent.status?.bootstrap,
       };
     },

--- a/src/cim/types/k8s/agent-cluster-install.ts
+++ b/src/cim/types/k8s/agent-cluster-install.ts
@@ -56,6 +56,9 @@ export type AgentClusterInstallK8sResource = K8sResourceCommon & {
   status?: {
     connectivityMajorityGroups?: string;
     conditions?: AgentClusterInstallStatusCondition[];
+    progress: {
+      totalPercentage: number;
+    };
     debugInfo?: {
       eventsURL: string;
       logsURL: string;

--- a/src/cim/types/k8s/agent.ts
+++ b/src/cim/types/k8s/agent.ts
@@ -28,7 +28,9 @@ export type AgentK8sResource = K8sResourceCommon & {
     inventory: Inventory;
     progress: {
       currentStage: HostStage;
+      installationPercentage: number;
       progressInfo: string;
+      progressStages: HostStage[];
       stageStartTime: string;
       stageUpdateTime: string;
     };


### PR DESCRIPTION
Cluster and agent progress properties are now available from k8s resources
(agentClusterInstall and agent). This change replaces original client side
progress calculation with these newly available properties.