### PR TITLE
Enable disc encryption should not be present in the CIM

### DIFF
--- a/src/common/components/clusterWizard/ClusterDetailsFormFields.tsx
+++ b/src/common/components/clusterWizard/ClusterDetailsFormFields.tsx
@@ -114,11 +114,14 @@ export const ClusterDetailsFormFields: React.FC<ClusterDetailsFormFieldsProps> =
       {extensionAfter?.['openshiftVersion'] && extensionAfter['openshiftVersion']}
       {canEditPullSecret && <PullSecret isOcm={isOcm} defaultPullSecret={defaultPullSecret} />}
       {extensionAfter?.['pullSecret'] && extensionAfter['pullSecret']}
-      <DiskEncryptionControlGroup
-        values={values}
-        isDisabled={isPullSecretSet}
-        isSNO={isSNO({ highAvailabilityMode })}
-      />
+      {isOcm && (
+        <DiskEncryptionControlGroup
+          values={values}
+          isDisabled={isPullSecretSet}
+          isSNO={isSNO({ highAvailabilityMode })}
+        />
+      )}
+
       {atListOneDiskEncryptionEnableOn && values.diskEncryptionMode == 'tpmv2' && (
         <Alert
           variant={AlertVariant.warning}


### PR DESCRIPTION
Enable disc encryption should not be present in the CIM
Related to issue: https://bugzilla.redhat.com/show_bug.cgi?id=2059609