### PR TITLE
MGMT-8478: Removes to boot instructions at the bottom of the modal

### DIFF
--- a/src/common/components/clusterConfiguration/DownloadIso.tsx
+++ b/src/common/components/clusterConfiguration/DownloadIso.tsx
@@ -60,15 +60,6 @@ const DownloadIso: React.FC<DownloadISOProps> = ({
               </ClipboardCopy>
             }
           />
-          <DetailItem
-            title="Boot instructions"
-            value={
-              <>
-                Use a bootable device (local disk, USB drive, etc.) or network booting (PXE) to boot
-                each host <b>once</b> from the Discovery ISO.
-              </>
-            }
-          />
         </DetailList>
         <Alert
           variant="info"


### PR DESCRIPTION
Sample:
![image](https://user-images.githubusercontent.com/77008341/148689843-61e1ce67-0cf6-49e3-b108-e935ae06db5f.png)

Signed-off-by: Jonathan Kilzi <jkilzi@redhat.com>
