### PR TITLE
Bug 2061741: Host details shows clock speed at 0MHz in the cluster installation screen

### DIFF
--- a/src/common/api/types.ts
+++ b/src/common/api/types.ts
@@ -570,6 +570,7 @@ export interface Cpu {
   flags?: string[];
   modelName?: string;
   architecture?: string;
+  clockMegahertz?: number;
 }
 export interface CreateManifestParams {
   /**

--- a/src/common/components/hosts/hardwareInfo.ts
+++ b/src/common/components/hosts/hardwareInfo.ts
@@ -26,7 +26,7 @@ export const getDiskCapacity = (inventory: Inventory): number =>
     .reduce((diskSize: number, disk: Disk) => diskSize + (disk.sizeBytes || 0), 0) || 0;
 
 export const getHumanizedCpuClockSpeed = (inventory: Inventory) =>
-  Humanize.formatNumber(inventory.cpu?.frequency || 0);
+  Humanize.formatNumber(inventory.cpu?.frequency || inventory.cpu?.clockMegahertz || 0);
 
 export const getSimpleHardwareInfo = (inventory: Inventory): SimpleHardwareInfo => ({
   cores: inventory.cpu?.count || 0,


### PR DESCRIPTION
Related to https://bugzilla.redhat.com/show_bug.cgi?id=2061741