### PR TITLE
MGMT-9095: version 4.9.9 appeared before 4.9.17

### DIFF
--- a/src/ocm/hooks/useOpenshiftVersions.tsx
+++ b/src/ocm/hooks/useOpenshiftVersions.tsx
@@ -14,9 +14,11 @@ type UseOpenshiftVersionsType = {
   loading: boolean;
 };
 
-const sortVersions = (versions: string[]) => {
+const sortVersions = (versions: OpenshiftVersionOptionType[]) => {
   return versions
-    .sort((version1, version2) => version1.localeCompare(version2, undefined, { numeric: true }))
+    .sort((version1, version2) =>
+      version1.label.localeCompare(version2.label, undefined, { numeric: true }),
+    )
     .reverse();
 };
 
@@ -27,8 +29,7 @@ export default function useOpenshiftVersions(): UseOpenshiftVersionsType {
   const doAsync = React.useCallback(async () => {
     try {
       const { data } = await SupportedOpenshiftVersionsAPI.list();
-      const sortedVersionNames = sortVersions(Object.keys(data));
-      const versions: OpenshiftVersionOptionType[] = sortedVersionNames.map((key) => ({
+      const versions: OpenshiftVersionOptionType[] = Object.keys(data).map((key) => ({
         label: `OpenShift ${data[key].displayName || key}`,
         value: key,
         version: data[key].displayName,
@@ -36,8 +37,7 @@ export default function useOpenshiftVersions(): UseOpenshiftVersionsType {
         supportLevel: data[key].supportLevel,
         cpuArchitectures: data[key].cpuArchitectures as CpuArchitecture[],
       }));
-
-      setVersions(versions);
+      setVersions(sortVersions(versions));
     } catch (e) {
       return handleApiError(e, (e) => {
         setError({

--- a/src/ocm/services/apis/SupportedOpenshiftVersionsAPI.ts
+++ b/src/ocm/services/apis/SupportedOpenshiftVersionsAPI.ts
@@ -7,7 +7,7 @@ const SupportedOpenshiftVersionsAPI = {
   },
 
   list() {
-    return client.get<OpenshiftVersion>(`${SupportedOpenshiftVersionsAPI.makeBaseURI()}`);
+    return client.get<OpenshiftVersion[]>(`${SupportedOpenshiftVersionsAPI.makeBaseURI()}`);
   },
 };
 


### PR DESCRIPTION
root cause: following [this PR](https://github.com/openshift/assisted-service/pull/3254) in backend sorting by keys is incorrect, it should be sorted by displayName
includes fix of return value type of openshift-versions discovered during debugging