### PR TITLE
MGMT-9340: Kubeconfig download button and inline notification are shown even when the file is not available

### DIFF
--- a/src/ocm/components/clusterDetail/ClusterDetail.tsx
+++ b/src/ocm/components/clusterDetail/ClusterDetail.tsx
@@ -20,6 +20,7 @@ import {
   RenderIf,
   KubeconfigDownload,
   REDHAT_CONSOLE_OPENSHIFT,
+  canDownloadKubeconfig,
 } from '../../../common';
 import ClusterHostsTable from '../hosts/ClusterHostsTable';
 import ClusterToolbar from '../clusters/ClusterToolbar';
@@ -79,7 +80,7 @@ const ClusterDetail: React.FC<ClusterDetailProps> = ({ cluster }) => {
             />
           </GridItem>
           <ClusterDetailStatusVarieties cluster={cluster} clusterVarieties={clusterVarieties} />
-          <RenderIf condition={dateDifference > 0}>
+          <RenderIf condition={dateDifference > 0 && canDownloadKubeconfig(cluster.status)}>
             <GridItem>
               <KubeconfigDownload
                 status={cluster.status}
@@ -88,7 +89,11 @@ const ClusterDetail: React.FC<ClusterDetailProps> = ({ cluster }) => {
               />
             </GridItem>
           </RenderIf>
-          <RenderIf condition={typeof inactiveDeletionHours === 'number'}>
+          <RenderIf
+            condition={
+              typeof inactiveDeletionHours === 'number' && canDownloadKubeconfig(cluster.status)
+            }
+          >
             <Alert
               variant="info"
               isInline


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-9340

The button and alert aren't shown if the file cannot be downloaded.

![Screenshot from 2022-03-18 11-07-32](https://user-images.githubusercontent.com/87187179/158985433-656a500f-fcd4-4f55-b8c8-7da5a181a891.png)
