### PR TITLE
Delete location annotation when no location is set

### DIFF
--- a/src/cim/components/helpers/clusterDeployment.ts
+++ b/src/cim/components/helpers/clusterDeployment.ts
@@ -64,8 +64,10 @@ export const getAnnotationsFromAgentSelector = (
 
   delete annotations[AGENT_AUTO_SELECT_ANNOTATION_KEY];
 
-  if (locations?.length) {
+  if (locations.length) {
     annotations[AGENT_LOCATION_LABEL_KEY] = locations.join(',');
+  } else {
+    delete annotations[AGENT_LOCATION_LABEL_KEY];
   }
 
   if (!autoSelectHosts) {


### PR DESCRIPTION
The problem: When user removes all location filters in host selection screen
the location annotation is not updated in clusterdeployment resource.

Fix: If no location filters are specified, delete the location annotation
from the clusterdeployment resource.