### PR TITLE
Remove AI lib logging through console.log.

### DIFF
--- a/src/common/hacks.ts
+++ b/src/common/hacks.ts
@@ -1,11 +1,6 @@
 import React from 'react';
-import { getAssistedUiLibVersion } from './config';
 
 // TODO(jtomasek): Stop using this once https://github.com/developit/microbundle/issues/564#issuecomment-593146626
 // is fixed, use `microbundle --jsxFragment React.Fragment` instead.
 // Workaround for TS17016
 window['Fragment'] = React.Fragment;
-
-if (process.env.NODE_ENV !== 'test') {
-  console.log('Assisted-ui-lib version: ', getAssistedUiLibVersion());
-}


### PR DESCRIPTION
The version is already included in[ html tree](https://github.com/openshift-assisted/assisted-ui-lib/blob/master/src/ocm/components/Router.tsx#L21)