### PR TITLE
Fix link to "add hosts" on cluster installation page

### DIFF
--- a/src/common/config/constants.ts
+++ b/src/common/config/constants.ts
@@ -27,7 +27,7 @@ export const ENCRYPTING_DISK_DURING_INSTALLATION =
 export const getOcpConsoleNodesPage = (ocpConsoleUrl: string) =>
   `${ocpConsoleUrl}/k8s/cluster/nodes`;
 
-export const REDHAT_CONSOLE_OPENSHIFT = 'console.redhat.com/openshift';
+export const REDHAT_CONSOLE_OPENSHIFT = 'https://cloud.redhat.com/openshift';
 
 // TODO(mlibra): Retrieve branding dynamically, if needed, i.e. via injecting to the "window" object
 export const getProductBrandingCode = () => 'redhat';

--- a/src/ocm/components/clusterDetail/ClusterDetail.tsx
+++ b/src/ocm/components/clusterDetail/ClusterDetail.tsx
@@ -109,7 +109,7 @@ const ClusterDetail: React.FC<ClusterDetailProps> = ({ cluster }) => {
                   Add new hosts by generating a new Discovery ISO under your cluster's "Add hosts”
                   tab on{' '}
                   <a href={REDHAT_CONSOLE_OPENSHIFT} target="_blank" rel="noopener noreferrer">
-                    console.redhat.com/openshift <ExternalLinkAltIcon />
+                    https://cloud.redhat.com/openshift <ExternalLinkAltIcon />
                   </a>
                   .
                 </p>


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-9391

The link now is "https://cloud.redhat.com/opehshift"

![image](https://user-images.githubusercontent.com/69599321/155490403-adc08cc5-e134-4557-bf9c-f7a9fe51bc93.png)
![image](https://user-images.githubusercontent.com/69599321/155490174-c705f36b-e0f5-4bfe-9967-22c6ef021f68.png)
