### PR TITLE
MGMT-9105: Issues following changes in openshift-versions API

### DIFF
--- a/src/ocm/api/axiosClient.ts
+++ b/src/ocm/api/axiosClient.ts
@@ -15,17 +15,21 @@ const axiosCaseConverterOptions = {
   },
 };
 
-const getDefaultClient = () => {
+const getDefaultClient = (applyCase = true) => {
   const client = axios.create();
   client.interceptors.request.use((cfg) => ({
     ...cfg,
     url: `${process.env.REACT_APP_API_ROOT}${cfg.url}`,
   }));
-  return applyCaseMiddleware(client, axiosCaseConverterOptions);
+  if (applyCase) {
+    return applyCaseMiddleware(client, axiosCaseConverterOptions);
+  }
+  return client;
 };
 
 let client: AxiosInstance = getDefaultClient();
 let ocmClient: AxiosInstance | null;
+let noCoverterClient = getDefaultClient(false);
 
 const aiInterceptor = (client: AxiosInstance) => {
   client.interceptors.request.use((cfg) => ({
@@ -41,6 +45,7 @@ export const setAuthInterceptor = (authInterceptor: (client: AxiosInstance) => A
     aiInterceptor(authInterceptor(axios.create())),
     axiosCaseConverterOptions,
   );
+  noCoverterClient = aiInterceptor(authInterceptor(axios.create()));
 };
 
-export { client, ocmClient };
+export { client, ocmClient, noCoverterClient };

--- a/src/ocm/components/featureSupportLevels/FeatureSupportLevelProvider.tsx
+++ b/src/ocm/components/featureSupportLevels/FeatureSupportLevelProvider.tsx
@@ -96,27 +96,19 @@ export const FeatureSupportLevelProvider: React.FC<SupportLevelProviderProps> = 
 
   const isFeatureSupportedCallback = React.useCallback(
     (versionName: string, featureId: FeatureId) => {
-      const normalizedVersion = normalizeClusterVersion(versionName);
       const supportLevel = getFeatureSupportLevel(versionName, featureId);
-      return isFeatureSupported(normalizedVersion, featureId, supportLevel, versionOptions);
+      return isFeatureSupported(versionName, featureId, supportLevel, versionOptions);
     },
-    [getFeatureSupportLevel, normalizeClusterVersion, versionOptions],
+    [getFeatureSupportLevel, versionOptions],
   );
 
   //TODO(brotman): move to separate context FeatureStateContext
   const getDisabledReasonCallback = React.useCallback(
     (versionName: string, featureId: FeatureId) => {
-      const normalizedVersion = normalizeClusterVersion(versionName);
       const isSupported = isFeatureSupportedCallback(versionName, featureId);
-      return getFeatureDisabledReason(
-        featureId,
-        cluster,
-        normalizedVersion,
-        versionOptions,
-        isSupported,
-      );
+      return getFeatureDisabledReason(featureId, cluster, versionName, versionOptions, isSupported);
     },
-    [isFeatureSupportedCallback, normalizeClusterVersion, versionOptions, cluster],
+    [isFeatureSupportedCallback, versionOptions, cluster],
   );
 
   const isFeatureDisabled = React.useCallback(

--- a/src/ocm/hooks/useOpenshiftVersions.tsx
+++ b/src/ocm/hooks/useOpenshiftVersions.tsx
@@ -25,12 +25,12 @@ export default function useOpenshiftVersions(): UseOpenshiftVersionsType {
         .sort()
         .reverse()
         .map((key) => ({
-          label: `OpenShift ${data[key].displayName || key}`,
+          label: `OpenShift ${data[key].display_name || key}`,
           value: key,
-          version: data[key].displayName,
+          version: data[key].display_name,
           default: Boolean(data[key].default),
-          supportLevel: data[key].supportLevel,
-          cpuArchitectures: data[key].cpuArchitectures as CpuArchitecture[],
+          supportLevel: data[key].support_level,
+          cpuArchitectures: data[key].cpu_architectures as CpuArchitecture[],
         }));
 
       setVersions(versions);
@@ -48,12 +48,13 @@ export default function useOpenshiftVersions(): UseOpenshiftVersionsType {
     doAsync();
   }, [doAsync, setVersions]);
 
-  const normalizeClusterVersion = React.useCallback(
-    (version = ''): string =>
-      versions?.map((obj) => obj.value).find((normalized) => version.startsWith(normalized)) ||
-      version,
-    [versions],
-  );
+  const normalizeClusterVersion = React.useCallback((version = '') => {
+    if (!version) {
+      return '';
+    }
+    const [major, minor] = version.split('.');
+    return `${major}.${minor}`;
+  }, []);
 
   return {
     error,

--- a/src/ocm/services/apis/SupportedOpenshiftVersionsAPI.ts
+++ b/src/ocm/services/apis/SupportedOpenshiftVersionsAPI.ts
@@ -1,4 +1,4 @@
-import { client } from '../../api/axiosClient';
+import { noCoverterClient } from '../../api/axiosClient';
 import { OpenshiftVersion } from '../../../common';
 
 const SupportedOpenshiftVersionsAPI = {
@@ -7,7 +7,8 @@ const SupportedOpenshiftVersionsAPI = {
   },
 
   list() {
-    return client.get<OpenshiftVersion>(`${SupportedOpenshiftVersionsAPI.makeBaseURI()}`);
+    //use client without camel case converter, since openshift verion keys can contain hyphens
+    return noCoverterClient.get<OpenshiftVersion>(`${SupportedOpenshiftVersionsAPI.makeBaseURI()}`);
   },
 };
 


### PR DESCRIPTION
API openshift-versions changed to return the full version name as keys to support multiple z-stream.
Following this - getting feature support levels according to version key stopped working, and the version keys were converted incorrectly to camel case (4.10.0-fc2 -> 4.10.0Fc2)
The fixes in this PR include an option to create an axio client without conversion to camel case to support this change in the API