### PR TITLE
Use import to lodash functions not the entire module - OCM

### DIFF
--- a/src/ocm/api/utils.ts
+++ b/src/ocm/api/utils.ts
@@ -1,6 +1,6 @@
 import { Severity } from '@sentry/browser';
 import Axios, { AxiosError } from 'axios';
-import _ from 'lodash';
+import pick from 'lodash/pick';
 import { captureException } from '../sentry';
 import { APIErrorMixin } from './types';
 
@@ -20,7 +20,7 @@ export const handleApiError = (
       // that falls out of the range of 2xx
       message += `Status: ${error.response.status}\n`;
       message += `Response: ${JSON.stringify(
-        _.pick(error.response.data, ['code', 'message', 'reason']),
+        pick(error.response.data, ['code', 'message', 'reason']),
         null,
         1,
       )}\n`;

--- a/src/ocm/components/clusterConfiguration/ClusterDefaultConfigurationContext.tsx
+++ b/src/ocm/components/clusterConfiguration/ClusterDefaultConfigurationContext.tsx
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import pick from 'lodash/pick';
 import React, { PropsWithChildren, useContext, useEffect } from 'react';
 import { ClusterDefaultConfig } from '../../../common';
 import { ClustersAPI } from '../../services/apis';
@@ -88,5 +88,5 @@ export const ClusterDefaultConfigurationProvider = ({
 
 export const useDefaultConfiguration = (keys: Array<keyof ClusterDefaultConfig>) => {
   // TODO(mlibra): There is no more the need to pick just selected values here, we can pass all the retrieved data
-  return _.pick(useContext(ClusterDefaultConfigurationContext), keys);
+  return pick(useContext(ClusterDefaultConfigurationContext), keys);
 };

--- a/src/ocm/components/clusterConfiguration/NetworkConfigurationForm.tsx
+++ b/src/ocm/components/clusterConfiguration/NetworkConfigurationForm.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
 import { Formik, FormikConfig, FormikProps } from 'formik';
-import _ from 'lodash';
+import mapValues from 'lodash/mapValues';
+import omit from 'lodash/omit';
 import { Form, Grid, GridItem, Text, TextContent } from '@patternfly/react-core';
 
 import {
@@ -51,9 +52,7 @@ const NetworkConfigurationForm: React.FC<{
     [], // just once, Formik does not reinitialize
   );
 
-  const initialTouched = React.useMemo(() => _.mapValues(initialValues, () => true), [
-    initialValues,
-  ]);
+  const initialTouched = React.useMemo(() => mapValues(initialValues, () => true), [initialValues]);
 
   const memoizedValidationSchema = React.useMemo(
     () => getNetworkConfigurationValidationSchema(initialValues, hostSubnets),
@@ -87,7 +86,7 @@ const NetworkConfigurationForm: React.FC<{
     try {
       const isMultiNodeCluster = !isSNO(cluster);
       const isUserManagedNetworking = values.managedNetworkingType === 'userManaged';
-      const params = _.omit(values, [
+      const params = omit(values, [
         'hostSubnet',
         'useRedHatDnsService',
         'managedNetworkingType',

--- a/src/ocm/components/clusterDetail/utils.tsx
+++ b/src/ocm/components/clusterDetail/utils.tsx
@@ -1,5 +1,5 @@
 import { saveAs } from 'file-saver';
-import { get } from 'lodash';
+import get from 'lodash/get';
 import { ocmClient, handleApiError, getErrorMessage } from '../../api';
 import {
   Cluster,

--- a/src/ocm/components/clusterWizard/ClusterDetails.tsx
+++ b/src/ocm/components/clusterWizard/ClusterDetails.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from 'lodash';
+import omit from 'lodash/omit';
 import { useHistory } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import {
@@ -44,7 +44,7 @@ const ClusterDetails: React.FC<ClusterDetailsProps> = ({ cluster }) => {
   const handleClusterUpdate = React.useCallback(
     async (clusterId: Cluster['id'], values: V2ClusterUpdateParams) => {
       clearAlerts();
-      const params: V2ClusterUpdateParams = _.omit(values, [
+      const params: V2ClusterUpdateParams = omit(values, [
         'highAvailabilityMode',
         'pullSecret',
         'openshiftVersion',

--- a/src/ocm/components/clusterWizard/ClusterDetailsForm.tsx
+++ b/src/ocm/components/clusterWizard/ClusterDetailsForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from 'lodash';
+import isUndefined from 'lodash/isUndefined';
 import { Formik, FormikHelpers } from 'formik';
 import {
   Cluster,
@@ -69,7 +69,7 @@ const ClusterDetailsForm: React.FC<ClusterDetailsFormProps> = (props) => {
     cluster?: Cluster,
   ): (() => Promise<void> | void) => {
     let fn: () => Promise<void> | void = submitForm;
-    if (!dirty && !_.isUndefined(cluster) && canNextClusterDetails({ cluster })) {
+    if (!dirty && !isUndefined(cluster) && canNextClusterDetails({ cluster })) {
       fn = moveNext;
     }
 

--- a/src/ocm/components/clusters/ClustersListToolbar.tsx
+++ b/src/ocm/components/clusters/ClustersListToolbar.tsx
@@ -25,7 +25,7 @@ import { ResourceUIState } from '../../../common';
 import { selectClustersUIState } from '../../selectors/clusters';
 import { fetchClustersAsync } from '../../reducers/clusters/clustersSlice';
 import { routeBasePath } from '../../config';
-import _ from 'lodash';
+import omit from 'lodash/omit';
 
 export type ClusterFiltersType = {
   [key: string]: string[]; // value from CLUSTER_STATUS_LABELS
@@ -39,7 +39,7 @@ type ClustersListToolbarProps = {
 };
 
 const clusterStatusFilterLabels = Array.from(
-  new Set(Object.values(_.omit(CLUSTER_STATUS_LABELS, 'adding-hosts'))),
+  new Set(Object.values(omit(CLUSTER_STATUS_LABELS, 'adding-hosts'))),
 );
 
 const ClustersListToolbar: React.FC<ClustersListToolbarProps> = ({

--- a/src/ocm/components/clusters/utils.test.ts
+++ b/src/ocm/components/clusters/utils.test.ts
@@ -1,6 +1,6 @@
 import type { Cluster, Host } from '../../../common';
 import { calculateCollectedLogsCount, filterHostsByLogStates } from './utils';
-import { uniqueId } from 'lodash';
+import uniqueId from 'lodash/uniqueId';
 
 const hostTemplate: Host = {
   id: '',

--- a/src/ocm/reducers/clusters/currentClusterSlice.ts
+++ b/src/ocm/reducers/clusters/currentClusterSlice.ts
@@ -1,4 +1,5 @@
-import _ from 'lodash';
+import findIndex from 'lodash/findIndex';
+import set from 'lodash/set';
 import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
 import { Cluster, Host } from '../../../common';
 import { handleApiError } from '../../api/utils';
@@ -54,10 +55,10 @@ export const currentClusterSlice = createSlice({
       return { ...state, data: action.payload };
     },
     updateHost: (state, action: PayloadAction<Host>) => {
-      const hostIndex = _.findIndex(state.data?.hosts, (host) => host.id === action.payload.id);
+      const hostIndex = findIndex(state.data?.hosts, (host) => host.id === action.payload.id);
 
       if (hostIndex >= 0) {
-        _.set(state, `data.hosts[${hostIndex}]`, action.payload);
+        set(state, `data.hosts[${hostIndex}]`, action.payload);
       }
       return state;
     },

--- a/src/ocm/services/ClusterDetailsService.ts
+++ b/src/ocm/services/ClusterDetailsService.ts
@@ -1,7 +1,7 @@
 import { ClusterCreateParams, V2ClusterUpdateParams } from '../../common';
 import { ClustersAPI, ManagedDomainsAPI } from '../services/apis';
 import InfraEnvsService from './InfraEnvsService';
-import _ from 'lodash';
+import omit from 'lodash/omit';
 import DiskEncryptionService from './DiskEncryptionService';
 import { OcmClusterDetailsValues } from '../api/types';
 import { isArmArchitecture } from '../../common/selectors/clusterSelectors';
@@ -32,7 +32,7 @@ const ClusterDetailsService = {
   },
 
   getClusterCreateParams(values: OcmClusterDetailsValues): ClusterCreateParams {
-    const params: ClusterCreateParams = _.omit(values, [
+    const params: ClusterCreateParams = omit(values, [
       'useRedHatDnsService',
       'SNODisclaimer',
       'enableDiskEncryptionOnMasters',


### PR DESCRIPTION
Changed the imports of specific `lodash` functions to avoid loading the entire `lodash` module and reduce build time / bundle size.

This PR changes only the usages within `ocm` code.

More details in https://github.com/openshift-assisted/assisted-ui-lib/pull/1250