### PR TITLE
Merge CIM-2.5 into master

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openshift-assisted-ui-lib",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "React component library for the Bare Metal Installer",
   "license": "Apache-2.0",
   "repository": "openshift-assisted/assisted-ui-lib",


### PR DESCRIPTION
This is required since v2.3.3 and CIM-2.5 are a different branch in comparison to master.