### PR TITLE
Bug 2060047: AI provisioning - Download kubeconfig should have yaml file extension

### DIFF
--- a/src/cim/components/ClusterDeployment/ClusterDeploymentKubeconfigDownload.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentKubeconfigDownload.tsx
@@ -32,7 +32,7 @@ const ClusterDeploymentKubeconfigDownload = ({
         if (!kubeconfig) throw new Error('Kubeconfig is empty.');
 
         const blob = new Blob([atob(kubeconfig)], { type: 'text/plain;charset=utf-8' });
-        saveAs(blob, 'kubeconfig.json');
+        saveAs(blob, 'kubeconfig.yaml');
       } catch (e) {
         console.error('Failed to fetch kubeconfig secret.', e);
       }


### PR DESCRIPTION
Related to https://bugzilla.redhat.com/show_bug.cgi?id=2060447