### PR TITLE
MGMT-9389: wrong form styling for networking step

### DIFF
--- a/src/ocm/components/clusterConfiguration/NetworkConfigurationForm.tsx
+++ b/src/ocm/components/clusterConfiguration/NetworkConfigurationForm.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useDispatch } from 'react-redux';
 import { Formik, FormikConfig, FormikProps } from 'formik';
 import _ from 'lodash';
-import { Grid, GridItem, Text, TextContent } from '@patternfly/react-core';
+import { Form, Grid, GridItem, Text, TextContent } from '@patternfly/react-core';
 
 import {
   Cluster,
@@ -155,7 +155,7 @@ const NetworkConfigurationForm: React.FC<{
       {({ isSubmitting, dirty, errors, touched }: FormikProps<NetworkConfigurationValues>) => {
         const errorFields = getFormikErrorFields(errors, touched);
         const form = (
-          <>
+          <Form>
             <Grid hasGutter>
               <GridItem>
                 <ClusterWizardStepHeader
@@ -180,7 +180,7 @@ const NetworkConfigurationForm: React.FC<{
               </GridItem>
             </Grid>
             <FormikAutoSave />
-          </>
+          </Form>
         );
 
         const footer = (


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-9389
root cause: Form section in NetworkConfigurationFormFields component was replaced with Grid
before:
![image (1)](https://user-images.githubusercontent.com/22211154/155475788-22e68863-f03f-4e0a-96c0-e404ffcacc52.png)

after:
![image](https://user-images.githubusercontent.com/22211154/155475821-f101392e-3f23-4f94-b8ed-4f62c6438b5a.png)

