### PR TITLE
MGMT-9029: Platform integration is shown only in the Assisted cluster list

### DIFF
--- a/src/ocm/components/clusterDetail/AssistedInstallerDetailCard.tsx
+++ b/src/ocm/components/clusterDetail/AssistedInstallerDetailCard.tsx
@@ -10,6 +10,7 @@ import {
   FeatureGateContextProvider,
   ErrorState,
   LoadingState,
+  FeatureListType,
 } from '../../../common';
 import { useClusterPolling, useFetchCluster } from '../clusters/clusterPolling';
 import ClusterWizard from '../clusterWizard/ClusterWizard';
@@ -23,6 +24,7 @@ import { FeatureSupportLevelProvider } from '../featureSupportLevels';
 
 type AssistedInstallerDetailCardProps = {
   aiClusterId: string;
+  allEnabledFeatures: FeatureListType;
 };
 
 const errorStateActions: React.ReactNode[] = [];
@@ -86,6 +88,7 @@ const LoadingDefaultConfigFailedCard: React.FC = () => (
 
 const AssistedInstallerDetailCard: React.FC<AssistedInstallerDetailCardProps> = ({
   aiClusterId,
+  allEnabledFeatures,
 }) => {
   const fetchCluster = useFetchCluster(aiClusterId);
   const { cluster, uiState } = useClusterPolling(aiClusterId);
@@ -113,13 +116,7 @@ const AssistedInstallerDetailCard: React.FC<AssistedInstallerDetailCardProps> = 
   }
 
   return (
-    <FeatureGateContextProvider
-      features={
-        {
-          /* TODO(mlibra): pass features from OCM */
-        }
-      }
-    >
+    <FeatureGateContextProvider features={allEnabledFeatures}>
       <AlertsContextProvider>
         <ModalDialogsContextProvider>
           <ClusterDefaultConfigurationProvider


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-9029

OCM was using two different components and only one of them (`AssistedUIRouter`) had a feature gate list passed down.
Related: https://gitlab.cee.redhat.com/service/uhc-portal/-/merge_requests/3070

From AI list: 
![image](https://user-images.githubusercontent.com/87187179/152765760-99d14a7d-52f6-467b-b87e-ff4e8a1c1836.png)

From OCM list before: 
![image](https://user-images.githubusercontent.com/87187179/152766486-d9e1d70a-a041-4895-99b5-70e7675e8214.png)

From OCM list after:
![image](https://user-images.githubusercontent.com/87187179/152765851-dbe080df-bc20-480e-80c7-ef13c878a9b6.png)
