### PR TITLE
Don't show host progress popover when starting installation

### DIFF
--- a/src/common/components/hosts/HostStatus.tsx
+++ b/src/common/components/hosts/HostStatus.tsx
@@ -61,7 +61,7 @@ const HostStatusPopoverContent: React.FC<HostStatusPopoverContentProps> = ({
     );
   }
 
-  if (['installing', 'installing-in-progress'].includes(status)) {
+  if (['installing-in-progress'].includes(status)) {
     return (
       <TextContent>
         <HostProgress host={host} />
@@ -95,6 +95,7 @@ const HostStatusPopoverContent: React.FC<HostStatusPopoverContentProps> = ({
     [
       'preparing-for-installation',
       'preparing-successful',
+      'installing',
       'unbinding-pending-user-action',
       'binding',
       'unbinding',


### PR DESCRIPTION
Host status 'installing' is more of a 'starting installation'. At that
point the installation progress and stages are not reported.
The progress reporting starts with 'installing-in-progress' status.