### PR TITLE
MGMT-9228: Show Static IP info only if hasDHCP is false

### DIFF
--- a/src/common/components/clusterConfiguration/DownloadIso.tsx
+++ b/src/common/components/clusterConfiguration/DownloadIso.tsx
@@ -42,7 +42,7 @@ const DownloadIso: React.FC<DownloadISOProps> = ({
     <>
       <ModalBoxBody>
         <Stack hasGutter>
-          {!hasDHCP && (
+          {hasDHCP === false && (
             <StackItem>
               <StaticIPInfo />
             </StackItem>


### PR DESCRIPTION
We dont want to show static ip info in OCM.