### PR TITLE
MGMT-9411: Fix host re-render

### DIFF
--- a/src/common/components/clusterConfiguration/NetworkConfigurationTable.tsx
+++ b/src/common/components/clusterConfiguration/NetworkConfigurationTable.tsx
@@ -83,19 +83,24 @@ const NetworkConfigurationTable: React.FC<NetworkConfigurationTableProps> = ({
 
   const paginationProps = usePagination(hosts.length);
 
+  const ExpandComponent = React.useCallback(
+    ({ obj }) => {
+      return (
+        <HostDetail
+          host={obj}
+          AdditionalNTPSourcesDialogToggleComponent={AdditionalNTPSourcesDialogToggleComponent}
+        />
+      );
+    },
+    [AdditionalNTPSourcesDialogToggleComponent],
+  );
+
   return (
     <HostsTable
       testId="networking-host-table"
       hosts={hosts}
       skipDisabled={skipDisabled}
-      ExpandComponent={({ obj }) => {
-        return (
-          <HostDetail
-            host={obj}
-            AdditionalNTPSourcesDialogToggleComponent={AdditionalNTPSourcesDialogToggleComponent}
-          />
-        );
-      }}
+      ExpandComponent={ExpandComponent}
       content={content}
       actionResolver={actionResolver}
       onSelect={onSelect}

--- a/src/ocm/components/clusterConfiguration/NetworkConfigurationForm.tsx
+++ b/src/ocm/components/clusterConfiguration/NetworkConfigurationForm.tsx
@@ -19,7 +19,7 @@ import {
   LoadingState,
 } from '../../../common';
 import { HostSubnet, NetworkConfigurationValues } from '../../../common/types/clusters';
-import { updateCluster } from '../../reducers/clusters/currentClusterSlice';
+import { updateClusterBase } from '../../reducers/clusters/currentClusterSlice';
 import { canNextNetwork } from '../clusterWizard/wizardTransition';
 import ClusterWizardContext from '../clusterWizard/ClusterWizardContext';
 import ClusterWizardFooter from '../clusterWizard/ClusterWizardFooter';
@@ -131,7 +131,7 @@ const NetworkConfigurationForm: React.FC<{
       }
 
       const { data } = await ClustersAPI.update(cluster.id, params);
-      dispatch(updateCluster(data));
+      dispatch(updateClusterBase(data));
       actions.resetForm({ values: getNetworkInitialValues(data, defaultNetworkSettings) });
     } catch (e) {
       handleApiError(e, () =>

--- a/src/ocm/components/hosts/use-hosts-table.tsx
+++ b/src/ocm/components/hosts/use-hosts-table.tsx
@@ -333,78 +333,98 @@ export const HostsTableModals: React.FC<HostsTableModalsProps> = ({
 
   const content = React.useMemo(() => [hostnameColumn(), statusColumn()], []);
   const paginationProps = usePagination(massDeleteHostDialog.data?.hosts?.length || 0);
+  
   return (
     <>
-      <EventsModal
-        title={`Host Events${eventsDialog.isOpen ? `: ${eventsDialog.data?.hostname}` : ''}`}
-        entityKind="host"
-        cluster={cluster}
-        hostId={eventsDialog.data?.hostId}
-        onClose={eventsDialog.close}
-        isOpen={eventsDialog.isOpen}
-        onFetchEvents={onFetchEvents}
-      />
-      <ResetHostModal
-        hostname={resetHostDialog.data?.hostname}
-        onClose={resetHostDialog.close}
-        isOpen={resetHostDialog.isOpen}
-        onReset={onReset}
-      />
-      <DeleteHostModal
-        hostname={deleteHostDialog.data?.hostname}
-        onClose={deleteHostDialog.close}
-        isOpen={deleteHostDialog.isOpen}
-        onDelete={onDelete}
-      />
-      <EditHostModal
-        host={editHostDialog.data?.host}
-        inventory={editHostDialog.data?.inventory}
-        usedHostnames={
-          cluster?.hosts?.map((h: Host) => h.requestedHostname).filter((h) => h) as
-            | string[]
-            | undefined
-        }
-        onClose={editHostDialog.close}
-        isOpen={editHostDialog.isOpen}
-        onSave={async (values: EditHostFormValues) => {
-          const { data } = await HostsService.updateHostName(
-            cluster.id,
-            values.hostId,
-            values.hostname,
-          );
-          resetCluster ? resetCluster() : dispatch(updateHost(data));
-          editHostDialog.close();
-        }}
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        onFormSaveError={(e: any) => {
-          let message;
-          handleApiError(e, () => (message = getErrorMessage(e)));
-          return message;
-        }}
-      />
-      <AdditionalNTPSourcesDialog
-        additionalNtpSource={cluster.additionalNtpSource}
-        isOpen={additionalNTPSourcesDialog.isOpen}
-        onClose={additionalNTPSourcesDialog.close}
-        onAdditionalNtpSource={onAdditionalNtpSource}
-      />
-      <UpdateDay2ApiVipModal
-        isOpen={UpdateDay2ApiVipDialog.isOpen}
-        onClose={UpdateDay2ApiVipDialog.close}
-        onUpdateDay2ApiVip={onUpdateDay2ApiVip}
-        currentApiVip={cluster.apiVipDnsName}
-      />
-      <MassChangeHostnameModal
-        isOpen={massUpdateHostnameDialog.isOpen}
-        onClose={massUpdateHostnameDialog.close}
-        hosts={massUpdateHostnameDialog.data?.cluster?.hosts || []}
-        selectedHostIDs={massUpdateHostnameDialog.data?.hostIDs || []}
-        onChangeHostname={(host, hostname) =>
-          HostsService.updateHostName(cluster.id, host.id, hostname)
-        }
-      />
-      <MassDeleteHostModal
-        isOpen={massDeleteHostDialog.isOpen}
+      {eventsDialog.isOpen && (
+        <EventsModal
+          isOpen
+          title={`Host Events${eventsDialog.isOpen ? `: ${eventsDialog.data?.hostname}` : ''}`}
+          entityKind="host"
+          cluster={cluster}
+          hostId={eventsDialog.data?.hostId}
+          onClose={eventsDialog.close}
+          onFetchEvents={onFetchEvents}
+        />
+      )}
+      {resetHostDialog.isOpen && (
+        <ResetHostModal
+          isOpen
+          hostname={resetHostDialog.data?.hostname}
+          onClose={resetHostDialog.close}
+          onReset={onReset}
+        />
+      )}
+
+      {deleteHostDialog.isOpen && (
+        <DeleteHostModal
+          isOpen
+          hostname={deleteHostDialog.data?.hostname}
+          onClose={deleteHostDialog.close}
+          onDelete={onDelete}
+        />
+      )}
+
+      {editHostDialog.isOpen && (
+        <EditHostModal
+          isOpen
+          host={editHostDialog.data?.host}
+          inventory={editHostDialog.data?.inventory}
+          usedHostnames={
+            cluster?.hosts?.map((h: Host) => h.requestedHostname).filter((h) => h) as
+              | string[]
+              | undefined
+          }
+          onClose={editHostDialog.close}
+          onSave={async (values: EditHostFormValues) => {
+            const { data } = await HostsService.updateHostName(
+              cluster.id,
+              values.hostId,
+              values.hostname,
+            );
+            resetCluster ? resetCluster() : dispatch(updateHost(data));
+            editHostDialog.close();
+          }}
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          onFormSaveError={(e: any) => {
+            let message;
+            handleApiError(e, () => (message = getErrorMessage(e)));
+            return message;
+          }}
+        />
+      )}
+
+      {additionalNTPSourcesDialog.isOpen && (
+        <AdditionalNTPSourcesDialog
+          isOpen
+          additionalNtpSource={cluster.additionalNtpSource}
+          onClose={additionalNTPSourcesDialog.close}
+          onAdditionalNtpSource={onAdditionalNtpSource}
+        />
+      )}
+
+      {UpdateDay2ApiVipDialog.isOpen && (
+        <UpdateDay2ApiVipModal
+          isOpen
+          onClose={UpdateDay2ApiVipDialog.close}
+          onUpdateDay2ApiVip={onUpdateDay2ApiVip}
+          currentApiVip={cluster.apiVipDnsName}
+        />
+      )}
+      {massUpdateHostnameDialog.isOpen && (
+        <MassChangeHostnameModal
+          isOpen
+          onClose={massUpdateHostnameDialog.close}
+          hosts={massUpdateHostnameDialog.data?.cluster?.hosts || []}
+          selectedHostIDs={massUpdateHostnameDialog.data?.hostIDs || []}
+          onChangeHostname={(host, hostname) =>
+            HostsService.updateHostName(cluster.id, host.id, hostname)
+          }
+        />
+      )}
+      {massDeleteHostDialog.isOpen && (
+        <MassDeleteHostModal
+        isOpen
         onClose={massDeleteHostDialog.close}
         hosts={massDeleteHostDialog.data?.hosts || []}
         onDelete={massDeleteHostDialog.data?.onDelete}
@@ -417,6 +437,7 @@ export const HostsTableModals: React.FC<HostsTableModalsProps> = ({
           <div>No hosts selected</div>
         </HostsTable>
       </MassDeleteHostModal>
+      )}
     </>
   );
 };

--- a/src/ocm/components/hosts/use-hosts-table.tsx
+++ b/src/ocm/components/hosts/use-hosts-table.tsx
@@ -333,7 +333,7 @@ export const HostsTableModals: React.FC<HostsTableModalsProps> = ({
 
   const content = React.useMemo(() => [hostnameColumn(), statusColumn()], []);
   const paginationProps = usePagination(massDeleteHostDialog.data?.hosts?.length || 0);
-  
+
   return (
     <>
       {eventsDialog.isOpen && (
@@ -424,19 +424,19 @@ export const HostsTableModals: React.FC<HostsTableModalsProps> = ({
       )}
       {massDeleteHostDialog.isOpen && (
         <MassDeleteHostModal
-        isOpen
-        onClose={massDeleteHostDialog.close}
-        hosts={massDeleteHostDialog.data?.hosts || []}
-        onDelete={massDeleteHostDialog.data?.onDelete}
-      >
-        <HostsTable
+          isOpen
+          onClose={massDeleteHostDialog.close}
           hosts={massDeleteHostDialog.data?.hosts || []}
-          content={content}
-          {...paginationProps}
+          onDelete={massDeleteHostDialog.data?.onDelete}
         >
-          <div>No hosts selected</div>
-        </HostsTable>
-      </MassDeleteHostModal>
+          <HostsTable
+            hosts={massDeleteHostDialog.data?.hosts || []}
+            content={content}
+            {...paginationProps}
+          >
+            <div>No hosts selected</div>
+          </HostsTable>
+        </MassDeleteHostModal>
       )}
     </>
   );

--- a/src/ocm/reducers/clusters/currentClusterSlice.ts
+++ b/src/ocm/reducers/clusters/currentClusterSlice.ts
@@ -45,9 +45,17 @@ export const currentClusterSlice = createSlice({
   initialState,
   name: 'currentCluster',
   reducers: {
-    updateCluster: (state, action: PayloadAction<Cluster>) => ({ ...state, data: action.payload }),
+    updateClusterBase: (state, action: PayloadAction<Cluster>) => {
+      // Should not overwrite the hosts once they are created
+      const originalHosts = state.data?.hosts || [];
+      return ({ ...state, data: { ...action.payload, hosts: originalHosts } });
+    },
+    updateCluster: (state, action: PayloadAction<Cluster>) => {
+      return ({ ...state, data: action.payload  });
+    },
     updateHost: (state, action: PayloadAction<Host>) => {
       const hostIndex = _.findIndex(state.data?.hosts, (host) => host.id === action.payload.id);
+
       if (hostIndex >= 0) {
         _.set(state, `data.hosts[${hostIndex}]`, action.payload);
       }
@@ -87,6 +95,7 @@ export const currentClusterSlice = createSlice({
 
 export const {
   updateCluster,
+  updateClusterBase,
   updateHost,
   cleanCluster,
   forceReload,

--- a/src/ocm/reducers/clusters/currentClusterSlice.ts
+++ b/src/ocm/reducers/clusters/currentClusterSlice.ts
@@ -48,10 +48,10 @@ export const currentClusterSlice = createSlice({
     updateClusterBase: (state, action: PayloadAction<Cluster>) => {
       // Should not overwrite the hosts once they are created
       const originalHosts = state.data?.hosts || [];
-      return ({ ...state, data: { ...action.payload, hosts: originalHosts } });
+      return { ...state, data: { ...action.payload, hosts: originalHosts } };
     },
     updateCluster: (state, action: PayloadAction<Cluster>) => {
-      return ({ ...state, data: action.payload  });
+      return { ...state, data: action.payload };
     },
     updateHost: (state, action: PayloadAction<Host>) => {
       const hostIndex = _.findIndex(state.data?.hosts, (host) => host.id === action.payload.id);


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-9411

After investigating the issue, I found out that this might be a performance problem on slower computers.

This PR avoid unnecessary re-rendering of complex components, such as the Host table.

. On NetworkConfigurationForm, on form submit, only update the "base" cluster data, and not the `hosts` property. This prevents the hosts table being re-rendered.

- Avoid rendering all modals, even when they are not open.

- Memoized `ExpandComponent` on `NetworkConfigurationTable` based on profiling results.

These changes should improve the performance of the Network config page.