### PR TITLE
MGMT-8599: Add info that Cluster details cannot be edited

### DIFF
--- a/src/cim/components/ClusterDeployment/ClusterDeploymentDetailsForm.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentDetailsForm.tsx
@@ -1,5 +1,6 @@
 import { useFormikContext } from 'formik';
 import * as React from 'react';
+import { Alert, Stack, StackItem } from '@patternfly/react-core';
 import {
   ClusterDetailsFormFields,
   ClusterDetailsFormFieldsProps,
@@ -33,19 +34,32 @@ const ClusterDeploymentDetailsForm: React.FC<ClusterDeploymentDetailsFormProps> 
   const ocpVersions = React.useMemo(() => getOCPVersions(clusterImages), [clusterImages]);
   const isEditFlow = !!clusterDeployment;
   return (
-    <ClusterDetailsFormFields
-      toggleRedHatDnsService={toggleRedHatDnsService}
-      versions={ocpVersions}
-      canEditPullSecret={!clusterDeployment}
-      isPullSecretSet={!!clusterDeployment?.spec?.pullSecretRef?.name}
-      // isSNOGroupDisabled={!!clusterDeployment /* truish for create flow only */}
-      isNameDisabled={isEditFlow}
-      isBaseDnsDomainDisabled={isEditFlow}
-      forceOpenshiftVersion={agentClusterInstall?.spec?.imageSetRef?.name}
-      isOcm={false}
-      defaultPullSecret={pullSecret}
-      extensionAfter={extensionAfter}
-    />
+    <Stack hasGutter>
+      {isEditFlow && (
+        <StackItem>
+          <Alert
+            isInline
+            variant="info"
+            title="This page cannot be edited once the cluster draft is created."
+          />
+        </StackItem>
+      )}
+      <StackItem>
+        <ClusterDetailsFormFields
+          toggleRedHatDnsService={toggleRedHatDnsService}
+          versions={ocpVersions}
+          canEditPullSecret={!clusterDeployment}
+          isPullSecretSet={!!clusterDeployment?.spec?.pullSecretRef?.name}
+          // isSNOGroupDisabled={!!clusterDeployment /* truish for create flow only */}
+          isNameDisabled={isEditFlow}
+          isBaseDnsDomainDisabled={isEditFlow}
+          forceOpenshiftVersion={agentClusterInstall?.spec?.imageSetRef?.name}
+          isOcm={false}
+          defaultPullSecret={pullSecret}
+          extensionAfter={extensionAfter}
+        />
+      </StackItem>
+    </Stack>
   );
 };
 


### PR DESCRIPTION
![Screenshot from 2022-02-23 14-47-11](https://user-images.githubusercontent.com/2078045/155332028-8d6742d0-15cd-4074-8309-4ee5e673631b.png)

MGMT-8599 suggests to use tooltip for disabled fields, but all fields are disabled so @nirfarkas agreed to just use the alert. IIRC there was some text proposal but I dont remember. Is the current one ok ? @nirfarkas 