### PR TITLE
Use import to lodash functions not the entire module - Common

### DIFF
--- a/src/common/api/utils.ts
+++ b/src/common/api/utils.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import camelCase from 'lodash/camelCase';
 
 export const stringToJSON = <T>(jsonString: string | undefined): T | undefined => {
   let jsObject: T | undefined;
@@ -6,7 +6,7 @@ export const stringToJSON = <T>(jsonString: string | undefined): T | undefined =
     try {
       const camelCased = jsonString.replace(
         /"([\w-]+)":/g,
-        (_match, offset) => `"${_.camelCase(offset)}":`,
+        (_match, offset) => `"${camelCase(offset)}":`,
       );
       jsObject = JSON.parse(camelCased) as T;
     } catch (e) {

--- a/src/common/components/clusterWizard/ClusterWizardStepValidationsAlert.tsx
+++ b/src/common/components/clusterWizard/ClusterWizardStepValidationsAlert.tsx
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import lodashValues from 'lodash/values';
 import React from 'react';
 import {
   Alert,
@@ -41,7 +41,7 @@ const ClusterWizardStepValidationsAlert = <ClusterWizardStepsType extends string
       currentStepId,
       wizardStepsValidationsMap,
     );
-    const flattenedValues = _.values(reducedValidationsInfo).flat() as Validation[];
+    const flattenedValues = lodashValues(reducedValidationsInfo).flat() as Validation[];
     return {
       pendingClusterValidations: flattenedValues.filter(
         (validation) => validation.status === 'pending',

--- a/src/common/components/clusterWizard/ReviewValidations.tsx
+++ b/src/common/components/clusterWizard/ReviewValidations.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from 'lodash';
+import lodashValues from 'lodash/values';
 import { Button, ButtonVariant } from '@patternfly/react-core';
 import {
   CheckCircleIcon,
@@ -198,7 +198,7 @@ export const HostsValidations: HostsValidationsFC = ({
     });
   });
 
-  const array = _.values(failingValidations);
+  const array = lodashValues(failingValidations);
   if (array.length === 0) {
     return <AllValidationsPassed />;
   }

--- a/src/common/components/clusterWizard/validationsInfoUtils.ts
+++ b/src/common/components/clusterWizard/validationsInfoUtils.ts
@@ -1,4 +1,7 @@
-import _ from 'lodash';
+import lodashValues from 'lodash/values';
+import lodashKeys from 'lodash/keys';
+import reduce from 'lodash/reduce';
+
 import { Cluster, ClusterValidationId, Host, HostValidationId } from '../../api/types';
 import {
   ClusterWizardStepStatusDeterminationObject,
@@ -43,7 +46,7 @@ export const findValidationFixStep = <ClusterWizardStepsType extends string>(
   },
   wizardStepsValidationsMap: WizardStepsValidationMap<ClusterWizardStepsType>,
 ): ClusterWizardStepsType | undefined => {
-  const keys = _.keys(wizardStepsValidationsMap) as ClusterWizardStepsType[];
+  const keys = lodashKeys(wizardStepsValidationsMap) as ClusterWizardStepsType[];
   return keys.find((key) => {
     // find first matching validation-map name
     const { cluster: clusterValidationMap, host: hostValidationMap } = wizardStepsValidationsMap[
@@ -62,7 +65,7 @@ export const checkClusterValidations = (
   clusterValidationsInfo: ClusterValidationsInfo,
   requiredIds: ClusterValidationId[],
 ): boolean => {
-  const requiredValidations = _.values(clusterValidationsInfo)
+  const requiredValidations = lodashValues(clusterValidationsInfo)
     .flat()
     .filter((v) => v && requiredIds.includes(v.id));
   return (
@@ -89,7 +92,7 @@ export const checkHostValidations = (
   hostValidationsInfo: HostValidationsInfo,
   requiredIds: HostValidationId[],
 ): boolean => {
-  const requiredValidations = _.values(hostValidationsInfo)
+  const requiredValidations = lodashValues(hostValidationsInfo)
     .flat()
     .filter((v) => v && requiredIds.includes(v.id));
 
@@ -119,7 +122,7 @@ export const getWizardStepHostValidationsInfo = <ClusterWizardStepsType extends 
   wizardStepsValidationsMap: WizardStepsValidationMap<ClusterWizardStepsType>,
 ): HostValidationsInfo => {
   const { groups, validationIds } = wizardStepsValidationsMap[wizardStepId].host;
-  return _.reduce(
+  return reduce(
     validationsInfo,
     (result, groupValidations, groupName) => {
       if (groups.includes(groupName as HostValidationGroup)) {
@@ -167,7 +170,7 @@ export const getWizardStepClusterValidationsInfo = <ClusterWizardStepsType exten
   wizardStepsValidationsMap: WizardStepsValidationMap<ClusterWizardStepsType>,
 ): ClusterValidationsInfo => {
   const { groups, validationIds } = wizardStepsValidationsMap[wizardStepId].cluster;
-  return _.reduce(
+  return reduce(
     validationsInfo,
     (result, groupValidations, groupName) => {
       if (groups.includes(groupName as ClusterValidationGroup)) {

--- a/src/common/components/ui/ClusterEventsToolbar.tsx
+++ b/src/common/components/ui/ClusterEventsToolbar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from 'lodash';
+import capitalize from 'lodash/capitalize';
 import {
   Toolbar,
   ToolbarItem,
@@ -250,7 +250,7 @@ const ClusterEventsToolbar: React.FC<ClustersListToolbarProps> = ({
           chips={filters.severity.map(
             (severity): ToolbarChip => ({
               key: severity,
-              node: _.capitalize(severity),
+              node: capitalize(severity),
             }),
           )}
           deleteChip={onDeleteChip}
@@ -272,7 +272,7 @@ const ClusterEventsToolbar: React.FC<ClustersListToolbarProps> = ({
                 key={severity}
                 value={severity}
               >
-                {_.capitalize(severity)} <Badge isRead>{getEventsCount(severity, events)}</Badge>
+                {capitalize(severity)} <Badge isRead>{getEventsCount(severity, events)}</Badge>
               </SelectOption>
             ))}
           </Select>

--- a/src/common/components/ui/formik/FormikAutoSave.tsx
+++ b/src/common/components/ui/formik/FormikAutoSave.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { shallowEqual } from 'react-redux';
-import _ from 'lodash';
+import debouncer from 'lodash/debounce';
 import { useFormikContext } from 'formik';
 
 const FormikAutoSave: React.FC<{ debounce?: number }> = ({ debounce = 1000 }) => {
   const { values, dirty, isSubmitting, submitForm } = useFormikContext();
   const prevValuesRef = React.useRef(values);
-  const commitRef = React.useRef(_.debounce(submitForm, debounce));
+  const commitRef = React.useRef(debouncer(submitForm, debounce));
 
   React.useEffect(() => {
     if (!shallowEqual(prevValuesRef.current, values) && dirty && !isSubmitting) {

--- a/src/common/components/ui/table/utils.ts
+++ b/src/common/components/ui/table/utils.ts
@@ -1,5 +1,6 @@
 import React from 'react';
-import _ from 'lodash';
+import upperFirst from 'lodash/upperFirst';
+import endsWith from 'lodash/endsWith';
 import { ISortBy, SortByDirection, IRow } from '@patternfly/react-table';
 import { getHumanizedDateTime } from '../utils';
 
@@ -47,7 +48,7 @@ export const rowSorter = (sortBy: ISortBy, getCell: getCellType) => (a: IRow, b:
 
 /** Converts string into a sentence by capitalizing first letter and appending with . */
 export const toSentence = (s: string) =>
-  `${_.upperFirst(s)}${_.endsWith(s, '.') || s === '' ? '' : '.'}`;
+  `${upperFirst(s)}${endsWith(s, '.') || s === '' ? '' : '.'}`;
 
 export const getDateTimeCell = (time?: string): HumanizedSortable => {
   const date = getHumanizedDateTime(time);

--- a/src/common/hooks/useDeepCompareMemoize.ts
+++ b/src/common/hooks/useDeepCompareMemoize.ts
@@ -1,10 +1,10 @@
 import * as React from 'react';
-import * as _ from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 const useDeepCompareMemoize = <T>(value: T): T => {
   const ref = React.useRef<T>(value);
 
-  if (!_.isEqual(value, ref.current)) {
+  if (!isEqual(value, ref.current)) {
     ref.current = value;
   }
 

--- a/src/common/selectors/clusterSelectors.ts
+++ b/src/common/selectors/clusterSelectors.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash/fp';
+import head from 'lodash/fp/head';
 import { stringToJSON } from '../api/utils';
 import { CpuArchitecture, ValidationsInfo } from '../types';
 import { Cluster } from '../api/types';
@@ -6,19 +6,19 @@ import { Cluster } from '../api/types';
 export const selectMachineNetworkCIDR = ({
   machineNetworks,
   machineNetworkCidr,
-}: Partial<Cluster>) => _.head(machineNetworks)?.cidr ?? machineNetworkCidr;
+}: Partial<Cluster>) => head(machineNetworks)?.cidr ?? machineNetworkCidr;
 export const selectClusterNetworkCIDR = ({
   clusterNetworks,
   clusterNetworkCidr,
-}: Partial<Cluster>) => _.head(clusterNetworks)?.cidr ?? clusterNetworkCidr;
+}: Partial<Cluster>) => head(clusterNetworks)?.cidr ?? clusterNetworkCidr;
 export const selectClusterNetworkHostPrefix = ({
   clusterNetworks,
   clusterNetworkHostPrefix,
-}: Partial<Cluster>) => _.head(clusterNetworks)?.hostPrefix ?? clusterNetworkHostPrefix;
+}: Partial<Cluster>) => head(clusterNetworks)?.hostPrefix ?? clusterNetworkHostPrefix;
 export const selectServiceNetworkCIDR = ({
   serviceNetworks,
   serviceNetworkCidr,
-}: Partial<Cluster>) => _.head(serviceNetworks)?.cidr ?? serviceNetworkCidr;
+}: Partial<Cluster>) => head(serviceNetworks)?.cidr ?? serviceNetworkCidr;
 export const isSNO = ({ highAvailabilityMode }: Partial<Cluster>) =>
   highAvailabilityMode === 'None';
 export const isArmArchitecture = ({ cpuArchitecture }: Partial<Cluster>) =>


### PR DESCRIPTION
Changed the imports of specific `lodash` functions to avoid loading the entire `lodash` module and reduce build time / bundle size.

This PR changes only the usages within `common` code.

More details in https://github.com/openshift-assisted/assisted-ui-lib/pull/1250