### PR TITLE
MGMT-9061 - Download kubeconfig button doesn't exist

### DIFF
--- a/src/common/config/constants.ts
+++ b/src/common/config/constants.ts
@@ -278,6 +278,7 @@ export const getAssistedUiLibVersion = () => packageJson.version;
 export const EVENT_SEVERITIES: Event['severity'][] = ['info', 'warning', 'error', 'critical'];
 
 export const TIME_ZERO = '0001-01-01T00:00:00.000Z';
+export const INSTALL_TIME_ZERO = '2000-01-01T00:00:00.000Z';
 
 export const MS_PER_DAY = 1000 * 60 * 60 * 24;
 

--- a/src/ocm/components/clusterDetail/ClusterDetail.tsx
+++ b/src/ocm/components/clusterDetail/ClusterDetail.tsx
@@ -36,7 +36,7 @@ import { useDefaultConfiguration } from '../clusterConfiguration/ClusterDefaultC
 import ClusterProgress from '../../../common/components/clusterDetail/ClusterProgress';
 import { EventsModalButton } from '../../../common/components/ui/eventsModal';
 import { onFetchEvents } from '../fetching/fetchEvents';
-import { TIME_ZERO, VSPHERE_CONFIG_LINK } from '../../../common/config/constants';
+import { INSTALL_TIME_ZERO, VSPHERE_CONFIG_LINK } from '../../../common/config/constants';
 import { isSNO } from '../../selectors';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { diffInDaysBetweenDates } from '../../../common/sevices/DateAndTime';
@@ -46,7 +46,7 @@ type ClusterDetailProps = {
 };
 
 function calculateDateDifference(inactiveDeletionDays: number, completedAt?: string) {
-  if (completedAt && completedAt !== TIME_ZERO) {
+  if (completedAt && completedAt !== INSTALL_TIME_ZERO) {
     return inactiveDeletionDays - diffInDaysBetweenDates(completedAt);
   } else {
     return inactiveDeletionDays;


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-9061

The constant used to indicate installation hasn't started/finished yet is different than the `TIME_ZERO` constant. This was causing the calculated number of days until the kubeconfig file is deleted to be negative which prevented the button from rendering.