### PR TITLE
Change lodash dependencies only for the used functions

### DIFF
--- a/src/cim/components/Agent/AgentsSelectionUtils.ts
+++ b/src/cim/components/Agent/AgentsSelectionUtils.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useFormikContext } from 'formik';
-import * as _ from 'lodash';
+import isEqual from 'lodash/isEqual';
 import { AgentK8sResource } from '../../types/k8s/agent';
 import {
   ClusterDeploymentHostsSelectionValues,
@@ -28,7 +28,7 @@ export const useAgentsAutoSelection = <FormValues extends AllowedFormValues>(
 
   React.useEffect(() => {
     const ids = matchingAgents.map((a) => a.metadata?.uid).splice(0, hostCount);
-    if (!_.isEqual(ids, autoSelectedHostIds)) {
+    if (!isEqual(ids, autoSelectedHostIds)) {
       setTimeout(() => setFieldValue('autoSelectedHostIds', ids, true));
     }
   }, [matchingAgents, setFieldValue, autoSelectedHostIds, hostCount]);

--- a/src/cim/components/Agent/tableUtils.tsx
+++ b/src/cim/components/Agent/tableUtils.tsx
@@ -18,7 +18,7 @@ import BMHStatus from './BMHStatus';
 import { getAgentStatus, getBMHStatus, getWizardStepAgentStatus } from '../helpers/status';
 import { filterByHostname } from '../../../common/components/hosts/utils';
 import { agentStatus, bmhStatus } from '../helpers/agentStatus';
-import { noop } from 'lodash';
+import noop from 'lodash/noop';
 
 export const agentHostnameColumn = (
   hosts: Host[],

--- a/src/cim/components/ClusterDeployment/ACMClusterDeploymentDetailsStep.tsx
+++ b/src/cim/components/ClusterDeployment/ACMClusterDeploymentDetailsStep.tsx
@@ -1,5 +1,5 @@
 import { Formik, FormikProps } from 'formik';
-import { noop } from 'lodash';
+import noop from 'lodash/noop';
 import * as React from 'react';
 import { Ref } from 'react';
 import { ClusterDetailsFormFieldsProps, ClusterDetailsValues } from '../../../common';

--- a/src/cim/components/ClusterDeployment/ClusterDeploymentHostDiscoveryTable.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentHostDiscoveryTable.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { noop } from 'lodash';
+import noop from 'lodash/noop';
 
 import { Host } from '../../../common/api/types';
 import { discoveryTypeColumn, agentStatusColumn, useAgentsTable } from '../Agent/tableUtils';

--- a/src/cim/components/ClusterDeployment/ClusterDeploymentHostsSelectionAdvanced.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentHostsSelectionAdvanced.tsx
@@ -1,4 +1,4 @@
-import * as _ from 'lodash';
+import isMatch from 'lodash/isMatch';
 import { useFormikContext } from 'formik';
 import React from 'react';
 import Measure from 'react-measure';
@@ -40,7 +40,7 @@ const ClusterDeploymentHostsSelectionAdvanced = <T extends FormValues>({
             )
           : true;
         const matchesLabels = agent.metadata?.labels
-          ? _.isMatch(agent.metadata?.labels, labels)
+          ? isMatch(agent.metadata?.labels, labels)
           : true;
         return matchesLocation && matchesLabels;
       }),

--- a/src/cim/components/ClusterDeployment/LabelsSelector.tsx
+++ b/src/cim/components/ClusterDeployment/LabelsSelector.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import * as _ from 'lodash';
+import flatten from 'lodash/flatten';
 import { MultiSelectField } from '../../../common';
 import { AgentK8sResource } from '../../types';
 import { MultiSelectOption } from '../../../common/components/ui/formik/types';
@@ -8,7 +8,7 @@ import { AGENT_LOCATION_LABEL_KEY, INFRAENV_AGENTINSTALL_LABEL_KEY } from '../co
 const LabelsSelector: React.FC<{ agents: AgentK8sResource[] }> = ({ agents }) => {
   const agentLabelOptions = Array.from(
     new Set(
-      _.flatten(
+      flatten(
         agents.map((agent) =>
           Object.keys(agent.metadata?.labels || {})
             .filter((k) => ![INFRAENV_AGENTINSTALL_LABEL_KEY, AGENT_LOCATION_LABEL_KEY].includes(k))

--- a/src/cim/components/ClusterDeployment/LocationsSelector.tsx
+++ b/src/cim/components/ClusterDeployment/LocationsSelector.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import * as _ from 'lodash';
+import countBy from 'lodash/countBy';
 import { MultiSelectField, PopoverIcon } from '../../../common';
 import { AGENT_LOCATION_LABEL_KEY, AGENT_NOLOCATION_VALUE } from '../common';
 import { AgentK8sResource } from '../../types';
@@ -30,7 +30,7 @@ const getNumOfHosts = (size: number) => {
 };
 
 const LocationsSelector: React.FC<{ agents: AgentK8sResource[] }> = ({ agents }) => {
-  const locations = _.countBy(
+  const locations = countBy(
     agents,
     ({ metadata }) => metadata?.labels?.[AGENT_LOCATION_LABEL_KEY] || AGENT_NOLOCATION_VALUE,
   );

--- a/src/cim/components/ClusterDeployment/helpers.ts
+++ b/src/cim/components/ClusterDeployment/helpers.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import _ from 'lodash';
+import mapKeys from 'lodash/mapKeys';
+import camelCase from 'lodash/camelCase';
+import uniq from 'lodash/uniq';
 import { EventList } from '../../../common/api/types';
 import {
   AgentClusterInstallK8sResource,
@@ -90,7 +92,7 @@ export const shouldShowClusterInstallationError = (
 };
 
 export const formatEventsData = (rawData: any): EventList =>
-  rawData.map((event: any) => _.mapKeys(event, (value, key) => _.camelCase(key)));
+  rawData.map((event: any) => mapKeys(event, (value, key) => camelCase(key)));
 
 // events are downloaded using ACM's wrapped fetchGet(), so the backendUrl is missing here
 const getEventsURL = (
@@ -147,7 +149,7 @@ export const getAgentsHostsNames = (
       raw.push(hostname);
     }
   });
-  return _.uniq(raw.filter(Boolean)) as string[];
+  return uniq(raw.filter(Boolean)) as string[];
 };
 
 export const getGridSpans = (

--- a/src/cim/components/InfraEnv/InfraEnvAgentTable.tsx
+++ b/src/cim/components/InfraEnv/InfraEnvAgentTable.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Button, DropdownItem, Stack, StackItem } from '@patternfly/react-core';
-import { noop } from 'lodash';
+import noop from 'lodash/noop';
 
 import { Host } from '../../../common/api/types';
 import {

--- a/src/cim/components/YamlPreview/useYAMLPreview.ts
+++ b/src/cim/components/YamlPreview/useYAMLPreview.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import * as React from 'react';
 import * as yaml from 'js-yaml';
 import { K8sResourceCommon } from 'console-sdk-ai-lib';
@@ -20,7 +20,7 @@ const resourceToString = (resource: K8sResourceCommon | undefined) => {
   if (!resource) {
     return undefined;
   }
-  const resourceClone = _.cloneDeep(resource);
+  const resourceClone = cloneDeep(resource);
   // eslint-disable-next-line
   delete (resourceClone as any).status;
   resourceClone.metadata = {

--- a/src/cim/components/helpers/toAssisted.ts
+++ b/src/cim/components/helpers/toAssisted.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 import { AgentK8sResource } from '../../types/k8s/agent';
 import { Cluster, Host, Inventory } from '../../../common/api/types';
 import { ClusterDeploymentK8sResource } from '../../types/k8s/cluster-deployment';
@@ -20,14 +20,14 @@ export const getAIHosts = (
       const { status } = getAgentStatus(agent, true);
       const statusInfo = agent.status?.debugInfo?.stateInfo || '';
       // TODO(mlibra) Remove that workaround once https://issues.redhat.com/browse/MGMT-7052 is fixed
-      const inventory: Inventory = _.cloneDeep(agent.status?.inventory || {});
+      const inventory: Inventory = cloneDeep(agent.status?.inventory || {});
       inventory.interfaces?.forEach((intf) => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
         // @ts-ignore
-        intf.ipv4Addresses = _.cloneDeep(intf.ipV4Addresses);
+        intf.ipv4Addresses = cloneDeep(intf.ipV4Addresses);
         // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
         // @ts-ignore
-        intf.ipv6Addresses = _.cloneDeep(intf.ipV6Addresses);
+        intf.ipv6Addresses = cloneDeep(intf.ipV6Addresses);
       });
 
       if (agent.metadata?.labels?.[AGENT_BMH_HOSTNAME_LABEL_KEY]) {

--- a/src/cim/components/helpers/versions.ts
+++ b/src/cim/components/helpers/versions.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import uniqBy from 'lodash/uniqBy';
 import { AgentClusterInstallK8sResource, ClusterImageSetK8sResource } from '../../types';
 import { OpenshiftVersionOptionType, OpenshiftVersion } from '../../../common';
 
@@ -55,7 +55,7 @@ export const getOCPVersions = (
     // make sure that the pre-selected one is the first-one after sorting
     versions[0].default = true;
   }
-  const deduped = _.uniqBy(versions, (v) => v.version);
+  const deduped = uniqBy(versions, (v) => v.version);
   return deduped;
 };
 

--- a/src/common/api/utils.ts
+++ b/src/common/api/utils.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import camelCase from 'lodash/camelCase';
 
 export const stringToJSON = <T>(jsonString: string | undefined): T | undefined => {
   let jsObject: T | undefined;
@@ -6,7 +6,7 @@ export const stringToJSON = <T>(jsonString: string | undefined): T | undefined =
     try {
       const camelCased = jsonString.replace(
         /"([\w-]+)":/g,
-        (_match, offset) => `"${_.camelCase(offset)}":`,
+        (_match, offset) => `"${camelCase(offset)}":`,
       );
       jsObject = JSON.parse(camelCased) as T;
     } catch (e) {

--- a/src/common/components/clusterWizard/ClusterWizardStepValidationsAlert.tsx
+++ b/src/common/components/clusterWizard/ClusterWizardStepValidationsAlert.tsx
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import lodashValues from 'lodash/values';
 import React from 'react';
 import {
   Alert,
@@ -41,7 +41,7 @@ const ClusterWizardStepValidationsAlert = <ClusterWizardStepsType extends string
       currentStepId,
       wizardStepsValidationsMap,
     );
-    const flattenedValues = _.values(reducedValidationsInfo).flat() as Validation[];
+    const flattenedValues = lodashValues(reducedValidationsInfo).flat() as Validation[];
     return {
       pendingClusterValidations: flattenedValues.filter(
         (validation) => validation.status === 'pending',

--- a/src/common/components/clusterWizard/ReviewValidations.tsx
+++ b/src/common/components/clusterWizard/ReviewValidations.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from 'lodash';
+import lodashValues from 'lodash/values';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 import {
   CheckCircleIcon,
@@ -198,7 +198,7 @@ export const HostsValidations: HostsValidationsFC = ({
     });
   });
 
-  const array = _.values(failingValidations);
+  const array = lodashValues(failingValidations);
   if (array.length === 0) {
     return <AllValidationsPassed />;
   }

--- a/src/common/components/clusterWizard/validationsInfoUtils.ts
+++ b/src/common/components/clusterWizard/validationsInfoUtils.ts
@@ -1,4 +1,7 @@
-import _ from 'lodash';
+import lodashValues from 'lodash/values';
+import lodashKeys from 'lodash/keys';
+import reduce from 'lodash/reduce';
+
 import { Cluster, ClusterValidationId, Host, HostValidationId } from '../../api/types';
 import {
   ClusterWizardStepStatusDeterminationObject,
@@ -43,7 +46,7 @@ export const findValidationFixStep = <ClusterWizardStepsType extends string>(
   },
   wizardStepsValidationsMap: WizardStepsValidationMap<ClusterWizardStepsType>,
 ): ClusterWizardStepsType | undefined => {
-  const keys = _.keys(wizardStepsValidationsMap) as ClusterWizardStepsType[];
+  const keys = lodashKeys(wizardStepsValidationsMap) as ClusterWizardStepsType[];
   return keys.find((key) => {
     // find first matching validation-map name
     const { cluster: clusterValidationMap, host: hostValidationMap } = wizardStepsValidationsMap[
@@ -62,7 +65,7 @@ export const checkClusterValidations = (
   clusterValidationsInfo: ClusterValidationsInfo,
   requiredIds: ClusterValidationId[],
 ): boolean => {
-  const requiredValidations = _.values(clusterValidationsInfo)
+  const requiredValidations = lodashValues(clusterValidationsInfo)
     .flat()
     .filter((v) => v && requiredIds.includes(v.id));
   return (
@@ -89,7 +92,7 @@ export const checkHostValidations = (
   hostValidationsInfo: HostValidationsInfo,
   requiredIds: HostValidationId[],
 ): boolean => {
-  const requiredValidations = _.values(hostValidationsInfo)
+  const requiredValidations = lodashValues(hostValidationsInfo)
     .flat()
     .filter((v) => v && requiredIds.includes(v.id));
 
@@ -119,7 +122,7 @@ export const getWizardStepHostValidationsInfo = <ClusterWizardStepsType extends 
   wizardStepsValidationsMap: WizardStepsValidationMap<ClusterWizardStepsType>,
 ): HostValidationsInfo => {
   const { groups, validationIds } = wizardStepsValidationsMap[wizardStepId].host;
-  return _.reduce(
+  return reduce(
     validationsInfo,
     (result, groupValidations, groupName) => {
       if (groups.includes(groupName as HostValidationGroup)) {
@@ -167,7 +170,7 @@ export const getWizardStepClusterValidationsInfo = <ClusterWizardStepsType exten
   wizardStepsValidationsMap: WizardStepsValidationMap<ClusterWizardStepsType>,
 ): ClusterValidationsInfo => {
   const { groups, validationIds } = wizardStepsValidationsMap[wizardStepId].cluster;
-  return _.reduce(
+  return reduce(
     validationsInfo,
     (result, groupValidations, groupName) => {
       if (groups.includes(groupName as ClusterValidationGroup)) {

--- a/src/common/components/ui/ClusterEventsToolbar.tsx
+++ b/src/common/components/ui/ClusterEventsToolbar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from 'lodash';
+import capitalize from 'lodash/capitalize';
 import {
   Toolbar,
   ToolbarItem,
@@ -250,7 +250,7 @@ const ClusterEventsToolbar: React.FC<ClustersListToolbarProps> = ({
           chips={filters.severity.map(
             (severity): ToolbarChip => ({
               key: severity,
-              node: _.capitalize(severity),
+              node: capitalize(severity),
             }),
           )}
           deleteChip={onDeleteChip}
@@ -272,7 +272,7 @@ const ClusterEventsToolbar: React.FC<ClustersListToolbarProps> = ({
                 key={severity}
                 value={severity}
               >
-                {_.capitalize(severity)} <Badge isRead>{getEventsCount(severity, events)}</Badge>
+                {capitalize(severity)} <Badge isRead>{getEventsCount(severity, events)}</Badge>
               </SelectOption>
             ))}
           </Select>

--- a/src/common/components/ui/formik/FormikAutoSave.tsx
+++ b/src/common/components/ui/formik/FormikAutoSave.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { shallowEqual } from 'react-redux';
-import _ from 'lodash';
+import debouncer from 'lodash/debounce';
 import { useFormikContext } from 'formik';
 
 const FormikAutoSave: React.FC<{ debounce?: number }> = ({ debounce = 1000 }) => {
   const { values, dirty, isSubmitting, submitForm } = useFormikContext();
   const prevValuesRef = React.useRef(values);
-  const commitRef = React.useRef(_.debounce(submitForm, debounce));
+  const commitRef = React.useRef(debouncer(submitForm, debounce));
 
   React.useEffect(() => {
     if (!shallowEqual(prevValuesRef.current, values) && dirty && !isSubmitting) {

--- a/src/common/components/ui/table/utils.ts
+++ b/src/common/components/ui/table/utils.ts
@@ -1,5 +1,6 @@
 import React from 'react';
-import _ from 'lodash';
+import upperFirst from 'lodash/upperFirst';
+import endsWith from 'lodash/endsWith';
 import { ISortBy, SortByDirection, IRow } from '@patternfly/react-table';
 import { getHumanizedDateTime } from '../utils';
 
@@ -47,7 +48,7 @@ export const rowSorter = (sortBy: ISortBy, getCell: getCellType) => (a: IRow, b:
 
 /** Converts string into a sentence by capitalizing first letter and appending with . */
 export const toSentence = (s: string) =>
-  `${_.upperFirst(s)}${_.endsWith(s, '.') || s === '' ? '' : '.'}`;
+  `${upperFirst(s)}${endsWith(s, '.') || s === '' ? '' : '.'}`;
 
 export const getDateTimeCell = (time?: string): HumanizedSortable => {
   const date = getHumanizedDateTime(time);

--- a/src/common/hooks/useDeepCompareMemoize.ts
+++ b/src/common/hooks/useDeepCompareMemoize.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import * as _ from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 const useDeepCompareMemoize = <T>(value: T): T => {
   const ref = React.useRef<T>(value);
 
-  if (!_.isEqual(value, ref.current)) {
+  if (!isEqual(value, ref.current)) {
     ref.current = value;
   }
 

--- a/src/common/selectors/clusterSelectors.ts
+++ b/src/common/selectors/clusterSelectors.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash/fp';
+import head from 'lodash/fp/head';
 import { stringToJSON } from '../api/utils';
 import { CpuArchitecture, ValidationsInfo } from '../types';
 import { Cluster } from '../api/types';
@@ -6,19 +6,19 @@ import { Cluster } from '../api/types';
 export const selectMachineNetworkCIDR = ({
   machineNetworks,
   machineNetworkCidr,
-}: Partial<Cluster>) => _.head(machineNetworks)?.cidr ?? machineNetworkCidr;
+}: Partial<Cluster>) => head(machineNetworks)?.cidr ?? machineNetworkCidr;
 export const selectClusterNetworkCIDR = ({
   clusterNetworks,
   clusterNetworkCidr,
-}: Partial<Cluster>) => _.head(clusterNetworks)?.cidr ?? clusterNetworkCidr;
+}: Partial<Cluster>) => head(clusterNetworks)?.cidr ?? clusterNetworkCidr;
 export const selectClusterNetworkHostPrefix = ({
   clusterNetworks,
   clusterNetworkHostPrefix,
-}: Partial<Cluster>) => _.head(clusterNetworks)?.hostPrefix ?? clusterNetworkHostPrefix;
+}: Partial<Cluster>) => head(clusterNetworks)?.hostPrefix ?? clusterNetworkHostPrefix;
 export const selectServiceNetworkCIDR = ({
   serviceNetworks,
   serviceNetworkCidr,
-}: Partial<Cluster>) => _.head(serviceNetworks)?.cidr ?? serviceNetworkCidr;
+}: Partial<Cluster>) => head(serviceNetworks)?.cidr ?? serviceNetworkCidr;
 export const isSNO = ({ highAvailabilityMode }: Partial<Cluster>) =>
   highAvailabilityMode === 'None';
 export const isArmArchitecture = ({ cpuArchitecture }: Partial<Cluster>) =>

--- a/src/ocm/api/utils.ts
+++ b/src/ocm/api/utils.ts
@@ -1,6 +1,6 @@
 import { Severity } from '@sentry/browser';
 import Axios, { AxiosError } from 'axios';
-import _ from 'lodash';
+import pick from 'lodash/pick';
 import { captureException } from '../sentry';
 import { APIErrorMixin } from './types';
 
@@ -20,7 +20,7 @@ export const handleApiError = (
       // that falls out of the range of 2xx
       message += `Status: ${error.response.status}\n`;
       message += `Response: ${JSON.stringify(
-        _.pick(error.response.data, ['code', 'message', 'reason']),
+        pick(error.response.data, ['code', 'message', 'reason']),
         null,
         1,
       )}\n`;

--- a/src/ocm/components/clusterConfiguration/ClusterDefaultConfigurationContext.tsx
+++ b/src/ocm/components/clusterConfiguration/ClusterDefaultConfigurationContext.tsx
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import pick from 'lodash/pick';
 import React, { PropsWithChildren, useContext, useEffect } from 'react';
 import { ClusterDefaultConfig } from '../../../common';
 import { ClustersAPI } from '../../services/apis';
@@ -88,5 +88,5 @@ export const ClusterDefaultConfigurationProvider = ({
 
 export const useDefaultConfiguration = (keys: Array<keyof ClusterDefaultConfig>) => {
   // TODO(mlibra): There is no more the need to pick just selected values here, we can pass all the retrieved data
-  return _.pick(useContext(ClusterDefaultConfigurationContext), keys);
+  return pick(useContext(ClusterDefaultConfigurationContext), keys);
 };

--- a/src/ocm/components/clusterConfiguration/NetworkConfigurationForm.tsx
+++ b/src/ocm/components/clusterConfiguration/NetworkConfigurationForm.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
 import { Formik, FormikConfig, FormikProps } from 'formik';
-import _ from 'lodash';
+import mapValues from 'lodash/mapValues';
+import omit from 'lodash/omit';
 import { Form, Grid, GridItem, Text, TextContent } from '@patternfly/react-core';
 
 import {
@@ -51,9 +52,7 @@ const NetworkConfigurationForm: React.FC<{
     [], // just once, Formik does not reinitialize
   );
 
-  const initialTouched = React.useMemo(() => _.mapValues(initialValues, () => true), [
-    initialValues,
-  ]);
+  const initialTouched = React.useMemo(() => mapValues(initialValues, () => true), [initialValues]);
 
   const memoizedValidationSchema = React.useMemo(
     () => getNetworkConfigurationValidationSchema(initialValues, hostSubnets),
@@ -87,7 +86,7 @@ const NetworkConfigurationForm: React.FC<{
     try {
       const isMultiNodeCluster = !isSNO(cluster);
       const isUserManagedNetworking = values.managedNetworkingType === 'userManaged';
-      const params = _.omit(values, [
+      const params = omit(values, [
         'hostSubnet',
         'useRedHatDnsService',
         'managedNetworkingType',

--- a/src/ocm/components/clusterDetail/utils.tsx
+++ b/src/ocm/components/clusterDetail/utils.tsx
@@ -1,5 +1,5 @@
 import { saveAs } from 'file-saver';
-import { get } from 'lodash';
+import get from 'lodash/get';
 import { ocmClient, handleApiError, getErrorMessage } from '../../api';
 import {
   Cluster,

--- a/src/ocm/components/clusterWizard/ClusterDetails.tsx
+++ b/src/ocm/components/clusterWizard/ClusterDetails.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from 'lodash';
+import omit from 'lodash/omit';
 import { useHistory } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import {
@@ -44,7 +44,7 @@ const ClusterDetails: React.FC<ClusterDetailsProps> = ({ cluster }) => {
   const handleClusterUpdate = React.useCallback(
     async (clusterId: Cluster['id'], values: V2ClusterUpdateParams) => {
       clearAlerts();
-      const params: V2ClusterUpdateParams = _.omit(values, [
+      const params: V2ClusterUpdateParams = omit(values, [
         'highAvailabilityMode',
         'pullSecret',
         'openshiftVersion',

--- a/src/ocm/components/clusterWizard/ClusterDetailsForm.tsx
+++ b/src/ocm/components/clusterWizard/ClusterDetailsForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from 'lodash';
+import isUndefined from 'lodash/isUndefined';
 import { Formik, FormikHelpers } from 'formik';
 import {
   Cluster,
@@ -69,7 +69,7 @@ const ClusterDetailsForm: React.FC<ClusterDetailsFormProps> = (props) => {
     cluster?: Cluster,
   ): (() => Promise<void> | void) => {
     let fn: () => Promise<void> | void = submitForm;
-    if (!dirty && !_.isUndefined(cluster) && canNextClusterDetails({ cluster })) {
+    if (!dirty && !isUndefined(cluster) && canNextClusterDetails({ cluster })) {
       fn = moveNext;
     }
 

--- a/src/ocm/components/clusters/ClustersListToolbar.tsx
+++ b/src/ocm/components/clusters/ClustersListToolbar.tsx
@@ -25,7 +25,7 @@ import { ResourceUIState } from '../../../common';
 import { selectClustersUIState } from '../../selectors/clusters';
 import { fetchClustersAsync } from '../../reducers/clusters/clustersSlice';
 import { routeBasePath } from '../../config';
-import _ from 'lodash';
+import omit from 'lodash/omit';
 
 export type ClusterFiltersType = {
   [key: string]: string[]; // value from CLUSTER_STATUS_LABELS
@@ -39,7 +39,7 @@ type ClustersListToolbarProps = {
 };
 
 const clusterStatusFilterLabels = Array.from(
-  new Set(Object.values(_.omit(CLUSTER_STATUS_LABELS, 'adding-hosts'))),
+  new Set(Object.values(omit(CLUSTER_STATUS_LABELS, 'adding-hosts'))),
 );
 
 const ClustersListToolbar: React.FC<ClustersListToolbarProps> = ({

--- a/src/ocm/components/clusters/utils.test.ts
+++ b/src/ocm/components/clusters/utils.test.ts
@@ -1,6 +1,6 @@
 import type { Cluster, Host } from '../../../common';
 import { calculateCollectedLogsCount, filterHostsByLogStates } from './utils';
-import { uniqueId } from 'lodash';
+import uniqueId from 'lodash/uniqueId';
 
 const hostTemplate: Host = {
   id: '',

--- a/src/ocm/reducers/clusters/currentClusterSlice.ts
+++ b/src/ocm/reducers/clusters/currentClusterSlice.ts
@@ -1,4 +1,5 @@
-import _ from 'lodash';
+import findIndex from 'lodash/findIndex';
+import set from 'lodash/set';
 import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
 import { Cluster, Host } from '../../../common';
 import { handleApiError } from '../../api/utils';
@@ -54,10 +55,10 @@ export const currentClusterSlice = createSlice({
       return { ...state, data: action.payload };
     },
     updateHost: (state, action: PayloadAction<Host>) => {
-      const hostIndex = _.findIndex(state.data?.hosts, (host) => host.id === action.payload.id);
+      const hostIndex = findIndex(state.data?.hosts, (host) => host.id === action.payload.id);
 
       if (hostIndex >= 0) {
-        _.set(state, `data.hosts[${hostIndex}]`, action.payload);
+        set(state, `data.hosts[${hostIndex}]`, action.payload);
       }
       return state;
     },

--- a/src/ocm/services/ClusterDetailsService.ts
+++ b/src/ocm/services/ClusterDetailsService.ts
@@ -1,7 +1,7 @@
 import { ClusterCreateParams, V2ClusterUpdateParams } from '../../common';
 import { ClustersAPI, ManagedDomainsAPI } from '../services/apis';
 import InfraEnvsService from './InfraEnvsService';
-import _ from 'lodash';
+import omit from 'lodash/omit';
 import DiskEncryptionService from './DiskEncryptionService';
 import { OcmClusterDetailsValues } from '../api/types';
 import { isArmArchitecture } from '../../common/selectors/clusterSelectors';
@@ -32,7 +32,7 @@ const ClusterDetailsService = {
   },
 
   getClusterCreateParams(values: OcmClusterDetailsValues): ClusterCreateParams {
-    const params: ClusterCreateParams = _.omit(values, [
+    const params: ClusterCreateParams = omit(values, [
       'useRedHatDnsService',
       'SNODisclaimer',
       'enableDiskEncryptionOnMasters',


### PR DESCRIPTION
The bundle for `assisted-ui-lib` in `dev` mode is pretty large (aprox. 17MB), which results in slow build times.
The main libraries in the bundle are are `patternfly`, `monaco-editor` and `lodash`. 

This PR focuses on `lodash`, and it reduces its size in the dev mode bundle, from aprox. 500Kb of bundle size in dev mode to aprox. 150Kb.

We could later try to apply the same principles on the `patternfly` imports to slim the bundle further, as it's the biggest dependency we have.

Before
![build-initial](https://user-images.githubusercontent.com/829045/159914842-62025126-0804-418f-bc58-e8378e7d3fb0.png)

After
![build-after](https://user-images.githubusercontent.com/829045/159913851-48cc623e-9310-4e16-970f-88c6f75e2241.png)

**NOTE** There will be a separate PR in `assisted-ui` which has a bigger impact than this PR in reducing the build time on changes to `assisted-ui-lib`.
