### PR TITLE
set displayName on DeveloperPreview, TechnologyPreview

### DIFF
--- a/src/common/components/ui/PreviewBadge.tsx
+++ b/src/common/components/ui/PreviewBadge.tsx
@@ -78,6 +78,7 @@ const popoverTexts = {
 export const DeveloperPreview: React.FC<DeveloperPreviewProps> = (props) => (
   <PreviewBadge text="Developer Preview" popoverText={popoverTexts['dev-preview']} {...props} />
 );
+DeveloperPreview.displayName = 'DeveloperPreview';
 
 export const TechnologyPreview: React.FC<TechnologyPreviewProps> = (props) => (
   <PreviewBadge
@@ -87,3 +88,4 @@ export const TechnologyPreview: React.FC<TechnologyPreviewProps> = (props) => (
     {...props}
   />
 );
+TechnologyPreview.displayName = 'TechnologyPreview';


### PR DESCRIPTION
Currently, [OCM](https://console.redhat.com/openshift) consumes assisted-ui-lib in minified dist/ form from npm.
These 2 components cause churn in OCM's snapshot tests on every ui-lib release, for example:
```diff
--- src/components/tokens/__tests__/__snapshots__/Tokens.test.jsx.snap
+++ src/components/tokens/__tests__/__snapshots__/Tokens.test.jsx.snap
@@ -76,7 +76,7 @@ exports[`<Tokens /> Renders loading screen 1`] = `
                     ocm command-line tool
                   </ExternalLink>
                    
-                  <cl
+                  <Oa
                     position={1}
                   />
                 </ListItem>
```

A more systematic solution could be to export it non-uglified to npm, but unless you know how to do that quickly, I'd be happy if you can merge this band-aid.