### PR TITLE
Add NTP sources configuration for CIM

### DIFF
--- a/src/cim/components/InfraEnv/InfraEnvFormPage.tsx
+++ b/src/cim/components/InfraEnv/InfraEnvFormPage.tsx
@@ -33,6 +33,8 @@ import {
   PopoverIcon,
   pullSecretValidationSchema,
   OCP_STATIC_IP_DOC,
+  CheckboxField,
+  AdditionalNTPSourcesField,
 } from '../../../common';
 
 import './infra-env.css';
@@ -48,6 +50,8 @@ export type EnvironmentStepFormValues = {
   enableProxy: boolean;
   labels: string[];
   networkType: 'dhcp' | 'static';
+  enableNtpSources: boolean;
+  additionalNtpSources: string;
 };
 
 const validationSchema = (usedNames: string[]) =>
@@ -93,6 +97,8 @@ const initialValues: EnvironmentStepFormValues = {
   enableProxy: false,
   labels: [],
   networkType: 'dhcp',
+  enableNtpSources: false,
+  additionalNtpSources: '',
 };
 
 type InfraEnvFormProps = {
@@ -188,6 +194,22 @@ const InfraEnvForm: React.FC<InfraEnvFormProps> = ({ onValuesChanged }) => {
           <PullSecretField isOcm={false} />
           <UploadSSH />
           <ProxyFields />
+          <CheckboxField
+            label="Add your own NTP (Network Time Protocol) sources"
+            name="enableNtpSources"
+            helperText={
+              <p>
+                Configure your own NTP sources to synchronize the time between the hosts that will
+                be added to this infrastructure environment.
+              </p>
+            }
+          />
+          {values.enableNtpSources && (
+            <AdditionalNTPSourcesField
+              name="additionalNtpSources"
+              helperText="A comma separated list of IP or domain names of the NTP pools or servers."
+            />
+          )}
         </Form>
       </StackItem>
     </Stack>

--- a/src/cim/components/modals/EditNtpSourcesModal.tsx
+++ b/src/cim/components/modals/EditNtpSourcesModal.tsx
@@ -1,0 +1,118 @@
+import * as React from 'react';
+import {
+  Alert,
+  Button,
+  ButtonVariant,
+  Form,
+  Modal,
+  ModalBoxBody,
+  ModalBoxFooter,
+  ModalVariant,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import { Formik, FormikProps } from 'formik';
+import { InfraEnvK8sResource } from '../../types';
+import { RadioField, AdditionalNTPSourcesField } from '../../../common';
+import { EditNtpSourcesFormikValues } from './types';
+
+export type EditNtpSourcesModalProps = {
+  onSubmit: (
+    values: EditNtpSourcesFormikValues,
+    infraEnv: InfraEnvK8sResource,
+  ) => Promise<InfraEnvK8sResource>;
+  isOpen: boolean;
+  infraEnv: InfraEnvK8sResource;
+  onClose: VoidFunction;
+};
+
+const EditNtpSourcesModal: React.FC<EditNtpSourcesModalProps> = ({
+  isOpen,
+  onClose,
+  onSubmit,
+  infraEnv,
+}) => {
+  const [error, setError] = React.useState();
+  return (
+    <Modal
+      aria-label="Edit Ntp sources dialog"
+      title="Edit NTP sources"
+      isOpen={isOpen}
+      onClose={onClose}
+      variant={ModalVariant.small}
+      hasNoBodyWrapper
+      id="edit-ntp-sources-modal"
+    >
+      <Formik<EditNtpSourcesFormikValues>
+        initialValues={{
+          enableNtpSources: infraEnv.spec?.additionalNTPSources ? 'additional' : 'auto',
+          additionalNtpSources: infraEnv.spec?.additionalNTPSources?.join(',') || '',
+        }}
+        onSubmit={async (values) => {
+          try {
+            await onSubmit(values, infraEnv);
+            onClose();
+          } catch (err) {
+            setError(err?.message || 'An error occured');
+          }
+        }}
+        validateOnMount
+      >
+        {({
+          isSubmitting,
+          isValid,
+          values,
+          submitForm,
+        }: FormikProps<EditNtpSourcesFormikValues>) => {
+          return (
+            <>
+              <ModalBoxBody>
+                <Form>
+                  <Stack hasGutter>
+                    <StackItem>
+                      <RadioField
+                        label="Auto synchronized NTP (Network Time Protocol) sources"
+                        value="auto"
+                        name="enableNtpSources"
+                      />
+                    </StackItem>
+                    <StackItem>
+                      <RadioField
+                        name="enableNtpSources"
+                        value="additional"
+                        description="Configure your own NTP sources to sychronize the time between the hotsts that will be added to this infrastructure environment."
+                        label="Your own NTP (Network Time Protocol) sources"
+                      />
+                    </StackItem>
+                    <StackItem>
+                      <AdditionalNTPSourcesField
+                        name="additionalNtpSources"
+                        isDisabled={values.enableNtpSources === 'auto'}
+                        helperText="A comma separated list of IP or domain names of the NTP pools or servers."
+                      />
+                    </StackItem>
+                    {error && (
+                      <StackItem>
+                        <Alert variant="danger" title={error} />
+                      </StackItem>
+                    )}
+                  </Stack>
+                </Form>
+              </ModalBoxBody>
+              <ModalBoxFooter>
+                <Button onClick={submitForm} isDisabled={isSubmitting || !isValid}>
+                  Save NTP sources
+                </Button>
+                <Button onClick={onClose} variant={ButtonVariant.secondary}>
+                  Cancel
+                </Button>
+              </ModalBoxFooter>
+            </>
+          );
+        }}
+      </Formik>
+    </Modal>
+  );
+};
+
+export default EditNtpSourcesModal;

--- a/src/cim/components/modals/types.ts
+++ b/src/cim/components/modals/types.ts
@@ -39,3 +39,8 @@ export type EditPullSecretFormikValues = {
   pullSecret: string | undefined;
   createSecret: boolean;
 };
+
+export type EditNtpSourcesFormikValues = {
+  enableNtpSources: string;
+  additionalNtpSources: string;
+};

--- a/src/cim/types/k8s/infra-env-k8s-resource.ts
+++ b/src/cim/types/k8s/infra-env-k8s-resource.ts
@@ -21,6 +21,7 @@ export type InfraEnvK8sResource = K8sResourceCommon & {
       noProxy: string;
     };
     nmStateConfigLabelSelector?: Selector;
+    additionalNTPSources?: string[];
   };
   status?: {
     agentLabelSelector?: Selector;

--- a/src/common/components/hosts/AdditionalNTPSourcesDialog.tsx
+++ b/src/common/components/hosts/AdditionalNTPSourcesDialog.tsx
@@ -15,9 +15,8 @@ import {
 import {
   Cluster,
   ClusterUpdateParams,
-  TextAreaField,
-  trimCommaSeparatedList,
   ntpSourceValidationSchema,
+  AdditionalNTPSourcesField,
 } from '../../../common';
 
 export type AdditionalNTPSourcesFormProps = {
@@ -68,27 +67,7 @@ const AdditionalNTPSourcesForm: React.FC<AdditionalNTPSourcesFormProps> = ({
       validationSchema={validationSchema}
       onSubmit={handleSubmit}
     >
-      {({
-        submitForm,
-        status,
-        setStatus,
-        setFieldValue,
-        setFieldTouched,
-        isSubmitting,
-        isValid,
-        dirty,
-        values,
-      }) => {
-        const formatAdditionalNtpSource = () => {
-          if (values.additionalNtpSource) {
-            setFieldValue(
-              'additionalNtpSource',
-              trimCommaSeparatedList(values.additionalNtpSource),
-            );
-            setFieldTouched('additionalNtpSource');
-          }
-        };
-
+      {({ submitForm, status, setStatus, isSubmitting, isValid, dirty }) => {
         return (
           <>
             <ModalBoxBody>
@@ -105,12 +84,10 @@ const AdditionalNTPSourcesForm: React.FC<AdditionalNTPSourcesFormProps> = ({
                     {status.error.message}
                   </Alert>
                 )}
-                <TextAreaField
+                <AdditionalNTPSourcesField
                   name="additionalNtpSource"
                   label="Additional NTP Sources"
                   helperText="A comma separated list of IP or domain names of the NTP pools or servers. Additional NTP sources are added to all hosts to ensure all hosts clocks are synchronized with a valid NTP server. It may take a few minutes for the new NTP sources to sync."
-                  onBlur={formatAdditionalNtpSource}
-                  spellCheck={false}
                   isRequired
                 />
               </Form>

--- a/src/common/components/ui/formik/AdditionalNTPSourcesField.tsx
+++ b/src/common/components/ui/formik/AdditionalNTPSourcesField.tsx
@@ -1,0 +1,41 @@
+import { useField } from 'formik';
+import * as React from 'react';
+import TextAreaField from './TextAreaField';
+import { trimCommaSeparatedList } from './utils';
+
+type AdditionalNTPSourcesFieldProps = {
+  name: string;
+  label?: string;
+  isRequired?: boolean;
+  isDisabled?: boolean;
+  helperText?: string;
+};
+
+const AdditionalNTPSourcesField: React.FC<AdditionalNTPSourcesFieldProps> = ({
+  name,
+  label,
+  isRequired,
+  isDisabled,
+  helperText,
+}) => {
+  const [field, , { setValue, setTouched }] = useField(name);
+  const formatAdditionalNtpSources = () => {
+    if (field.value) {
+      setValue(trimCommaSeparatedList(field.value));
+      setTouched(true);
+    }
+  };
+  return (
+    <TextAreaField
+      name={name}
+      label={label}
+      helperText={helperText}
+      onBlur={formatAdditionalNtpSources}
+      spellCheck={false}
+      isRequired={isRequired}
+      isDisabled={isDisabled}
+    />
+  );
+};
+
+export default AdditionalNTPSourcesField;

--- a/src/common/components/ui/formik/RadioField.tsx
+++ b/src/common/components/ui/formik/RadioField.tsx
@@ -16,6 +16,7 @@ const RadioField: React.FC<Optional<RadioProps, 'id'>> = (props) => {
       {...field}
       id={fieldId}
       label={props.label}
+      description={props.description}
       isChecked={!!field.checked}
       isDisabled={props.isDisabled}
       onChange={(checked, e) => {

--- a/src/common/components/ui/formik/index.tsx
+++ b/src/common/components/ui/formik/index.tsx
@@ -14,6 +14,7 @@ export { default as SingleNodeCheckbox } from './SingleNodeCheckbox';
 export { default as NumberInputField } from './NumberInputField';
 export { default as CodeField } from './CodeField';
 export { default as RichInputField } from './RichInputField';
+export { default as AdditionalNTPSourcesField } from './AdditionalNTPSourcesField';
 
 export * from './utils';
 export * from './PullSecretField';

--- a/src/common/components/ui/formik/types.ts
+++ b/src/common/components/ui/formik/types.ts
@@ -1,10 +1,5 @@
 import * as React from 'react';
-import {
-  TextInputTypes,
-  FormSelectOptionProps,
-  SelectOptionProps,
-  TooltipProps,
-} from '@patternfly/react-core';
+import { TextInputTypes, FormSelectOptionProps, SelectOptionProps } from '@patternfly/react-core';
 import { FieldValidator, FieldHelperProps } from 'formik';
 import { DropzoneProps, DropFileEventHandler } from 'react-dropzone';
 import { CodeEditorProps } from '@patternfly/react-code-editor';
@@ -44,7 +39,6 @@ export interface MultiSelectFieldProps extends FieldProps {
   placeholderText?: string;
   onChange?: (val: string[]) => void;
   getHelperText?: (value: string) => React.ReactNode | undefined;
-  tooltipProps?: TooltipProps;
 }
 
 export interface SwitchFieldProps extends FieldProps {
@@ -53,7 +47,6 @@ export interface SwitchFieldProps extends FieldProps {
   // called in addition to the default internal onChange handler
   onChange?: (checked: boolean, event: React.FormEvent<HTMLInputElement>) => void;
   getHelperText?: (value: string) => string | undefined;
-  tooltipProps?: TooltipProps;
 }
 
 export interface InputFieldProps extends FieldProps {


### PR DESCRIPTION
I've made some changes so @ShiranHi let me know if you agree or not

1. sources are separated via comma, not via new line. This is how we do it on OCM so I think it would be good to align
2. I've added a help text under TextArea to make clear what format we expect (we do the same on OCM)
3. TextArea is not aligned with checkbox content, we do not do it on other places

![ntp1](https://user-images.githubusercontent.com/2078045/150779360-20183f47-1a4d-4e70-a741-861b6d2e4c8d.png)

![ntp4](https://user-images.githubusercontent.com/2078045/150788678-22d8e291-a346-456c-bec0-ec8a8c89e3fd.png)

![net5](https://user-images.githubusercontent.com/2078045/150788706-1a54deb4-ba7d-4adf-aa8d-fa60b1a71a38.png)



