### PR TITLE
MGMT-6468 Adding Batch request for clusters by subscription ID

### DIFF
--- a/src/ocm/services/apis/ClustersAPI.ts
+++ b/src/ocm/services/apis/ClustersAPI.ts
@@ -175,6 +175,12 @@ const ClustersAPI = {
       `${ClustersAPI.makeBaseURI()}?openshift_cluster_id=${openshiftId}`,
     );
   },
+
+  listBySubscriptionIds(subscriptionIds: Cluster['amsSubscriptionId'][]) {
+    return client.get<Cluster[]>(
+      `${ClustersAPI.makeBaseURI()}?ams_subscription_ids=${subscriptionIds.toString()}`,
+    );
+  },
 };
 
 export default ClustersAPI;


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-6468

In order to improve the performance of the Cluster list in UHC Portal, we need to be able to query for the Clusters, passing a new parameter called `ams_subscription_ids`.

This will be used in UHC Portal, see https://gitlab.cee.redhat.com/service/uhc-portal/-/merge_requests/3239