### PR TITLE
MGMT-9176 Network type selection rules

### DIFF
--- a/src/common/components/clusterConfiguration/AdvancedNetworkFields.tsx
+++ b/src/common/components/clusterConfiguration/AdvancedNetworkFields.tsx
@@ -8,14 +8,12 @@ import { NetworkTypeControlGroup } from '../clusterWizard/networkingSteps/Networ
 import { useFeature } from '../../features';
 
 type AdvancedNetworkFieldsProps = {
-  isSNO: boolean;
-  isIPv6: boolean;
+  isSDNSelectable: boolean;
   isClusterCIDRIPv6: boolean;
 };
 
 const AdvancedNetworkFields: React.FC<AdvancedNetworkFieldsProps> = ({
-  isSNO,
-  isIPv6,
+  isSDNSelectable,
   isClusterCIDRIPv6,
 }) => {
   const isNetworkTypeSelectionEnabled = useFeature(
@@ -58,7 +56,9 @@ const AdvancedNetworkFields: React.FC<AdvancedNetworkFieldsProps> = ({
         helperText="The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic."
         isRequired
       />
-      {isNetworkTypeSelectionEnabled && <NetworkTypeControlGroup isSNO={isSNO} isIPv6={isIPv6} />}
+      {isNetworkTypeSelectionEnabled && (
+        <NetworkTypeControlGroup isSDNSelectable={isSDNSelectable} />
+      )}
     </Grid>
   );
 };

--- a/src/common/components/clusterConfiguration/AdvancedNetworkFields.tsx
+++ b/src/common/components/clusterConfiguration/AdvancedNetworkFields.tsx
@@ -8,7 +8,7 @@ import { PREFIX_MAX_RESTRICTION } from '../../config/constants';
 import { NetworkTypeControlGroup } from '../clusterWizard/networkingSteps/NetworkTypeControlGroup';
 import { useFeature } from '../../features';
 
-const AdvancedNetworkFields: React.FC<{}> = () => {
+const AdvancedNetworkFields: React.FC<{ isSNO: boolean }> = ({ isSNO }) => {
   const isNetworkTypeSelectionEnabled = useFeature(
     'ASSISTED_INSTALLER_NETWORK_TYPE_SELECTION_FEATURE',
   );
@@ -64,7 +64,7 @@ const AdvancedNetworkFields: React.FC<{}> = () => {
         helperText="The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic."
         isRequired
       />
-      {isNetworkTypeSelectionEnabled && <NetworkTypeControlGroup isIPv6={isIPv6} />}
+      {isNetworkTypeSelectionEnabled && <NetworkTypeControlGroup isSNO={isSNO} isIPv6={isIPv6} />}
     </Grid>
   );
 };

--- a/src/common/components/clusterConfiguration/AdvancedNetworkFields.tsx
+++ b/src/common/components/clusterConfiguration/AdvancedNetworkFields.tsx
@@ -11,9 +11,13 @@ type AdvancedNetworkFieldsProps = {
   isSNO: boolean;
   isIPv6: boolean;
   isClusterCIDRIPv6: boolean;
-}
+};
 
-const AdvancedNetworkFields: React.FC<AdvancedNetworkFieldsProps> = ({ isSNO, isIPv6, isClusterCIDRIPv6 }) => {
+const AdvancedNetworkFields: React.FC<AdvancedNetworkFieldsProps> = ({
+  isSNO,
+  isIPv6,
+  isClusterCIDRIPv6,
+}) => {
   const isNetworkTypeSelectionEnabled = useFeature(
     'ASSISTED_INSTALLER_NETWORK_TYPE_SELECTION_FEATURE',
   );
@@ -29,8 +33,6 @@ const AdvancedNetworkFields: React.FC<AdvancedNetworkFieldsProps> = ({ isSNO, is
   const clusterNetworkHostPrefixHelperText = isClusterCIDRIPv6
     ? 'The subnet prefix length to assign to each individual node. For example, if Cluster Network Host Prefix is set to 116, then each node is assigned a /116 subnet out of the given cidr (clusterNetworkCIDR), which allows for 4,094 (2^(128 - 116) - 2) pod IPs addresses. If you are required to provide access to nodes from an external network, configure load balancers and routers to manage the traffic.'
     : 'The subnet prefix length to assign to each individual node. For example, if Cluster Network Host Prefix is set to 23, then each node is assigned a /23 subnet out of the given cidr (clusterNetworkCIDR), which allows for 510 (2^(32 - 23) - 2) pod IPs addresses. If you are required to provide access to nodes from an external network, configure load balancers and routers to manage the traffic.';
-
-
 
   return (
     <Grid hasGutter>

--- a/src/common/components/clusterConfiguration/AdvancedNetworkFields.tsx
+++ b/src/common/components/clusterConfiguration/AdvancedNetworkFields.tsx
@@ -4,7 +4,7 @@ import { useFormikContext } from 'formik';
 import { InputField } from '../../components/ui';
 import { NetworkConfigurationValues } from '../../types/clusters';
 import { Address6 } from 'ip-address';
-import { PREFIX_MAX_RESTRICTION } from '../../config/constants';
+import { NETWORK_TYPE_OVN, PREFIX_MAX_RESTRICTION } from '../../config/constants';
 import { NetworkTypeControlGroup } from '../clusterWizard/networkingSteps/NetworkTypeControlGroup';
 import { useFeature } from '../../features';
 
@@ -36,7 +36,7 @@ const AdvancedNetworkFields: React.FC<{ isSNO: boolean }> = ({ isSNO }) => {
 
   useEffect(() => {
     if (isNetworkTypeSelectionEnabled && isIPv6) {
-      setFieldValue('networkType', 'OVNKubernetes');
+      setFieldValue('networkType', NETWORK_TYPE_OVN);
     }
   }, [isIPv6, setFieldValue, isNetworkTypeSelectionEnabled]);
 

--- a/src/common/components/clusterConfiguration/AdvancedNetworkFields.tsx
+++ b/src/common/components/clusterConfiguration/AdvancedNetworkFields.tsx
@@ -1,14 +1,19 @@
-import React, { useEffect, useMemo } from 'react';
+import React from 'react';
 import { Grid, TextInputTypes } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
 import { InputField } from '../../components/ui';
 import { NetworkConfigurationValues } from '../../types/clusters';
-import { Address6 } from 'ip-address';
-import { NETWORK_TYPE_OVN, PREFIX_MAX_RESTRICTION } from '../../config/constants';
+import { PREFIX_MAX_RESTRICTION } from '../../config/constants';
 import { NetworkTypeControlGroup } from '../clusterWizard/networkingSteps/NetworkTypeControlGroup';
 import { useFeature } from '../../features';
 
-const AdvancedNetworkFields: React.FC<{ isSNO: boolean }> = ({ isSNO }) => {
+type AdvancedNetworkFieldsProps = {
+  isSNO: boolean;
+  isIPv6: boolean;
+  isClusterCIDRIPv6: boolean;
+}
+
+const AdvancedNetworkFields: React.FC<AdvancedNetworkFieldsProps> = ({ isSNO, isIPv6, isClusterCIDRIPv6 }) => {
   const isNetworkTypeSelectionEnabled = useFeature(
     'ASSISTED_INSTALLER_NETWORK_TYPE_SELECTION_FEATURE',
   );
@@ -21,24 +26,11 @@ const AdvancedNetworkFields: React.FC<{ isSNO: boolean }> = ({ isSNO }) => {
     }
   };
 
-  const isClusterCIDRIPv6 = Address6.isValid(values.clusterNetworkCidr || '');
-  const isIPv6 = useMemo(
-    () =>
-      isClusterCIDRIPv6 ||
-      Address6.isValid(values.machineNetworkCidr || '') ||
-      Address6.isValid(values.serviceNetworkCidr || ''),
-    [isClusterCIDRIPv6, values.machineNetworkCidr, values.serviceNetworkCidr],
-  );
-
   const clusterNetworkHostPrefixHelperText = isClusterCIDRIPv6
     ? 'The subnet prefix length to assign to each individual node. For example, if Cluster Network Host Prefix is set to 116, then each node is assigned a /116 subnet out of the given cidr (clusterNetworkCIDR), which allows for 4,094 (2^(128 - 116) - 2) pod IPs addresses. If you are required to provide access to nodes from an external network, configure load balancers and routers to manage the traffic.'
     : 'The subnet prefix length to assign to each individual node. For example, if Cluster Network Host Prefix is set to 23, then each node is assigned a /23 subnet out of the given cidr (clusterNetworkCIDR), which allows for 510 (2^(32 - 23) - 2) pod IPs addresses. If you are required to provide access to nodes from an external network, configure load balancers and routers to manage the traffic.';
 
-  useEffect(() => {
-    if (isNetworkTypeSelectionEnabled && isIPv6) {
-      setFieldValue('networkType', NETWORK_TYPE_OVN);
-    }
-  }, [isIPv6, setFieldValue, isNetworkTypeSelectionEnabled]);
+
 
   return (
     <Grid hasGutter>

--- a/src/common/components/clusterConfiguration/NetworkConfiguration.tsx
+++ b/src/common/components/clusterConfiguration/NetworkConfiguration.tsx
@@ -55,9 +55,7 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
   const clusterFeatureSupportLevels = React.useMemo(() => {
     return getLimitedFeatureSupportLevels(cluster, featureSupportLevelData);
   }, [cluster, featureSupportLevelData]);
-  const [isAdvanced, setAdvanced] = React.useState(
-    isAdvNetworkConf(cluster, defaultNetworkSettings),
-  );
+
   const isMultiNodeCluster = !isSNO(cluster);
   const isClusterCIDRIPv6 = Address6.isValid(values.clusterNetworkCidr || '');
   const isIPv6 = React.useMemo(
@@ -69,6 +67,10 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
       }),
     [values.clusterNetworkCidr, values.machineNetworkCidr, values.serviceNetworkCidr],
   );
+  const defaultNetworkType = getDefaultNetworkType(!isMultiNodeCluster, isIPv6);
+  const [isAdvanced, setAdvanced] = React.useState(
+    isAdvNetworkConf(cluster, defaultNetworkSettings, defaultNetworkType),
+  );
   const isSDNSelectable = canSelectNetworkTypeSDN(!isMultiNodeCluster, isIPv6);
 
   const toggleAdvConfiguration = (checked: boolean) => {
@@ -78,7 +80,7 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
       setFieldValue('clusterNetworkCidr', defaultNetworkSettings.clusterNetworkCidr);
       setFieldValue('serviceNetworkCidr', defaultNetworkSettings.serviceNetworkCidr);
       setFieldValue('clusterNetworkHostPrefix', defaultNetworkSettings.clusterNetworkHostPrefix);
-      setFieldValue('networkType', getDefaultNetworkType(!isMultiNodeCluster, isIPv6));
+      setFieldValue('networkType', defaultNetworkType);
     }
   };
 

--- a/src/common/components/clusterConfiguration/NetworkConfiguration.tsx
+++ b/src/common/components/clusterConfiguration/NetworkConfiguration.tsx
@@ -11,7 +11,11 @@ import {
   VirtualIPControlGroupProps,
 } from '../clusterWizard/networkingSteps';
 import { ClusterDefaultConfig } from '../../api';
-import { DEFAULT_NETWORK_TYPE, NETWORK_TYPE_OVN, NETWORK_TYPE_SDN, NO_SUBNET_SET } from '../../config';
+import {
+  DEFAULT_NETWORK_TYPE,
+  NETWORK_TYPE_OVN,
+  NO_SUBNET_SET,
+} from '../../config';
 import { isAdvNetworkConf } from './utils';
 import { useFeatureSupportLevel } from '../featureSupportLevels';
 import { getLimitedFeatureSupportLevels } from '../featureSupportLevels/utils';
@@ -161,7 +165,15 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
         description="Configure advanced networking properties (e.g. CIDR ranges)."
         isChecked={isAdvanced}
         onChange={toggleAdvConfiguration}
-        body={isAdvanced && <AdvancedNetworkFields isSNO={!isMultiNodeCluster} isIPv6={isIPv6} isClusterCIDRIPv6={isClusterCIDRIPv6} />}
+        body={
+          isAdvanced && (
+            <AdvancedNetworkFields
+              isSNO={!isMultiNodeCluster}
+              isIPv6={isIPv6}
+              isClusterCIDRIPv6={isClusterCIDRIPv6}
+            />
+          )
+        }
       />
     </Grid>
   );

--- a/src/common/components/clusterConfiguration/NetworkConfiguration.tsx
+++ b/src/common/components/clusterConfiguration/NetworkConfiguration.tsx
@@ -11,7 +11,7 @@ import {
   VirtualIPControlGroupProps,
 } from '../clusterWizard/networkingSteps';
 import { ClusterDefaultConfig } from '../../api';
-import { NO_SUBNET_SET } from '../../config';
+import { DEFAULT_NETWORK_TYPE, NETWORK_TYPE_OVN, NETWORK_TYPE_SDN, NO_SUBNET_SET } from '../../config';
 import { isAdvNetworkConf } from './utils';
 import { useFeatureSupportLevel } from '../featureSupportLevels';
 import { getLimitedFeatureSupportLevels } from '../featureSupportLevels/utils';
@@ -56,11 +56,13 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
   const toggleAdvConfiguration = (checked: boolean) => {
     setAdvanced(checked);
 
-    if (!checked) {
+    if (checked) {
+      setFieldValue('networkType', NETWORK_TYPE_SDN);
+    } else {
       setFieldValue('clusterNetworkCidr', defaultNetworkSettings.clusterNetworkCidr);
       setFieldValue('serviceNetworkCidr', defaultNetworkSettings.serviceNetworkCidr);
       setFieldValue('clusterNetworkHostPrefix', defaultNetworkSettings.clusterNetworkHostPrefix);
-      setFieldValue('networkType', 'OpenShiftSDN');
+      setFieldValue('networkType', NETWORK_TYPE_OVN); // This is the default option
     }
   };
 

--- a/src/common/components/clusterConfiguration/NetworkConfiguration.tsx
+++ b/src/common/components/clusterConfiguration/NetworkConfiguration.tsx
@@ -146,7 +146,7 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
         description="Configure advanced networking properties (e.g. CIDR ranges)."
         isChecked={isAdvanced}
         onChange={toggleAdvConfiguration}
-        body={isAdvanced && <AdvancedNetworkFields />}
+        body={isAdvanced && <AdvancedNetworkFields isSNO={!isMultiNodeCluster} />}
       />
     </Grid>
   );

--- a/src/common/components/clusterConfiguration/NetworkConfiguration.tsx
+++ b/src/common/components/clusterConfiguration/NetworkConfiguration.tsx
@@ -58,20 +58,27 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
 
   const isMultiNodeCluster = !isSNO(cluster);
   const isClusterCIDRIPv6 = Address6.isValid(values.clusterNetworkCidr || '');
-  const isIPv6 = React.useMemo(
-    () =>
-      isSubnetInIPv6({
-        machineNetworkCidr: values.machineNetworkCidr,
-        clusterNetworkCidr: values.clusterNetworkCidr,
-        serviceNetworkCidr: values.serviceNetworkCidr,
-      }),
-    [values.clusterNetworkCidr, values.machineNetworkCidr, values.serviceNetworkCidr],
-  );
-  const defaultNetworkType = getDefaultNetworkType(!isMultiNodeCluster, isIPv6);
+  const { isIPv6, defaultNetworkType, isSDNSelectable } = React.useMemo(() => {
+    const isIPv6 = isSubnetInIPv6({
+      machineNetworkCidr: values.machineNetworkCidr,
+      clusterNetworkCidr: values.clusterNetworkCidr,
+      serviceNetworkCidr: values.serviceNetworkCidr,
+    });
+    return {
+      isIPv6,
+      defaultNetworkType: getDefaultNetworkType(!isMultiNodeCluster, isIPv6),
+      isSDNSelectable: canSelectNetworkTypeSDN(!isMultiNodeCluster, isIPv6),
+    };
+  }, [
+    isMultiNodeCluster,
+    values.clusterNetworkCidr,
+    values.machineNetworkCidr,
+    values.serviceNetworkCidr,
+  ]);
+
   const [isAdvanced, setAdvanced] = React.useState(
     isAdvNetworkConf(cluster, defaultNetworkSettings, defaultNetworkType),
   );
-  const isSDNSelectable = canSelectNetworkTypeSDN(!isMultiNodeCluster, isIPv6);
 
   const toggleAdvConfiguration = (checked: boolean) => {
     setAdvanced(checked);

--- a/src/common/components/clusterConfiguration/networkConfigurationValidation.ts
+++ b/src/common/components/clusterConfiguration/networkConfigurationValidation.ts
@@ -11,12 +11,15 @@ import {
 
 import { getSubnetFromMachineNetworkCidr, getHostSubnets } from './utils';
 import {
+  getDefaultNetworkType,
+  isSNO,
+  isSubnetInIPv6,
   selectClusterNetworkCIDR,
   selectClusterNetworkHostPrefix,
   selectMachineNetworkCIDR,
   selectServiceNetworkCIDR,
 } from '../../selectors/clusterSelectors';
-import { DEFAULT_NETWORK_TYPE, NO_SUBNET_SET } from '../../config';
+import { NO_SUBNET_SET } from '../../config';
 
 const getInitHostSubnet = (
   cluster: Cluster,
@@ -36,6 +39,9 @@ export const getNetworkInitialValues = (
   defaultNetworkSettings: ClusterDefaultConfig,
 ): NetworkConfigurationValues => {
   const managedNetworkingType = cluster.userManagedNetworking ? 'userManaged' : 'clusterManaged';
+  const isIPv6 = isSubnetInIPv6(cluster);
+  const isSNOCluster = isSNO(cluster);
+
   return {
     clusterNetworkCidr:
       selectClusterNetworkCIDR(cluster) || defaultNetworkSettings.clusterNetworkCidr,
@@ -49,7 +55,7 @@ export const getNetworkInitialValues = (
     hostSubnet: getInitHostSubnet(cluster, managedNetworkingType) || NO_SUBNET_SET,
     vipDhcpAllocation: cluster.vipDhcpAllocation,
     managedNetworkingType: cluster.userManagedNetworking ? 'userManaged' : 'clusterManaged',
-    networkType: cluster.networkType || DEFAULT_NETWORK_TYPE,
+    networkType: cluster.networkType || getDefaultNetworkType(isSNOCluster, isIPv6),
     enableProxy: false,
     editProxy: false,
   };

--- a/src/common/components/clusterConfiguration/networkConfigurationValidation.ts
+++ b/src/common/components/clusterConfiguration/networkConfigurationValidation.ts
@@ -16,7 +16,7 @@ import {
   selectMachineNetworkCIDR,
   selectServiceNetworkCIDR,
 } from '../../selectors/clusterSelectors';
-import { NO_SUBNET_SET } from '../../config';
+import { DEFAULT_NETWORK_TYPE, NO_SUBNET_SET } from '../../config';
 
 const getInitHostSubnet = (
   cluster: Cluster,
@@ -49,7 +49,7 @@ export const getNetworkInitialValues = (
     hostSubnet: getInitHostSubnet(cluster, managedNetworkingType) || NO_SUBNET_SET,
     vipDhcpAllocation: cluster.vipDhcpAllocation,
     managedNetworkingType: cluster.userManagedNetworking ? 'userManaged' : 'clusterManaged',
-    networkType: cluster.networkType || 'OpenShiftSDN',
+    networkType: cluster.networkType || DEFAULT_NETWORK_TYPE,
     enableProxy: false,
     editProxy: false,
   };

--- a/src/common/components/clusterConfiguration/utils.ts
+++ b/src/common/components/clusterConfiguration/utils.ts
@@ -1,6 +1,6 @@
 import { Address4, Address6 } from 'ip-address';
 import { Cluster, ClusterDefaultConfig, Inventory, stringToJSON } from '../../api';
-import { NETWORK_TYPE_OVN, NO_SUBNET_SET } from '../../config';
+import { NO_SUBNET_SET } from '../../config';
 import {
   HostDiscoveryValues,
   HostSubnets,
@@ -66,11 +66,15 @@ export const getSubnetFromMachineNetworkCidr = (machineNetworkCidr?: string) => 
   return subnet?.address;
 };
 
-export const isAdvNetworkConf = (cluster: Cluster, defaultNetworkSettings: ClusterDefaultConfig) =>
+export const isAdvNetworkConf = (
+  cluster: Cluster,
+  defaultNetworkSettings: ClusterDefaultConfig,
+  defaultNetworkType: string,
+) =>
   selectClusterNetworkCIDR(cluster) !== defaultNetworkSettings.clusterNetworkCidr ||
   selectClusterNetworkHostPrefix(cluster) !== defaultNetworkSettings.clusterNetworkHostPrefix ||
   selectServiceNetworkCIDR(cluster) !== defaultNetworkSettings.serviceNetworkCidr ||
-  (Boolean(cluster.networkType) && cluster.networkType !== NETWORK_TYPE_OVN);
+  (Boolean(cluster.networkType) && cluster.networkType !== defaultNetworkType);
 
 export const getHostDiscoveryInitialValues = (cluster: Cluster): HostDiscoveryValues => {
   const monitoredOperators = cluster.monitoredOperators || [];

--- a/src/common/components/clusterConfiguration/utils.ts
+++ b/src/common/components/clusterConfiguration/utils.ts
@@ -1,6 +1,6 @@
 import { Address4, Address6 } from 'ip-address';
 import { Cluster, ClusterDefaultConfig, Inventory, stringToJSON } from '../../api';
-import { NO_SUBNET_SET } from '../../config';
+import { DEFAULT_NETWORK_TYPE, NO_SUBNET_SET } from '../../config';
 import {
   HostDiscoveryValues,
   HostSubnets,
@@ -66,11 +66,12 @@ export const getSubnetFromMachineNetworkCidr = (machineNetworkCidr?: string) => 
   return subnet?.address;
 };
 
+
 export const isAdvNetworkConf = (cluster: Cluster, defaultNetworkSettings: ClusterDefaultConfig) =>
   selectClusterNetworkCIDR(cluster) !== defaultNetworkSettings.clusterNetworkCidr ||
   selectClusterNetworkHostPrefix(cluster) !== defaultNetworkSettings.clusterNetworkHostPrefix ||
   selectServiceNetworkCIDR(cluster) !== defaultNetworkSettings.serviceNetworkCidr ||
-  (Boolean(cluster.networkType) && cluster.networkType !== 'OpenShiftSDN');
+  (Boolean(cluster.networkType) && cluster.networkType !== DEFAULT_NETWORK_TYPE);
 
 export const getHostDiscoveryInitialValues = (cluster: Cluster): HostDiscoveryValues => {
   const monitoredOperators = cluster.monitoredOperators || [];

--- a/src/common/components/clusterConfiguration/utils.ts
+++ b/src/common/components/clusterConfiguration/utils.ts
@@ -66,7 +66,6 @@ export const getSubnetFromMachineNetworkCidr = (machineNetworkCidr?: string) => 
   return subnet?.address;
 };
 
-
 export const isAdvNetworkConf = (cluster: Cluster, defaultNetworkSettings: ClusterDefaultConfig) =>
   selectClusterNetworkCIDR(cluster) !== defaultNetworkSettings.clusterNetworkCidr ||
   selectClusterNetworkHostPrefix(cluster) !== defaultNetworkSettings.clusterNetworkHostPrefix ||

--- a/src/common/components/clusterConfiguration/utils.ts
+++ b/src/common/components/clusterConfiguration/utils.ts
@@ -1,6 +1,6 @@
 import { Address4, Address6 } from 'ip-address';
 import { Cluster, ClusterDefaultConfig, Inventory, stringToJSON } from '../../api';
-import { DEFAULT_NETWORK_TYPE, NO_SUBNET_SET } from '../../config';
+import { NETWORK_TYPE_OVN, NO_SUBNET_SET } from '../../config';
 import {
   HostDiscoveryValues,
   HostSubnets,
@@ -70,7 +70,7 @@ export const isAdvNetworkConf = (cluster: Cluster, defaultNetworkSettings: Clust
   selectClusterNetworkCIDR(cluster) !== defaultNetworkSettings.clusterNetworkCidr ||
   selectClusterNetworkHostPrefix(cluster) !== defaultNetworkSettings.clusterNetworkHostPrefix ||
   selectServiceNetworkCIDR(cluster) !== defaultNetworkSettings.serviceNetworkCidr ||
-  (Boolean(cluster.networkType) && cluster.networkType !== DEFAULT_NETWORK_TYPE);
+  (Boolean(cluster.networkType) && cluster.networkType !== NETWORK_TYPE_OVN);
 
 export const getHostDiscoveryInitialValues = (cluster: Cluster): HostDiscoveryValues => {
   const monitoredOperators = cluster.monitoredOperators || [];

--- a/src/common/components/clusterWizard/networkingSteps/NetworkTypeControlGroup.tsx
+++ b/src/common/components/clusterWizard/networkingSteps/NetworkTypeControlGroup.tsx
@@ -16,25 +16,6 @@ export const NetworkTypeControlGroup: React.FC<NetworkTypeControlGroupProps> = (
     <FormGroup fieldId={GROUP_NAME} label="Network type">
       <Split hasGutter>
         <SplitItem>
-          <RadioField
-            id={GROUP_NAME}
-            name={GROUP_NAME}
-            value={NETWORK_TYPE_OVN}
-            label={
-              <>
-                Open Virtual Networking (OVN){' '}
-                <PopoverIcon
-                  variant={'plain'}
-                  bodyContent={
-                    "The next generation networking type, select this when you're using new features and telco features"
-                  }
-                />
-              </>
-            }
-          />
-        </SplitItem>
-        <SplitItem />
-        <SplitItem>
           <Tooltip
             hidden={isSDNSelectable}
             content={
@@ -57,6 +38,25 @@ export const NetworkTypeControlGroup: React.FC<NetworkTypeControlGroupProps> = (
               }
             />
           </Tooltip>
+        </SplitItem>
+        <SplitItem />
+        <SplitItem>
+          <RadioField
+            id={GROUP_NAME}
+            name={GROUP_NAME}
+            value={NETWORK_TYPE_OVN}
+            label={
+              <>
+                Open Virtual Networking (OVN){' '}
+                <PopoverIcon
+                  variant={'plain'}
+                  bodyContent={
+                    "The next generation networking type, select this when you're using new features and telco features"
+                  }
+                />
+              </>
+            }
+          />
         </SplitItem>
       </Split>
     </FormGroup>

--- a/src/common/components/clusterWizard/networkingSteps/NetworkTypeControlGroup.tsx
+++ b/src/common/components/clusterWizard/networkingSteps/NetworkTypeControlGroup.tsx
@@ -1,45 +1,26 @@
 import React from 'react';
-import { Split, SplitItem, Tooltip, FormGroup } from '@patternfly/react-core';
+import { Split, SplitItem, FormGroup } from '@patternfly/react-core';
 import { RadioField } from '../../ui/formik';
 import { PopoverIcon } from '../../../components/ui';
 
+const GROUP_NAME = 'networkType';
 export interface NetworkTypeControlGroupProps {
   isIPv6: boolean;
+  isSNO: boolean;
 }
 
 export const NetworkTypeControlGroup: React.FC<NetworkTypeControlGroupProps> = ({
   isIPv6 = false,
+  isSNO = false,
 }) => {
-  const GROUP_NAME = 'networkType';
+  const isSDNSelectable = !(isSNO || isIPv6);
+  const SDNIconContent = `The classic bullet-proof networking type.${
+    isSDNSelectable ? '' : ' Not available in SNO clusters or clusters using IPv6'
+  }`;
 
   return (
     <FormGroup fieldId={GROUP_NAME} label="Network type">
       <Split hasGutter>
-        <SplitItem>
-          <Tooltip
-            hidden={!isIPv6}
-            content={
-              'Software-Defined Networking (SDN) can be selected only when IPv4 is detected.'
-            }
-          >
-            <RadioField
-              id={GROUP_NAME}
-              name={GROUP_NAME}
-              isDisabled={isIPv6}
-              value={'OpenShiftSDN'}
-              label={
-                <>
-                  Software-Defined Networking (SDN){' '}
-                  <PopoverIcon
-                    variant={'plain'}
-                    bodyContent={'The classic bullet-proof networking type'}
-                  />
-                </>
-              }
-            />
-          </Tooltip>
-        </SplitItem>
-        <SplitItem />
         <SplitItem>
           <RadioField
             id={GROUP_NAME}
@@ -54,6 +35,21 @@ export const NetworkTypeControlGroup: React.FC<NetworkTypeControlGroupProps> = (
                     "The next generation networking type, select this when you're using new features and telco features"
                   }
                 />
+              </>
+            }
+          />
+        </SplitItem>
+        <SplitItem />
+        <SplitItem>
+          <RadioField
+            id={GROUP_NAME}
+            name={GROUP_NAME}
+            isDisabled={!isSDNSelectable}
+            value={'OpenShiftSDN'}
+            label={
+              <>
+                Software-Defined Networking (SDN){' '}
+                <PopoverIcon variant={'plain'} bodyContent={SDNIconContent} />
               </>
             }
           />

--- a/src/common/components/clusterWizard/networkingSteps/NetworkTypeControlGroup.tsx
+++ b/src/common/components/clusterWizard/networkingSteps/NetworkTypeControlGroup.tsx
@@ -6,16 +6,12 @@ import { NETWORK_TYPE_OVN, NETWORK_TYPE_SDN } from '../../../config';
 
 const GROUP_NAME = 'networkType';
 export interface NetworkTypeControlGroupProps {
-  isIPv6: boolean;
-  isSNO: boolean;
+  isSDNSelectable: boolean;
 }
 
 export const NetworkTypeControlGroup: React.FC<NetworkTypeControlGroupProps> = ({
-  isIPv6 = false,
-  isSNO = false,
+  isSDNSelectable,
 }) => {
-  const isSDNSelectable = !(isSNO || isIPv6);
-
   return (
     <FormGroup fieldId={GROUP_NAME} label="Network type">
       <Split hasGutter>

--- a/src/common/components/clusterWizard/networkingSteps/NetworkTypeControlGroup.tsx
+++ b/src/common/components/clusterWizard/networkingSteps/NetworkTypeControlGroup.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Split, SplitItem, FormGroup } from '@patternfly/react-core';
+import { Split, SplitItem, Tooltip, FormGroup } from '@patternfly/react-core';
 import { RadioField } from '../../ui/formik';
 import { PopoverIcon } from '../../../components/ui';
 import { NETWORK_TYPE_OVN, NETWORK_TYPE_SDN } from '../../../config';
@@ -14,10 +14,8 @@ export const NetworkTypeControlGroup: React.FC<NetworkTypeControlGroupProps> = (
   isIPv6 = false,
   isSNO = false,
 }) => {
+  const GROUP_NAME = 'networkType';
   const isSDNSelectable = !(isSNO || isIPv6);
-  const SDNIconContent = `The classic bullet-proof networking type.${
-    isSDNSelectable ? '' : ' Not available in SNO clusters or clusters using IPv6'
-  }`;
 
   return (
     <FormGroup fieldId={GROUP_NAME} label="Network type">
@@ -42,18 +40,28 @@ export const NetworkTypeControlGroup: React.FC<NetworkTypeControlGroupProps> = (
         </SplitItem>
         <SplitItem />
         <SplitItem>
-          <RadioField
-            id={GROUP_NAME}
-            name={GROUP_NAME}
-            isDisabled={!isSDNSelectable}
-            value={NETWORK_TYPE_SDN}
-            label={
-              <>
-                Software-Defined Networking (SDN){' '}
-                <PopoverIcon variant={'plain'} bodyContent={SDNIconContent} />
-              </>
+          <Tooltip
+            hidden={isSDNSelectable}
+            content={
+              'Software-Defined Networking (SDN) can be selected only in non-SNO clusters when IPv4 is detected.'
             }
-          />
+          >
+            <RadioField
+              id={GROUP_NAME}
+              name={GROUP_NAME}
+              isDisabled={!isSDNSelectable}
+              value={NETWORK_TYPE_SDN}
+              label={
+                <>
+                  Software-Defined Networking (SDN){' '}
+                  <PopoverIcon
+                    variant={'plain'}
+                    bodyContent={'The classic bullet-proof networking type'}
+                  />
+                </>
+              }
+            />
+          </Tooltip>
         </SplitItem>
       </Split>
     </FormGroup>

--- a/src/common/components/clusterWizard/networkingSteps/NetworkTypeControlGroup.tsx
+++ b/src/common/components/clusterWizard/networkingSteps/NetworkTypeControlGroup.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Split, SplitItem, FormGroup } from '@patternfly/react-core';
 import { RadioField } from '../../ui/formik';
 import { PopoverIcon } from '../../../components/ui';
+import { NETWORK_TYPE_OVN, NETWORK_TYPE_SDN } from '../../../config';
 
 const GROUP_NAME = 'networkType';
 export interface NetworkTypeControlGroupProps {
@@ -25,7 +26,7 @@ export const NetworkTypeControlGroup: React.FC<NetworkTypeControlGroupProps> = (
           <RadioField
             id={GROUP_NAME}
             name={GROUP_NAME}
-            value={'OVNKubernetes'}
+            value={NETWORK_TYPE_OVN}
             label={
               <>
                 Open Virtual Networking (OVN){' '}
@@ -45,7 +46,7 @@ export const NetworkTypeControlGroup: React.FC<NetworkTypeControlGroupProps> = (
             id={GROUP_NAME}
             name={GROUP_NAME}
             isDisabled={!isSDNSelectable}
-            value={'OpenShiftSDN'}
+            value={NETWORK_TYPE_SDN}
             label={
               <>
                 Software-Defined Networking (SDN){' '}

--- a/src/common/components/clusterWizard/networkingSteps/NetworkTypeControlGroup.tsx
+++ b/src/common/components/clusterWizard/networkingSteps/NetworkTypeControlGroup.tsx
@@ -14,7 +14,6 @@ export const NetworkTypeControlGroup: React.FC<NetworkTypeControlGroupProps> = (
   isIPv6 = false,
   isSNO = false,
 }) => {
-  const GROUP_NAME = 'networkType';
   const isSDNSelectable = !(isSNO || isIPv6);
 
   return (

--- a/src/common/config/constants.ts
+++ b/src/common/config/constants.ts
@@ -216,6 +216,10 @@ export const MS_PER_DAY = 1000 * 60 * 60 * 24;
 
 export const NO_SUBNET_SET = 'NO_SUBNET_SET';
 
+export const NETWORK_TYPE_OVN = 'OVNKubernetes';
+export const NETWORK_TYPE_SDN = 'OpenShiftSDN';
+export const DEFAULT_NETWORK_TYPE = NETWORK_TYPE_OVN;
+
 export const PREFIX_MAX_RESTRICTION = {
   IPv6: 128,
   IPv4: 25,

--- a/src/common/config/constants.ts
+++ b/src/common/config/constants.ts
@@ -218,7 +218,6 @@ export const NO_SUBNET_SET = 'NO_SUBNET_SET';
 
 export const NETWORK_TYPE_OVN = 'OVNKubernetes';
 export const NETWORK_TYPE_SDN = 'OpenShiftSDN';
-export const DEFAULT_NETWORK_TYPE = NETWORK_TYPE_OVN;
 
 export const PREFIX_MAX_RESTRICTION = {
   IPv6: 128,

--- a/src/common/selectors/clusterSelectors.ts
+++ b/src/common/selectors/clusterSelectors.ts
@@ -2,6 +2,8 @@ import head from 'lodash/fp/head';
 import { stringToJSON } from '../api/utils';
 import { CpuArchitecture, ValidationsInfo } from '../types';
 import { Cluster } from '../api/types';
+import { NETWORK_TYPE_OVN, NETWORK_TYPE_SDN } from '../config';
+import { Address6 } from 'ip-address';
 
 export const selectMachineNetworkCIDR = ({
   machineNetworks,
@@ -25,4 +27,21 @@ export const isArmArchitecture = ({ cpuArchitecture }: Partial<Cluster>) =>
   cpuArchitecture === CpuArchitecture.ARM;
 export const selectClusterValidationsInfo = ({ validationsInfo }: Partial<Cluster>) => {
   return stringToJSON<ValidationsInfo>(validationsInfo);
+};
+export const getDefaultNetworkType = (isSNO: boolean, isIPv6 = false) => {
+  return isSNO || isIPv6 ? NETWORK_TYPE_OVN : NETWORK_TYPE_SDN;
+};
+export const canSelectNetworkTypeSDN = (isSNO: boolean, isIPv6 = false) => {
+  return !(isSNO || isIPv6);
+};
+export const isSubnetInIPv6 = ({
+  clusterNetworkCidr,
+  machineNetworkCidr,
+  serviceNetworkCidr,
+}: Partial<Cluster>) => {
+  return (
+    Address6.isValid(clusterNetworkCidr || '') ||
+    Address6.isValid(machineNetworkCidr || '') ||
+    Address6.isValid(serviceNetworkCidr || '')
+  );
 };

--- a/src/ocm/components/clusterDetail/ClusterProperties.tsx
+++ b/src/ocm/components/clusterDetail/ClusterProperties.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { GridItem, TextContent, Text } from '@patternfly/react-core';
-import { Cluster, DetailList, DetailItem, DiskEncryption, PopoverIcon } from '../../../common';
+import { Cluster, DetailList, DetailItem, DiskEncryption, PopoverIcon, NETWORK_TYPE_OVN, NETWORK_TYPE_SDN } from '../../../common';
+
 import {
   selectClusterNetworkCIDR,
   selectClusterNetworkHostPrefix,
@@ -27,11 +28,12 @@ type ClusterPropertiesProps = {
   cluster: Cluster;
 };
 
+
 const getNetworkType = (
   clusterNetworkType: 'OpenShiftSDN' | 'OVNKubernetes' | undefined,
 ): string => {
   let networkType: string;
-  clusterNetworkType == 'OpenShiftSDN'
+  clusterNetworkType === NETWORK_TYPE_SDN
     ? (networkType = 'Software-Defined Networking (SDN)')
     : (networkType = 'Open Virtual Network (OVN)');
   return networkType;

--- a/src/ocm/components/clusterDetail/ClusterProperties.tsx
+++ b/src/ocm/components/clusterDetail/ClusterProperties.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import { GridItem, TextContent, Text } from '@patternfly/react-core';
-import { Cluster, DetailList, DetailItem, DiskEncryption, PopoverIcon, NETWORK_TYPE_OVN, NETWORK_TYPE_SDN } from '../../../common';
+import {
+  Cluster,
+  DetailList,
+  DetailItem,
+  DiskEncryption,
+  PopoverIcon,
+  NETWORK_TYPE_SDN,
+} from '../../../common';
 
 import {
   selectClusterNetworkCIDR,
@@ -27,7 +34,6 @@ const getCpuArchTitle = () => (
 type ClusterPropertiesProps = {
   cluster: Cluster;
 };
-
 
 const getNetworkType = (
   clusterNetworkType: 'OpenShiftSDN' | 'OVNKubernetes' | undefined,

--- a/src/ocm/services/ClusterDetailsService.ts
+++ b/src/ocm/services/ClusterDetailsService.ts
@@ -45,6 +45,7 @@ const ClusterDetailsService = {
     if (isArmArchitecture({ cpuArchitecture: params.cpuArchitecture })) {
       params.userManagedNetworking = true;
     }
+    params.networkType = 'OVNKubernetes';
     return params;
   },
 };

--- a/src/ocm/services/ClusterDetailsService.ts
+++ b/src/ocm/services/ClusterDetailsService.ts
@@ -1,14 +1,14 @@
-import {
-  ClusterCreateParams,
-  DEFAULT_NETWORK_TYPE,
-  V2ClusterUpdateParams,
-} from '../../common';
+import { ClusterCreateParams, V2ClusterUpdateParams } from '../../common';
 import { ClustersAPI, ManagedDomainsAPI } from '../services/apis';
 import InfraEnvsService from './InfraEnvsService';
 import omit from 'lodash/omit';
 import DiskEncryptionService from './DiskEncryptionService';
 import { OcmClusterDetailsValues } from '../api/types';
-import { isArmArchitecture } from '../../common/selectors/clusterSelectors';
+import {
+  getDefaultNetworkType,
+  isArmArchitecture,
+  isSNO,
+} from '../../common/selectors/clusterSelectors';
 
 const ClusterDetailsService = {
   async create(params: ClusterCreateParams) {
@@ -36,6 +36,7 @@ const ClusterDetailsService = {
   },
 
   getClusterCreateParams(values: OcmClusterDetailsValues): ClusterCreateParams {
+    const isSNOCluster = isSNO(values);
     const params: ClusterCreateParams = omit(values, [
       'useRedHatDnsService',
       'SNODisclaimer',
@@ -49,7 +50,7 @@ const ClusterDetailsService = {
     if (isArmArchitecture({ cpuArchitecture: params.cpuArchitecture })) {
       params.userManagedNetworking = true;
     }
-    params.networkType = DEFAULT_NETWORK_TYPE;
+    params.networkType = getDefaultNetworkType(isSNOCluster);
     return params;
   },
 };

--- a/src/ocm/services/ClusterDetailsService.ts
+++ b/src/ocm/services/ClusterDetailsService.ts
@@ -1,4 +1,8 @@
-import { ClusterCreateParams, DEFAULT_NETWORK_TYPE, NETWORK_TYPE_OVN, V2ClusterUpdateParams } from '../../common';
+import {
+  ClusterCreateParams,
+  DEFAULT_NETWORK_TYPE,
+  V2ClusterUpdateParams,
+} from '../../common';
 import { ClustersAPI, ManagedDomainsAPI } from '../services/apis';
 import InfraEnvsService from './InfraEnvsService';
 import omit from 'lodash/omit';

--- a/src/ocm/services/ClusterDetailsService.ts
+++ b/src/ocm/services/ClusterDetailsService.ts
@@ -1,4 +1,4 @@
-import { ClusterCreateParams, V2ClusterUpdateParams } from '../../common';
+import { ClusterCreateParams, DEFAULT_NETWORK_TYPE, NETWORK_TYPE_OVN, V2ClusterUpdateParams } from '../../common';
 import { ClustersAPI, ManagedDomainsAPI } from '../services/apis';
 import InfraEnvsService from './InfraEnvsService';
 import omit from 'lodash/omit';
@@ -45,7 +45,7 @@ const ClusterDetailsService = {
     if (isArmArchitecture({ cpuArchitecture: params.cpuArchitecture })) {
       params.userManagedNetworking = true;
     }
-    params.networkType = 'OVNKubernetes';
+    params.networkType = DEFAULT_NETWORK_TYPE;
     return params;
   },
 };


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-9176

This PR makes sure that Assisted Installer sets valid configurations for "networkType" .

- SNO clusters and Multi-node clusters using ipV6, they must use `OVNKubernetes` as its Network Type.
- Multi-node clusters using ipV4 can use either `OVNKubernetes` or `OpenShiftSDN`. However, when a cluster is created, its default Network Type must be `OpenShiftSDN`. Users can modify this to OVN by toggling the Advanced network options and selecting it.

The fix includes:
- Setting the default Network Type on the API call to create a new cluster. This will depend on the cluster type as explained above.
- Disabling the SDN option when the cluster type does not allow it.
- Updating the Network Type of a cluster when the subnets are selected and it changes from ipV4 to ipV6 or viceversa.

SNO cluster / Multi-node cluster using ipV6:  OVN is the default, SDN is not selectable
![network-type-sno](https://user-images.githubusercontent.com/829045/161007326-7a33a741-e636-429c-88e1-f8c059b26ab2.png)


Multi-node cluster using ipV4:  SDN is the default, OVN is selectable
![network-type-mc](https://user-images.githubusercontent.com/829045/161007315-2e8e1f00-ca6e-427f-9395-30dda3bb21bd.png)


