### PR TITLE
MGMT-8297: Add a message about adding workers after cluster is installed

### DIFF
--- a/src/common/config/constants.ts
+++ b/src/common/config/constants.ts
@@ -28,6 +28,8 @@ export const FIREWALL_DOCUMENTATION_LINK =
 export const getOcpConsoleNodesPage = (ocpConsoleUrl: string) =>
   `${ocpConsoleUrl}/k8s/cluster/nodes`;
 
+export const REDHAT_CONSOLE_OPENSHIFT = 'console.redhat.com/openshift';
+
 // TODO(mlibra): Retrieve branding dynamically, if needed, i.e. via injecting to the "window" object
 export const getProductBrandingCode = () => 'redhat';
 

--- a/src/ocm/components/clusterDetail/ClusterDetail.tsx
+++ b/src/ocm/components/clusterDetail/ClusterDetail.tsx
@@ -86,7 +86,7 @@ const ClusterDetail: React.FC<ClusterDetailProps> = ({ cluster }) => {
             />
           </RenderIf>
           <RenderIf
-            condition={cluster.status === 'installed' && cluster.highAvailabilityMode === 'Full'}
+            condition={cluster.status === 'installed' && cluster.highAvailabilityMode !== 'None'}
           >
             <Alert
               variant="info"

--- a/src/ocm/components/clusterDetail/ClusterDetail.tsx
+++ b/src/ocm/components/clusterDetail/ClusterDetail.tsx
@@ -19,6 +19,7 @@ import {
   useAlerts,
   RenderIf,
   KubeconfigDownload,
+  REDHAT_CONSOLE_OPENSHIFT,
 } from '../../../common';
 import ClusterHostsTable from '../hosts/ClusterHostsTable';
 import ClusterToolbar from '../clusters/ClusterToolbar';
@@ -40,6 +41,17 @@ import { VSPHERE_CONFIG_LINK } from '../../../common/config/constants';
 type ClusterDetailProps = {
   cluster: Cluster;
 };
+
+// const linkToConsole: React.FC = () => (
+//   <>
+//     <>
+//       Add new hosts using the Discovery ISO you can find under your cluster\'s "Add hosts” tab on{' '}
+//     </>
+//     <a href={REDHAT_CONSOLE_OPENSHIFT} target="_blank" rel="noopener noreferrer">
+//       {'console.red.hat.com/openshift'}
+//     </a>
+//   </>
+// );
 
 const ClusterDetail: React.FC<ClusterDetailProps> = ({ cluster }) => {
   const { addAlert } = useAlerts();
@@ -84,6 +96,23 @@ const ClusterDetail: React.FC<ClusterDetailProps> = ({ cluster }) => {
               }
             />
           </RenderIf>
+          <RenderIf condition={cluster.status == 'installed'}>
+            <Alert
+              variant="info"
+              isInline
+              title={
+                <p>
+                  Add new hosts using the Discovery ISO you can find under your cluster's "Add
+                  hosts” tab on{' '}
+                  <a href={REDHAT_CONSOLE_OPENSHIFT} target="_blank" rel="noopener noreferrer">
+                    console.redhat.com/openshift <i className="fas fa-external-link-alt" />
+                  </a>
+                  .
+                </p>
+              }
+            />
+          </RenderIf>
+
           <RenderIf condition={cluster.platform?.type !== 'baremetal'}>
             <Alert
               variant="warning"

--- a/src/ocm/components/clusterDetail/ClusterDetail.tsx
+++ b/src/ocm/components/clusterDetail/ClusterDetail.tsx
@@ -42,17 +42,6 @@ type ClusterDetailProps = {
   cluster: Cluster;
 };
 
-// const linkToConsole: React.FC = () => (
-//   <>
-//     <>
-//       Add new hosts using the Discovery ISO you can find under your cluster\'s "Add hosts” tab on{' '}
-//     </>
-//     <a href={REDHAT_CONSOLE_OPENSHIFT} target="_blank" rel="noopener noreferrer">
-//       {'console.red.hat.com/openshift'}
-//     </a>
-//   </>
-// );
-
 const ClusterDetail: React.FC<ClusterDetailProps> = ({ cluster }) => {
   const { addAlert } = useAlerts();
   const { resetClusterDialog, cancelInstallationDialog } = useModalDialogsContext();
@@ -102,8 +91,8 @@ const ClusterDetail: React.FC<ClusterDetailProps> = ({ cluster }) => {
               isInline
               title={
                 <p>
-                  Add new hosts using the Discovery ISO you can find under your cluster's "Add
-                  hosts” tab on{' '}
+                  Add new hosts by generating a new Discovery ISO under your cluster's "Add hosts”
+                  tab on{' '}
                   <a href={REDHAT_CONSOLE_OPENSHIFT} target="_blank" rel="noopener noreferrer">
                     console.redhat.com/openshift <i className="fas fa-external-link-alt" />
                   </a>

--- a/src/ocm/components/clusterDetail/ClusterDetail.tsx
+++ b/src/ocm/components/clusterDetail/ClusterDetail.tsx
@@ -37,6 +37,8 @@ import ClusterProgress from '../../../common/components/clusterDetail/ClusterPro
 import { EventsModalButton } from '../../../common/components/ui/eventsModal';
 import { onFetchEvents } from '../fetching/fetchEvents';
 import { VSPHERE_CONFIG_LINK } from '../../../common/config/constants';
+import { isSNO } from '../../selectors';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 type ClusterDetailProps = {
   cluster: Cluster;
@@ -85,9 +87,7 @@ const ClusterDetail: React.FC<ClusterDetailProps> = ({ cluster }) => {
               }
             />
           </RenderIf>
-          <RenderIf
-            condition={cluster.status === 'installed' && cluster.highAvailabilityMode !== 'None'}
-          >
+          <RenderIf condition={cluster.status === 'installed' && !isSNO(cluster)}>
             <Alert
               variant="info"
               isInline
@@ -96,7 +96,7 @@ const ClusterDetail: React.FC<ClusterDetailProps> = ({ cluster }) => {
                   Add new hosts by generating a new Discovery ISO under your cluster's "Add hosts”
                   tab on{' '}
                   <a href={REDHAT_CONSOLE_OPENSHIFT} target="_blank" rel="noopener noreferrer">
-                    console.redhat.com/openshift <i className="fas fa-external-link-alt" />
+                    console.redhat.com/openshift <ExternalLinkAltIcon />
                   </a>
                   .
                 </p>

--- a/src/ocm/components/clusterDetail/ClusterDetail.tsx
+++ b/src/ocm/components/clusterDetail/ClusterDetail.tsx
@@ -85,7 +85,9 @@ const ClusterDetail: React.FC<ClusterDetailProps> = ({ cluster }) => {
               }
             />
           </RenderIf>
-          <RenderIf condition={cluster.status == 'installed'}>
+          <RenderIf
+            condition={cluster.status === 'installed' && cluster.highAvailabilityMode === 'Full'}
+          >
             <Alert
               variant="info"
               isInline

--- a/src/ocm/selectors/clusterSelectors.ts
+++ b/src/ocm/selectors/clusterSelectors.ts
@@ -17,3 +17,5 @@ export const selectServiceNetworkCIDR = ({
   serviceNetworks,
   serviceNetworkCidr,
 }: Partial<Cluster>) => _.head(serviceNetworks)?.cidr ?? serviceNetworkCidr;
+export const isSNO = ({ highAvailabilityMode }: Partial<Cluster>) =>
+  highAvailabilityMode === 'None';


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-8297

The following message appears when _cluster.status === 'installed'_ and the cluster is not an SNO:
**"Add new hosts by generating a new Discovery ISO under your cluster's "Add hosts" tab on console.redhat.com/openshift"**

![image](https://user-images.githubusercontent.com/69599321/149914567-d559bd69-f35b-4363-a660-7ed143306ee8.png)
