### PR TITLE
MGMT-7987: Add an option to update day2 api vip for a host failing to connect

### DIFF
--- a/src/common/api/types.ts
+++ b/src/common/api/types.ts
@@ -1423,7 +1423,8 @@ export type HostValidationId =
   | 'apps-domain-name-resolved-correctly'
   | 'compatible-with-cluster-platform'
   | 'dns-wildcard-not-configured'
-  | 'disk-encryption-requirements-satisfied';
+  | 'disk-encryption-requirements-satisfied'
+  | 'api-vip-connected';
 /**
  * Explicit ignition endpoint overrides the default ignition endpoint.
  */

--- a/src/common/components/hosts/HostStatus.tsx
+++ b/src/common/components/hosts/HostStatus.tsx
@@ -47,6 +47,7 @@ import OcpConsoleNodesSectionLink from './OcpConsoleNodesSectionLink';
 import { toSentence } from '../ui/table/utils';
 import { RenderIf } from '../ui';
 import { HostStatusProps } from './types';
+import { UpdateDay2ApiVipPropsType } from './HostValidationGroups';
 
 const getStatusIcon = (status: Host['status'] | 'discovered') => {
   let icon = null;
@@ -224,6 +225,7 @@ const HostStatusPopoverFooter: React.FC<{ host: Host }> = ({ host }) => {
 
 const WithHostStatusPopover = (
   props: AdditionNtpSourcePropsType &
+    UpdateDay2ApiVipPropsType &
     PropsWithChildren<{
       hideOnOutsideClick: PopoverProps['hideOnOutsideClick'];
       host: Host;
@@ -256,6 +258,7 @@ const HostStatus: React.FC<HostStatusProps> = ({
   sublabel,
   onEditHostname,
   AdditionalNTPSourcesDialogToggleComponent,
+  UpdateDay2ApiVipDialogToggleComponent,
   children,
 }) => {
   const [keepOnOutsideClick, onValidationActionToggle] = React.useState(false);
@@ -295,6 +298,7 @@ const HostStatus: React.FC<HostStatusProps> = ({
             title={title}
             validationsInfo={validationsInfo}
             statusOverride={status}
+            UpdateDay2ApiVipDialogToggleComponent={UpdateDay2ApiVipDialogToggleComponent}
           >
             {titleWithProgress}
           </WithHostStatusPopover>
@@ -315,11 +319,11 @@ const HostStatus: React.FC<HostStatusProps> = ({
               hideOnOutsideClick={!keepOnOutsideClick}
               host={host}
               onEditHostname={toggleHostname}
-              // onAdditionalNtpSource={onAdditionalNtpSource}
               AdditionalNTPSourcesDialogToggleComponent={AdditionalNTPSourcesDialogToggleComponent}
               title={title}
               validationsInfo={validationsInfo}
               statusOverride={status}
+              UpdateDay2ApiVipDialogToggleComponent={UpdateDay2ApiVipDialogToggleComponent}
             >
               {sublabel}
             </WithHostStatusPopover>

--- a/src/common/components/hosts/HostValidationGroups.tsx
+++ b/src/common/components/hosts/HostValidationGroups.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, ReactElement } from 'react';
 import { Alert, AlertGroup, AlertVariant, Level, LevelItem } from '@patternfly/react-core';
 import {
   global_warning_color_100 as warningColor,
@@ -6,7 +6,7 @@ import {
 } from '@patternfly/react-tokens';
 import { PendingIcon, CheckCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
 
-import { Host } from '../../api';
+import { Host, HostValidationId } from '../../api';
 import { Validation, ValidationsInfo } from '../../types/hosts';
 import {
   HOST_VALIDATION_FAILURE_HINTS,
@@ -14,18 +14,26 @@ import {
   HOST_VALIDATION_LABELS,
 } from '../../config';
 import { toSentence } from '../ui/table/utils';
-import Hostname from './Hostname';
 
 import './HostValidationGroups.css';
+import Hostname from './Hostname';
 
 export type AdditionNtpSourcePropsType = {
   AdditionalNTPSourcesDialogToggleComponent?: React.FC;
 };
 
-export type ValidationInfoActionProps = AdditionNtpSourcePropsType & {
+export type UpdateDay2ApiVipPropsType = {
+  UpdateDay2ApiVipDialogToggleComponent?: React.FC;
+};
+
+export type InvalidHostnameActionProps = {
   onEditHostname?: () => void;
   host: Host;
 };
+
+export type ValidationInfoActionProps = AdditionNtpSourcePropsType &
+  InvalidHostnameActionProps &
+  UpdateDay2ApiVipPropsType;
 
 type HostValidationGroupsProps = ValidationInfoActionProps & {
   validationsInfo: ValidationsInfo;
@@ -37,61 +45,147 @@ type ValidationGroupAlertProps = ValidationInfoActionProps & {
   title: string;
 };
 
-const ValidationGroupAlert: React.FC<ValidationGroupAlertProps> = ({
-  variant,
+const ValidationsAlert: React.FC<{
+  validations: Validation[];
+  variant: AlertVariant;
+  title: string;
+  actionLinks?: ReactElement[];
+}> = ({ validations, variant, title, actionLinks = [] }) => (
+  <Alert title={title} variant={variant} actionLinks={actionLinks} isInline>
+    <ul>
+      {validations.map((v) => (
+        <li key={v.id}>
+          <strong>{HOST_VALIDATION_LABELS[v.id] || v.id}:</strong>&nbsp;{toSentence(v.message)}{' '}
+          {v.status === 'failure' && HOST_VALIDATION_FAILURE_HINTS[v.id]}
+        </li>
+      ))}
+    </ul>
+  </Alert>
+);
+
+const HostnameAlert: React.FC<
+  Required<InvalidHostnameActionProps> & {
+    hostnameValidations: Validation[];
+    variant: AlertVariant;
+  }
+> = ({ onEditHostname, host, hostnameValidations, variant }) => {
+  const actionLinks = [
+    <Hostname
+      key="change-hostname"
+      title="Change hostname"
+      onEditHostname={onEditHostname}
+      host={host}
+    />,
+  ];
+  const title = 'Illegal hostname';
+  return hostnameValidations.length === 1 ? (
+    <Alert title={title} variant={variant} actionLinks={actionLinks} isInline>
+      {toSentence(hostnameValidations[0].message)}
+    </Alert>
+  ) : (
+    <ValidationsAlert
+      title={title}
+      validations={hostnameValidations}
+      variant={variant}
+      actionLinks={actionLinks}
+    />
+  );
+};
+
+const NtpSyncAlert: React.FC<
+  Required<AdditionNtpSourcePropsType> & { variant: AlertVariant; validation: Validation }
+> = ({ AdditionalNTPSourcesDialogToggleComponent, variant, validation }) => {
+  const actionLinks = [<AdditionalNTPSourcesDialogToggleComponent key="add-ntp-sources" />];
+  return (
+    <Alert title="NTP synchronization failure" variant={variant} actionLinks={actionLinks} isInline>
+      {toSentence(validation.message)} {HOST_VALIDATION_FAILURE_HINTS[validation.id]}
+    </Alert>
+  );
+};
+
+const ApiVipConnectivityAlert: React.FC<
+  Required<UpdateDay2ApiVipPropsType> & { variant: AlertVariant }
+> = ({ UpdateDay2ApiVipDialogToggleComponent, variant }) => {
+  const actionLinks = [<UpdateDay2ApiVipDialogToggleComponent key="update-api-vip" />];
+  return (
+    <Alert
+      title="API Virtual IP connectivity failure"
+      variant={variant}
+      actionLinks={actionLinks}
+      isInline
+    >
+      To continue installation, configure your DNS or alternatively
+    </Alert>
+  );
+};
+
+const ValidationGroupAlerts: React.FC<ValidationGroupAlertProps> = ({
   validations,
   title,
+  variant,
   onEditHostname,
   AdditionalNTPSourcesDialogToggleComponent,
-  ...props
+  UpdateDay2ApiVipDialogToggleComponent,
+  host,
 }) => {
-  let isValidHostname = true;
   if (!validations.length) {
     return null;
   }
-
-  const actionLinks = [];
-  if (
-    validations.find(
-      (validation) =>
-        validation.status === 'failure' &&
-        ['hostname-unique', 'hostname-valid'].includes(validation.id),
-    )
-  ) {
-    actionLinks.push(
-      <Hostname
-        key="change-hostname"
-        title="Change hostname"
+  const validationsWithActions: { [id in HostValidationId]?: Validation } = {
+    ['hostname-unique']: undefined,
+    ['hostname-valid']: undefined,
+    ['ntp-synced']: undefined,
+    ['api-vip-connected']: undefined,
+  };
+  const alerts = [];
+  const validationsWithoutActions: Validation[] = [];
+  for (const v of validations) {
+    if (v.id in validationsWithActions && v.status === 'failure') {
+      validationsWithActions[v.id] = v;
+    } else {
+      validationsWithoutActions.push(v);
+    }
+  }
+  const hostnameValidations: Validation[] = [];
+  if (validationsWithActions['hostname-unique']) {
+    hostnameValidations.push(validationsWithActions['hostname-unique']);
+  }
+  if (validationsWithActions['hostname-valid']) {
+    hostnameValidations.push(validationsWithActions['hostname-valid']);
+  }
+  if (hostnameValidations.length > 0 && onEditHostname) {
+    alerts.push(
+      <HostnameAlert
+        hostnameValidations={hostnameValidations}
+        variant={variant}
         onEditHostname={onEditHostname}
-        {...props}
+        host={host}
       />,
     );
-    isValidHostname = false;
   }
-  if (
-    AdditionalNTPSourcesDialogToggleComponent &&
-    validations.find(
-      (validation) => validation.status === 'failure' && validation.id === 'ntp-synced',
-    )
-  ) {
-    actionLinks.push(<AdditionalNTPSourcesDialogToggleComponent key="add-ntp-sources" />);
+  if (validationsWithActions['api-vip-connected'] && UpdateDay2ApiVipDialogToggleComponent) {
+    alerts.push(
+      <ApiVipConnectivityAlert
+        UpdateDay2ApiVipDialogToggleComponent={UpdateDay2ApiVipDialogToggleComponent}
+        variant={variant}
+      />,
+    );
   }
-
-  return (
-    <Alert title={title} variant={variant} actionLinks={actionLinks} isInline>
-      <ul>
-        {validations.map((v) => (
-          <li key={v.id}>
-            <strong>{HOST_VALIDATION_LABELS[v.id] || v.id}:</strong>&nbsp;{toSentence(v.message)}{' '}
-            {v.status === 'failure' && HOST_VALIDATION_FAILURE_HINTS[v.id]}
-          </li>
-        ))}
-      </ul>
-      {!isValidHostname && (
-        <span>To fix this click the "Change hostname" link and rename the host.</span>
-      )}
-    </Alert>
-  );
+  if (validationsWithActions['ntp-synced'] && AdditionalNTPSourcesDialogToggleComponent) {
+    alerts.push(
+      <NtpSyncAlert
+        AdditionalNTPSourcesDialogToggleComponent={AdditionalNTPSourcesDialogToggleComponent}
+        validation={validationsWithActions['ntp-synced']}
+        variant={variant}
+      />,
+    );
+  }
+  if (validationsWithoutActions.length > 0) {
+    alerts.push(
+      <ValidationsAlert validations={validationsWithoutActions} variant={variant} title={title} />,
+    );
+  }
+  return <AlertGroup>{alerts}</AlertGroup>;
 };
 
 export const HostValidationGroups: React.FC<HostValidationGroupsProps> = ({
@@ -139,22 +233,20 @@ export const HostValidationGroups: React.FC<HostValidationGroupsProps> = ({
               </LevelItem>
               <LevelItem>{getValidationGroupState()}</LevelItem>
             </Level>
-            <AlertGroup>
-              {!failedValidations.length && ( // display pending validations only if there are no failing validations
-                <ValidationGroupAlert
-                  variant={AlertVariant.info}
-                  title="Pending validations:"
-                  validations={pendingValidations}
-                  {...props}
-                />
-              )}
-              <ValidationGroupAlert
-                variant={AlertVariant.warning}
-                title="Failed validations:"
-                validations={failedValidations}
+            {!failedValidations.length && ( // display pending validations only if there are no failing validations
+              <ValidationGroupAlerts
+                variant={AlertVariant.info}
+                title="Pending validations:"
+                validations={pendingValidations}
                 {...props}
               />
-            </AlertGroup>
+            )}
+            <ValidationGroupAlerts
+              variant={AlertVariant.warning}
+              title="Failed validations:"
+              validations={failedValidations}
+              {...props}
+            />
           </Fragment>
         );
       })}

--- a/src/common/components/hosts/tableUtils.tsx
+++ b/src/common/components/hosts/tableUtils.tsx
@@ -117,6 +117,7 @@ export const roleColumn = (
 export const statusColumn = (
   AdditionalNTPSourcesDialogToggleComponent: React.FC,
   onEditHostname?: HostsTableActions['onEditHost'],
+  UpdateDay2ApiVipDialogToggleComponent?: React.FC,
 ): TableRow<Host> => {
   return {
     header: {
@@ -136,6 +137,7 @@ export const statusColumn = (
             onEditHostname={editHostname}
             validationsInfo={validationsInfo}
             AdditionalNTPSourcesDialogToggleComponent={AdditionalNTPSourcesDialogToggleComponent}
+            UpdateDay2ApiVipDialogToggleComponent={UpdateDay2ApiVipDialogToggleComponent}
           />
         ),
         props: { 'data-testid': 'host-status' },

--- a/src/common/components/hosts/types.ts
+++ b/src/common/components/hosts/types.ts
@@ -2,7 +2,7 @@ import { Cluster, Host, HostUpdateParams } from '../../api';
 import { ValidationsInfo } from '../../types/hosts';
 import { HostsNotShowingLinkProps } from '../clusterConfiguration';
 import { onDiskRoleType } from './DiskRole';
-import { AdditionNtpSourcePropsType } from './HostValidationGroups';
+import { AdditionNtpSourcePropsType, UpdateDay2ApiVipPropsType } from './HostValidationGroups';
 
 export type ClusterHostsTableProps = {
   cluster: Cluster;
@@ -50,10 +50,11 @@ export type HostNetworkingStatusComponentProps = {
   onEditHostname?: () => void;
 };
 
-export type HostStatusProps = AdditionNtpSourcePropsType & {
-  host: Host;
-  validationsInfo: ValidationsInfo;
-  onEditHostname?: () => void;
-  statusOverride?: Host['status'] | 'discovered';
-  sublabel?: string;
-};
+export type HostStatusProps = AdditionNtpSourcePropsType &
+  UpdateDay2ApiVipPropsType & {
+    host: Host;
+    validationsInfo: ValidationsInfo;
+    onEditHostname?: () => void;
+    statusOverride?: Host['status'] | 'Discovered';
+    sublabel?: string;
+  };

--- a/src/common/components/ui/formik/validationSchemas.ts
+++ b/src/common/components/ui/formik/validationSchemas.ts
@@ -394,3 +394,14 @@ export const ntpSourceValidationSchema = Yup.string().test(
     return trimCommaSeparatedList(value).split(',').every(isIPorDN);
   },
 );
+
+export const day2ApiVipValidationSchema = Yup.string().test(
+  'day2-api-vip',
+  'Provide a valid DNS name or IP Address',
+  (value: string) => {
+    if (!value) {
+      return true;
+    }
+    return isIPorDN(value);
+  },
+);

--- a/src/common/config/constants.ts
+++ b/src/common/config/constants.ts
@@ -190,6 +190,7 @@ export const HOST_VALIDATION_LABELS: { [key in HostValidationId]: string } = {
   'api-int-domain-name-resolved-correctly': 'API internal domain name resolution',
   'apps-domain-name-resolved-correctly': 'Application ingress domain name resolution',
   'dns-wildcard-not-configured': 'DNS wildcard not configured',
+  'api-vip-connected': 'API VIP connectivity failure',
 };
 
 export const HOST_VALIDATION_FAILURE_HINTS: { [key in HostValidationId]: string } = {
@@ -222,6 +223,7 @@ export const HOST_VALIDATION_FAILURE_HINTS: { [key in HostValidationId]: string 
   'api-int-domain-name-resolved-correctly': '',
   'apps-domain-name-resolved-correctly': '',
   'dns-wildcard-not-configured': '',
+  'api-vip-connected': '',
 };
 
 export const CLUSTER_VALIDATION_LABELS: { [key in ClusterValidationId]: string } = {

--- a/src/ocm/components/hosts/ClusterHostsTable.tsx
+++ b/src/ocm/components/hosts/ClusterHostsTable.tsx
@@ -15,6 +15,7 @@ import { HostDetail } from '../../../common/components/hosts/HostRowDetail';
 import { useHostsTable, HostsTableModals } from './use-hosts-table';
 import HostsTable, { HostsTableEmptyState } from '../../../common/components/hosts/HostsTable';
 import { ExpandComponentProps } from '../../../common/components/hosts/AITable';
+import { UpdateDay2ApiVipDialogToggle } from './UpdateDay2ApiVipDialogToggle';
 
 const ExpandComponent: React.FC<ExpandComponentProps<Host>> = ({ obj }) => {
   return (
@@ -39,7 +40,7 @@ const ClusterHostsTable: React.FC<ClusterHostsTableProps> = ({
     () => [
       hostnameColumn(onEditHost, undefined, actionChecks.canEditHostname),
       roleColumn(actionChecks.canEditRole, onEditRole, getSchedulableMasters(cluster)),
-      statusColumn(AdditionalNTPSourcesDialogToggle, onEditHost),
+      statusColumn(AdditionalNTPSourcesDialogToggle, onEditHost, UpdateDay2ApiVipDialogToggle),
       discoveredAtColumn,
       cpuCoresColumn,
       memoryColumn,

--- a/src/ocm/components/hosts/ModalDialogsContext.tsx
+++ b/src/ocm/components/hosts/ModalDialogsContext.tsx
@@ -36,6 +36,7 @@ type ModalDialogsDataTypes = {
   resetClusterDialog: ResetClusterProps;
   cancelInstallationDialog: CancelInstallationProps;
   discoveryImageDialog: DiscoveryImageDialogProps;
+  UpdateDay2ApiVipDialog: void;
 };
 
 type DialogId =
@@ -46,7 +47,8 @@ type DialogId =
   | 'additionalNTPSourcesDialog'
   | 'resetClusterDialog'
   | 'cancelInstallationDialog'
-  | 'discoveryImageDialog';
+  | 'discoveryImageDialog'
+  | 'UpdateDay2ApiVipDialog';
 
 export type ModalDialogsContextType = {
   [key in DialogId]: {
@@ -66,6 +68,7 @@ const dialogIds: DialogId[] = [
   'resetClusterDialog',
   'cancelInstallationDialog',
   'discoveryImageDialog',
+  'UpdateDay2ApiVipDialog',
 ];
 
 const ModalDialogsContext = React.createContext<ModalDialogsContextType | undefined>(undefined);

--- a/src/ocm/components/hosts/UpdateDay2ApiVipDialogToggle.tsx
+++ b/src/ocm/components/hosts/UpdateDay2ApiVipDialogToggle.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { AlertActionLink } from '@patternfly/react-core';
+import { useModalDialogsContext } from './ModalDialogsContext';
+
+export const UpdateDay2ApiVipDialogToggle: React.FC = () => {
+  const {
+    UpdateDay2ApiVipDialog: { open },
+  } = useModalDialogsContext();
+
+  return (
+    <AlertActionLink onClick={() => open()}>Update cluster with API Virtual IP</AlertActionLink>
+  );
+};

--- a/src/ocm/components/hosts/UpdateDay2ApiVipForm.tsx
+++ b/src/ocm/components/hosts/UpdateDay2ApiVipForm.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import * as Yup from 'yup';
+import {
+  Button,
+  ButtonVariant,
+  ButtonType,
+  Form,
+  ModalBoxBody,
+  ModalBoxFooter,
+  AlertVariant,
+  Alert,
+  AlertActionCloseButton,
+} from '@patternfly/react-core';
+import { Formik } from 'formik';
+import { day2ApiVipValidationSchema, InputField } from '../../../common/components/ui';
+import GridGap from '../../../common/components/ui/GridGap';
+
+export type UpdateDay2ApiVipFormProps = {
+  onClose: () => void;
+  onUpdateDay2ApiVip: (apiVip: string, onError: (message: string) => void) => Promise<void>;
+  currentApiVip?: string;
+};
+
+export type UpdateDay2ApiVipValues = {
+  apiVip?: string;
+};
+
+const UpdateDay2ApiVipForm: React.FC<UpdateDay2ApiVipFormProps> = ({
+  onUpdateDay2ApiVip,
+  onClose,
+  currentApiVip: originApiVip,
+}) => {
+  const apiVipInputRef = React.useRef<HTMLInputElement>();
+  React.useEffect(() => {
+    apiVipInputRef.current?.focus();
+    apiVipInputRef.current?.select();
+  }, []);
+  const initialValues = {
+    apiVip: originApiVip,
+  };
+  const validationSchema = React.useMemo(
+    () =>
+      Yup.object().shape({
+        apiVip: day2ApiVipValidationSchema.required(),
+      }),
+    [],
+  );
+
+  return (
+    <Formik
+      initialValues={initialValues}
+      validationSchema={validationSchema}
+      initialStatus={{ error: null }}
+      onSubmit={async (values, formikHelpers) => {
+        if (values.apiVip) {
+          const onError = (message: string) =>
+            formikHelpers.setStatus({
+              error: {
+                title: 'Failed to update Api Vip',
+                message,
+              },
+            });
+          await onUpdateDay2ApiVip(values.apiVip, onError);
+          onClose();
+        }
+      }}
+    >
+      {({ handleSubmit, status, setStatus, isSubmitting, isValid, dirty }) => (
+        <Form onSubmit={handleSubmit}>
+          <ModalBoxBody>
+            <GridGap>
+              {status.error && (
+                <Alert
+                  variant={AlertVariant.danger}
+                  title={status.error.title}
+                  actionClose={
+                    <AlertActionCloseButton onClose={() => setStatus({ error: null })} />
+                  }
+                  isInline
+                >
+                  {status.error.message}
+                </Alert>
+              )}
+              <InputField label="API VIP" name="apiVip" ref={apiVipInputRef} isRequired />
+            </GridGap>
+          </ModalBoxBody>
+          <ModalBoxFooter>
+            <Button
+              key="submit"
+              type={ButtonType.submit}
+              isDisabled={isSubmitting || !isValid || !dirty}
+            >
+              Update
+            </Button>
+            <Button key="cancel" variant={ButtonVariant.link} onClick={onClose}>
+              Cancel
+            </Button>
+          </ModalBoxFooter>
+        </Form>
+      )}
+    </Formik>
+  );
+};
+
+export default UpdateDay2ApiVipForm;

--- a/src/ocm/components/hosts/UpdateDay2ApiVipModal.tsx
+++ b/src/ocm/components/hosts/UpdateDay2ApiVipModal.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Modal, ModalVariant } from '@patternfly/react-core';
+import UpdateDay2ApiVipForm, { UpdateDay2ApiVipFormProps } from './UpdateDay2ApiVipForm';
+
+type UpdateDay2ApiVipModalProps = {
+  isOpen: boolean;
+} & UpdateDay2ApiVipFormProps;
+
+const UpdateDay2ApiVipModal: React.FC<UpdateDay2ApiVipModalProps> = ({ isOpen, ...props }) => (
+  <Modal
+    aria-label="Update API Vip Dialog"
+    title="Update API Vip"
+    isOpen={isOpen}
+    variant={ModalVariant.small}
+    hasNoBodyWrapper
+  >
+    <UpdateDay2ApiVipForm {...props} />
+  </Modal>
+);
+
+export default UpdateDay2ApiVipModal;

--- a/src/ocm/components/hosts/use-hosts-table.tsx
+++ b/src/ocm/components/hosts/use-hosts-table.tsx
@@ -17,7 +17,7 @@ import {
   AdditionalNTPSourcesFormProps,
 } from '../../../common/components/hosts/AdditionalNTPSourcesDialog';
 import { getErrorMessage, handleApiError } from '../../api';
-import { forceReload, updateHost } from '../../reducers/clusters';
+import { forceReload, updateCluster, updateHost } from '../../reducers/clusters';
 import { useModalDialogsContext } from './ModalDialogsContext';
 import { downloadHostInstallationLogs, onAdditionalNtpSourceAction } from './utils';
 import {
@@ -39,6 +39,9 @@ import ResetHostModal from './ResetHostModal';
 import DeleteHostModal from './DeleteHostModal';
 import { onFetchEvents } from '../fetching/fetchEvents';
 import { HostsService } from '../../services';
+import UpdateDay2ApiVipModal from './UpdateDay2ApiVipModal';
+import { UpdateDay2ApiVipFormProps } from './UpdateDay2ApiVipForm';
+import { ClustersAPI } from '../../services/apis';
 
 export const useHostsTable = (cluster: Cluster) => {
   const { addAlert } = useAlerts();
@@ -128,6 +131,20 @@ export const useHostsTable = (cluster: Cluster) => {
       }
     },
     [dispatch, resetCluster, addAlert, cluster.id],
+  );
+
+  const onUpdateDay2ApiVip: UpdateDay2ApiVipFormProps['onUpdateDay2ApiVip'] = React.useCallback(
+    async (apiVip: string, onError: (message: string) => void) => {
+      try {
+        const { data } = await ClustersAPI.update(cluster.id, {
+          apiVipDnsName: apiVip,
+        });
+        dispatch(updateCluster(data));
+      } catch (e) {
+        handleApiError(e, () => onError(getErrorMessage(e)));
+      }
+    },
+    [cluster.id, dispatch],
   );
 
   const onAdditionalNtpSource: AdditionalNTPSourcesFormProps['onAdditionalNtpSource'] = React.useMemo(
@@ -242,6 +259,7 @@ export const useHostsTable = (cluster: Cluster) => {
     onReset,
     onDelete,
     onAdditionalNtpSource,
+    onUpdateDay2ApiVip,
   };
 };
 
@@ -253,6 +271,7 @@ type HostsTableModalsProps = {
     additionalNtpSource: string,
     onError: (message: string) => void,
   ) => Promise<void>;
+  onUpdateDay2ApiVip: UpdateDay2ApiVipFormProps['onUpdateDay2ApiVip'];
 };
 
 export const HostsTableModals: React.FC<HostsTableModalsProps> = ({
@@ -260,6 +279,7 @@ export const HostsTableModals: React.FC<HostsTableModalsProps> = ({
   onDelete,
   onReset,
   onAdditionalNtpSource,
+  onUpdateDay2ApiVip,
 }) => {
   const dispatch = useDispatch();
   const { resetCluster } = React.useContext(AddHostsContext);
@@ -270,6 +290,7 @@ export const HostsTableModals: React.FC<HostsTableModalsProps> = ({
     deleteHostDialog,
     resetHostDialog,
     additionalNTPSourcesDialog,
+    UpdateDay2ApiVipDialog,
   } = useModalDialogsContext();
   return (
     <>
@@ -325,6 +346,12 @@ export const HostsTableModals: React.FC<HostsTableModalsProps> = ({
         isOpen={additionalNTPSourcesDialog.isOpen}
         onClose={additionalNTPSourcesDialog.close}
         onAdditionalNtpSource={onAdditionalNtpSource}
+      />
+      <UpdateDay2ApiVipModal
+        isOpen={UpdateDay2ApiVipDialog.isOpen}
+        onClose={UpdateDay2ApiVipDialog.close}
+        onUpdateDay2ApiVip={onUpdateDay2ApiVip}
+        currentApiVip={cluster.apiVipDnsName}
       />
     </>
   );


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-8735
![image](https://user-images.githubusercontent.com/22211154/148340076-d88ffc4d-9903-4443-bd9c-e79f8e0d00ad.png)
![image](https://user-images.githubusercontent.com/22211154/148340202-f3c01b10-3529-4eb2-9949-4e952928b23f.png)

Includes separation of alerts with an action and alerts without actions. For example, the alert on invalid host names in separated form the rest because it has an action "Change host name"
![image](https://user-images.githubusercontent.com/22211154/148346433-cf33e68c-10cb-4442-859e-4200c25493a8.png)
