### PR TITLE
MGMT-9067: Implement the UI for auto-select control plane nodes

### DIFF
--- a/src/common/components/hosts/RoleCell.tsx
+++ b/src/common/components/hosts/RoleCell.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@patternfly/react-core';
 import React from 'react';
 import { Host, HostUpdateParams } from '../../api';
 import RoleDropdown from './RoleDropdown';
@@ -8,13 +9,24 @@ export type RoleCellProps = {
   readonly?: boolean;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onEditRole?: (role: HostUpdateParams['hostRole']) => Promise<any>;
+  displayTooltip?: boolean;
 };
 
-const RoleCell: React.FC<RoleCellProps> = ({ host, role, readonly = false, onEditRole }) =>
+const RoleCell: React.FC<RoleCellProps> = ({
+  host,
+  role,
+  readonly = false,
+  onEditRole,
+  displayTooltip,
+}) =>
   !readonly && onEditRole ? (
     <RoleDropdown host={host} onEditRole={onEditRole} current={role} />
+  ) : displayTooltip ? (
+    <Tooltip content={'To make the role editable, 4 or more hosts need to be discovered.'}>
+      <span>{role}</span>
+    </Tooltip>
   ) : (
-    <>{role}</>
+    <span>{role}</span>
   );
 
 export default RoleCell;

--- a/src/common/components/hosts/tableUtils.tsx
+++ b/src/common/components/hosts/tableUtils.tsx
@@ -84,6 +84,7 @@ export const roleColumn = (
   canEditRole?: HostsTableActions['canEditRole'],
   onEditRole?: HostsTableActions['onEditRole'],
   schedulableMasters?: boolean,
+  displayTooltip?: boolean,
 ): TableRow<Host> => {
   return {
     header: {
@@ -105,6 +106,7 @@ export const roleColumn = (
             readonly={!canEditRole?.(host)}
             role={hostRole}
             onEditRole={editRole}
+            displayTooltip={displayTooltip}
           />
         ),
         props: { 'data-testid': 'host-role' },

--- a/src/common/components/hosts/utils.ts
+++ b/src/common/components/hosts/utils.ts
@@ -50,6 +50,8 @@ export const canReset = (clusterStatus: Cluster['status'], status: Host['status'
 
 export const canEditRole = (cluster: Cluster, hostStatus: Host['status']) =>
   !isSingleNodeCluster(cluster) &&
+  cluster.totalHostCount &&
+  cluster.totalHostCount > 3 &&
   ['pending-for-input', 'insufficient', 'ready'].includes(cluster.status) &&
   [
     'discovering',


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-9067

- [x] No toggle switch will be displayed
- [x] When 1-3 hosts are discovered we should show them with the suggested role ("Control plane, worker") that is not editable
- [x] Hovering the host role should show a tooltip: "To make the role editable, 4 or more hosts need to be discovered."
- [x] When the 4th  host is discovered, we should enable the edit option for the hosts' role and add the dropdown caret
- [x] We should not limit the user with the role selections (the user can select any combination of roles and they will be validated