### PR TITLE
MGMT-8775: wrong sno limitations in cluster details for an existing cluster

### DIFF
--- a/src/common/components/clusterConfiguration/SNOControlGroup.tsx
+++ b/src/common/components/clusterConfiguration/SNOControlGroup.tsx
@@ -7,11 +7,12 @@ import SNODisclaimer from './SNODisclaimer';
 import { FeatureSupportLevelContext } from '../featureSupportLevels';
 
 type SNOControlGroupProps = {
+  isDisabled?: boolean;
   versions: OpenshiftVersionOptionType[];
   highAvailabilityMode: ClusterDetailsValues['highAvailabilityMode'];
 };
 
-const SNOControlGroup = ({ versions, highAvailabilityMode }: SNOControlGroupProps) => {
+const SNOControlGroup = ({ versions, highAvailabilityMode, isDisabled }: SNOControlGroupProps) => {
   const { values } = useFormikContext<ClusterDetailsValues>();
   const featureSupportLevels = React.useContext(FeatureSupportLevelContext);
   const [snoSupportLevel, setSnoSupportLevel] = React.useState<SupportLevel>();
@@ -25,7 +26,6 @@ const SNOControlGroup = ({ versions, highAvailabilityMode }: SNOControlGroupProp
       setSnoSupportLevel(supportLevel);
     }
   }, [values.openshiftVersion, setSnoSupportLevel, featureSupportLevels]);
-
   return (
     <>
       <SingleNodeCheckbox name="highAvailabilityMode" versions={versions} isDisabled={isDisabled} />

--- a/src/common/components/clusterConfiguration/SNODisclaimer.tsx
+++ b/src/common/components/clusterConfiguration/SNODisclaimer.tsx
@@ -5,13 +5,14 @@ import { SupportLevel } from '../../types';
 
 type SNODisclaimerProps = {
   isDisabled?: boolean;
-  snoSupportLevel?: SupportLevel;
+  snoSupportLevel: SupportLevel;
 };
-const SNODisclaimer = ({
-  isDisabled = false,
-  snoSupportLevel = 'supported',
-}: SNODisclaimerProps) => {
-  const isUnsupported = snoSupportLevel === 'dev-preview';
+const SNODisclaimer = ({ isDisabled = false, snoSupportLevel }: SNODisclaimerProps) => {
+  if (!['dev-preview', 'supported'].includes(snoSupportLevel)) {
+    //if tech preview or unsupported there's no definition which warning to show
+    return null;
+  }
+  const isDevPreview = snoSupportLevel === 'dev-preview';
   const generalSNOFacts = (
     <>
       <ListItem>
@@ -32,7 +33,7 @@ const SNODisclaimer = ({
 
   return (
     <Alert
-      variant={isUnsupported ? AlertVariant.warning : AlertVariant.info}
+      variant={isDevPreview ? AlertVariant.warning : AlertVariant.info}
       title="Limitations for using Single Node OpenShift"
       isInline
     >
@@ -40,10 +41,10 @@ const SNODisclaimer = ({
         <StackItem>
           <List>
             {generalSNOFacts}
-            {isUnsupported && unsupportedWarnings}
+            {isDevPreview && unsupportedWarnings}
           </List>
         </StackItem>
-        {isUnsupported && (
+        {isDevPreview && (
           <StackItem>
             <CheckboxField
               name="SNODisclaimer"


### PR DESCRIPTION
root cause: searching for major+minor release in major releases, for example 4.9.11 in [4.9, 4.8...]
probably caused by v2 changes of openshift_versions API