### PR TITLE
Fix openshift version label in cluster deployment wizard

### DIFF
--- a/src/cim/components/helpers/versions.ts
+++ b/src/cim/components/helpers/versions.ts
@@ -67,6 +67,6 @@ export const getSelectedVersion = (
     (ci) => ci.metadata?.name === agentClusterInstall?.spec?.imageSetRef?.name,
   );
   return selectedClusterImage
-    ? getOCPVersions([selectedClusterImage])?.[0]?.label
+    ? getOCPVersions([selectedClusterImage])?.[0]?.version
     : agentClusterInstall?.spec?.imageSetRef?.name;
 };


### PR DESCRIPTION
Fixes the double `OpenShift OpenShift` in version field

![Screenshot from 2022-03-11 10-39-40](https://user-images.githubusercontent.com/2078045/157841839-081af23a-ecb1-44e5-a390-f448ef0bc26b.png)
