### PR TITLE
NO-ISSUE: Reset tang servers' fields in different scenarios

### DIFF
--- a/src/cim/components/ClusterDeployment/ClusterDeploymentWizardFooter.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentWizardFooter.tsx
@@ -47,7 +47,7 @@ const ValidationSection = ({
           title="Provided cluster configuration is not valid"
           isInline
         >
-          The following fields are not valid:{' '}
+          The following fields are invalid or missing:{' '}
           {errorFields
             .map((field: string) => CLUSTER_DEPLOYMENT_FIELD_LABELS[field] || field)
             .join(', ')}

--- a/src/common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionControlGroup.tsx
+++ b/src/common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionControlGroup.tsx
@@ -4,6 +4,8 @@ import SwitchField from '../../ui/formik/SwitchField';
 import { DiskEncryptionMode } from './DiskEncryptionMode';
 import { RenderIf } from '../../ui';
 import { DiskEncryptionValues } from './DiskEncryptionValues';
+import { useFormikContext } from 'formik';
+import { ClusterDetailsValues } from '../../clusterWizard/types';
 
 export interface DiskEncryptionControlGroupProps {
   values: DiskEncryptionValues;
@@ -21,6 +23,28 @@ const DiskEncryptionControlGroup: React.FC<DiskEncryptionControlGroupProps> = ({
     enableDiskEncryptionOnWorkers,
     diskEncryptionMode,
   } = values;
+
+  const { setFieldValue, setFieldTouched } = useFormikContext<ClusterDetailsValues>();
+
+  React.useEffect(() => {
+    if (!enableDiskEncryptionOnWorkers && !enableDiskEncryptionOnMasters) {
+      setFieldValue('diskEncryptionMode', 'tpmv2');
+      setFieldTouched('diskEncryptionTangServers', false, false);
+      setFieldValue('diskEncryptionTangServers', [{}], false);
+    }
+  }, [
+    enableDiskEncryptionOnMasters,
+    enableDiskEncryptionOnWorkers,
+    setFieldTouched,
+    setFieldValue,
+  ]);
+
+  React.useEffect(() => {
+    setFieldValue('enableDiskEncryptionOnWorkers', false);
+    if (!isSNO) {
+      setFieldValue('enableDiskEncryptionOnMasters', false);
+    }
+  }, [isSNO, setFieldValue]);
 
   return (
     <Stack hasGutter>

--- a/src/common/components/clusterConfiguration/DiskEncryptionFields/TangServers.tsx
+++ b/src/common/components/clusterConfiguration/DiskEncryptionFields/TangServers.tsx
@@ -20,53 +20,51 @@ export const TangServers: React.FC<{ isDisabled?: boolean }> = ({ isDisabled = f
   return (
     <FieldArray name="diskEncryptionTangServers">
       {({ remove, push }) => (
-        <Stack>
-          <StackItem>
-            {values.diskEncryptionTangServers.length > 0 &&
-              values.diskEncryptionTangServers.map((tang, index) => (
-                <>
-                  <Tooltip
-                    key={index}
-                    hidden={index == 0 || isDisabled}
-                    exitDelay={REMOVE_TANG_SERVER_SHOWN_TIMER}
-                    flipBehavior={['right', 'bottom']}
-                    distance={1}
-                    className="tooltip-tang-servers"
-                    position="right-start"
-                    content={
-                      <Button
-                        variant={ButtonVariant.link}
-                        onClick={() => {
-                          remove(index);
-                        }}
-                      >
-                        <MinusCircleIcon size="sm" />
-                      </Button>
-                    }
-                  >
-                    <div>
-                      <InputField
-                        type={TextInputTypes.url}
-                        name={`diskEncryptionTangServers.${index}.url`}
-                        placeholder="http//tang.srv"
-                        label="Server URL"
-                        isRequired
-                        isDisabled={isDisabled}
-                      />
-                      &thinsp;
-                      <InputField
-                        type={TextInputTypes.text}
-                        name={`diskEncryptionTangServers.${index}.thumbprint`}
-                        label="Server Thumbprint"
-                        isRequired
-                        isDisabled={isDisabled}
-                      />
-                    </div>
-                  </Tooltip>{' '}
-                  &nbsp;
-                </>
-              ))}
-          </StackItem>
+        <Stack hasGutter>
+          {values.diskEncryptionTangServers.length > 0 &&
+            values.diskEncryptionTangServers.map((tang, index) => (
+              <StackItem key={index}>
+                <Tooltip
+                  key={index}
+                  hidden={index == 0 || isDisabled}
+                  exitDelay={REMOVE_TANG_SERVER_SHOWN_TIMER}
+                  flipBehavior={['right', 'bottom']}
+                  distance={1}
+                  className="tooltip-tang-servers"
+                  position="right-start"
+                  content={
+                    <Button
+                      variant={ButtonVariant.link}
+                      onClick={() => {
+                        remove(index);
+                      }}
+                    >
+                      <MinusCircleIcon size="sm" />
+                    </Button>
+                  }
+                >
+                  <div>
+                    <InputField
+                      type={TextInputTypes.url}
+                      name={`diskEncryptionTangServers.${index}.url`}
+                      placeholder="http//tang.srv"
+                      label="Server URL"
+                      isRequired
+                      isDisabled={isDisabled}
+                    />
+                    &thinsp;
+                    <InputField
+                      type={TextInputTypes.text}
+                      name={`diskEncryptionTangServers.${index}.thumbprint`}
+                      label="Server Thumbprint"
+                      isRequired
+                      isDisabled={isDisabled}
+                    />
+                  </div>
+                </Tooltip>{' '}
+              </StackItem>
+            ))}
+
           {!isDisabled && (
             <StackItem>
               <Button

--- a/src/common/components/clusterWizard/clusterDetailsValidation.ts
+++ b/src/common/components/clusterWizard/clusterDetailsValidation.ts
@@ -10,6 +10,30 @@ import {
 } from '../ui';
 import { ClusterDetailsValues } from './types';
 
+const emptyTangServers = () => {
+  return [
+    {
+      url: '',
+      thumbprint: '',
+    },
+  ];
+};
+
+const parseTangServers = (tangServersString?: string) => {
+  if (!tangServersString) {
+    return emptyTangServers();
+  }
+
+  let parsedTangServers = emptyTangServers();
+  try {
+    parsedTangServers = JSON.parse(tangServersString);
+  } catch (e) {
+    console.warn('Tang Servers can not be parsed');
+  }
+
+  return parsedTangServers;
+};
+
 export const getClusterDetailsInitialValues = ({
   cluster,
   pullSecret,
@@ -30,25 +54,6 @@ export const getClusterDetailsInitialValues = ({
     openshiftVersion = getDefaultOpenShiftVersion(ocpVersions),
   } = cluster || {};
 
-  const emptyTangServers = () => {
-    return [
-      {
-        url: '',
-        thumbprint: '',
-      },
-    ];
-  };
-
-  const parseTangServers = (tangServersString: string) => {
-    let parsedTangServers = emptyTangServers();
-    try {
-      parsedTangServers = JSON.parse(tangServersString);
-    } catch (e) {
-      console.warn('Tang Servers can not be parsed');
-    }
-    return parsedTangServers;
-  };
-
   return {
     name,
     highAvailabilityMode,
@@ -65,9 +70,7 @@ export const getClusterDetailsInitialValues = ({
       cluster?.diskEncryption?.enableOn ?? 'none',
     ),
     diskEncryptionMode: cluster?.diskEncryption?.mode ?? 'tpmv2',
-    diskEncryptionTangServers: cluster?.diskEncryption?.tangServers
-      ? parseTangServers(cluster.diskEncryption.tangServers)
-      : emptyTangServers(),
+    diskEncryptionTangServers: parseTangServers(cluster?.diskEncryption?.tangServers),
     diskEncryption: cluster?.diskEncryption ?? {},
   };
 };
@@ -108,7 +111,7 @@ export const getClusterDetailsValidationSchema = (
         },
         then: Yup.array().of(
           Yup.object().shape({
-            url: Yup.string().url('Tang Server Url must be a valid URL').required('Required.'),
+            url: Yup.string().url('Tang Server URL must be a valid URL').required('Required.'),
             thumbprint: Yup.string().required('Required.'),
           }),
         ),

--- a/src/common/config/constants.ts
+++ b/src/common/config/constants.ts
@@ -113,7 +113,7 @@ export const CLUSTER_FIELD_LABELS: { [key in string]: string } = {
   pullSecret: 'Pull secret',
   sshPublicKey: 'SSH public key',
   SNODisclaimer: 'Single Node OpenShift disclaimer',
-  diskEncryptionTangServers: 'Tang servers URL or thumbprint',
+  diskEncryptionTangServers: "Tang servers' URLs or thumbprints",
 };
 
 export const HOST_STATUS_DETAILS: { [key in Host['status'] | 'discovered']: string } = {

--- a/src/ocm/components/clusterWizard/ClusterWizardFooter.tsx
+++ b/src/ocm/components/clusterWizard/ClusterWizardFooter.tsx
@@ -32,7 +32,7 @@ const ValidationSection = ({ cluster, errorFields = [] }: ClusterValidationSecti
           title="Provided cluster configuration is not valid"
           isInline
         >
-          The following fields are not valid:{' '}
+          The following fields are invalid or missing:{' '}
           {errorFields.map((field: string) => CLUSTER_FIELD_LABELS[field]).join(', ')}.
         </Alert>
       )}

--- a/src/ocm/components/clusterWizard/ClusterWizardFooter.tsx
+++ b/src/ocm/components/clusterWizard/ClusterWizardFooter.tsx
@@ -15,6 +15,7 @@ import { ValidationsInfo } from '../../../common/types/clusters';
 import { wizardStepsValidationsMap } from '../clusterWizard/wizardTransition';
 import ClusterWizardContext from '../clusterWizard/ClusterWizardContext';
 import ClusterWizardStepValidationsAlert from '../../../common/components/clusterWizard/ClusterWizardStepValidationsAlert';
+import { selectClusterValidationsInfo } from '../../selectors';
 
 type ClusterValidationSectionProps = {
   cluster?: Cluster;
@@ -23,7 +24,7 @@ type ClusterValidationSectionProps = {
 
 const ValidationSection = ({ cluster, errorFields = [] }: ClusterValidationSectionProps) => {
   const { currentStepId } = React.useContext(ClusterWizardContext);
-  const validationsInfo = stringToJSON<ValidationsInfo>(cluster?.validationsInfo);
+  const validationsInfo = cluster && selectClusterValidationsInfo(cluster);
   return (
     <AlertGroup>
       {!!errorFields.length && (

--- a/src/ocm/components/clusterWizard/ClusterWizardFooter.tsx
+++ b/src/ocm/components/clusterWizard/ClusterWizardFooter.tsx
@@ -7,15 +7,13 @@ import {
   WizardFooterGenericProps,
   Alerts,
   useAlerts,
-  stringToJSON,
   CLUSTER_FIELD_LABELS,
 } from '../../../common';
 import { routeBasePath } from '../../config/routeBaseBath';
-import { ValidationsInfo } from '../../../common/types/clusters';
 import { wizardStepsValidationsMap } from '../clusterWizard/wizardTransition';
 import ClusterWizardContext from '../clusterWizard/ClusterWizardContext';
 import ClusterWizardStepValidationsAlert from '../../../common/components/clusterWizard/ClusterWizardStepValidationsAlert';
-import { selectClusterValidationsInfo } from '../../selectors';
+import { selectClusterValidationsInfo } from '../../selectors/clusterSelectors';
 
 type ClusterValidationSectionProps = {
   cluster?: Cluster;

--- a/src/ocm/selectors/clusterSelectors.ts
+++ b/src/ocm/selectors/clusterSelectors.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash/fp';
 import { Cluster, CpuArchitecture } from '../../common/api/types';
+import { stringToJSON, ValidationsInfo } from '../../common';
 
 export const selectMachineNetworkCIDR = ({
   machineNetworks,
@@ -21,3 +22,6 @@ export const isSNO = ({ highAvailabilityMode }: Partial<Cluster>) =>
   highAvailabilityMode === 'None';
 export const isArmArchitecture = ({ cpuArchitecture }: Partial<Cluster>) =>
   cpuArchitecture === CpuArchitecture.ARM;
+export const selectClusterValidationsInfo = ({ validationsInfo }: Partial<Cluster>) => {
+  return stringToJSON<ValidationsInfo>(validationsInfo);
+};

--- a/src/ocm/selectors/clusterSelectors.ts
+++ b/src/ocm/selectors/clusterSelectors.ts
@@ -1,6 +1,7 @@
 import _ from 'lodash/fp';
 import { Cluster, CpuArchitecture } from '../../common/api/types';
-import { stringToJSON, ValidationsInfo } from '../../common';
+import { stringToJSON } from '../../common/api/utils';
+import { ValidationsInfo } from '../../common/types';
 
 export const selectMachineNetworkCIDR = ({
   machineNetworks,

--- a/src/ocm/services/DiskEncryptionService.ts
+++ b/src/ocm/services/DiskEncryptionService.ts
@@ -26,7 +26,7 @@ const DiskEncryptionService = {
               values.enableDiskEncryptionOnWorkers,
             ),
       tangServers:
-        values.diskEncryptionMode == 'tang'
+        values.diskEncryptionMode === 'tang'
           ? JSON.stringify(values.diskEncryptionTangServers)
           : undefined,
     };


### PR DESCRIPTION
The different scenarios can be seen in the video (https://youtu.be/sfgRzMkisJA). 
For example, if the user fills the url and/or thumbprint fields of the tang server and then regrets and cancel the encryption, those fields will be reset to their initial values. Same thing will happen if he switches from SNO to a regular cluster. 
As long as on of the "enable on masters" and "enable on workers" is on, the tang servers' fields will maintain their current values. 

Relates to #1114