### PR TITLE
MGMT-9795 Export ClusterDetails extra component

### DIFF
--- a/src/common/sevices/DateAndTime.tsx
+++ b/src/common/sevices/DateAndTime.tsx
@@ -1,7 +1,15 @@
-import { MS_PER_DAY } from '../config/constants';
+import { TIME_ZERO, MS_PER_DAY } from '../config/constants';
 
 export function diffInDaysBetweenDates(inputDate: string) {
   const dateObject = new Date(inputDate);
   const today = new Date();
   return Math.floor(Math.abs(today.valueOf() - dateObject.valueOf()) / MS_PER_DAY);
+}
+
+export function calculateClusterDateDiff(inactiveDeletionDays: number, completedAt?: string) {
+  if (completedAt && completedAt !== TIME_ZERO) {
+    return inactiveDeletionDays - diffInDaysBetweenDates(completedAt);
+  } else {
+    return inactiveDeletionDays;
+  }
 }

--- a/src/ocm/components/clusterDetail/AssistedInstallerExtraDetailCard.tsx
+++ b/src/ocm/components/clusterDetail/AssistedInstallerExtraDetailCard.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { store } from '../../store';
+import { useSelector } from 'react-redux';
+
+import { FeatureGateContextProvider, FeatureListType } from '../../../common';
+import { FeatureSupportLevelProvider } from '../featureSupportLevels';
+import ClusterProperties from './ClusterProperties';
+import { selectCurrentClusterState } from '../../selectors';
+import { Grid } from '@patternfly/react-core';
+
+type AssistedInstallerExtraDetailCardProps = {
+  allEnabledFeatures: FeatureListType;
+};
+
+const AssistedInstallerExtraDetailCard: React.FC<AssistedInstallerExtraDetailCardProps> = ({
+  allEnabledFeatures,
+}) => {
+  const { data: cluster } = useSelector(selectCurrentClusterState);
+
+  if (!cluster || cluster.status === 'adding-hosts') {
+    return null;
+  }
+
+  return (
+    <FeatureGateContextProvider features={allEnabledFeatures}>
+      <FeatureSupportLevelProvider loadingUi={<div />} cluster={cluster}>
+        <Grid className="pf-u-mt-md">
+          <ClusterProperties cluster={cluster} externalMode />
+        </Grid>
+      </FeatureSupportLevelProvider>
+    </FeatureGateContextProvider>
+  );
+};
+
+const Wrapper: React.FC<AssistedInstallerExtraDetailCardProps> = (props) => (
+  <Provider store={store}>
+    <AssistedInstallerExtraDetailCard {...props} />
+  </Provider>
+);
+
+export default Wrapper;

--- a/src/ocm/components/clusterDetail/ClusterDetailStatusMessages.tsx
+++ b/src/ocm/components/clusterDetail/ClusterDetailStatusMessages.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { Alert, GridItem } from '@patternfly/react-core';
+import {
+  RenderIf,
+  KubeconfigDownload,
+  REDHAT_CONSOLE_OPENSHIFT,
+  canDownloadKubeconfig,
+} from '../../../common';
+import { Cluster } from '../../../common/api/types';
+import { getClusterDetailId } from './utils';
+
+import { useDefaultConfiguration } from '../clusterConfiguration/ClusterDefaultConfigurationContext';
+import { VSPHERE_CONFIG_LINK } from '../../../common/config/constants';
+import { isSNO } from '../../../common/selectors/clusterSelectors';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { calculateClusterDateDiff } from '../../../common/sevices/DateAndTime';
+
+type ClusterDetailStatusMessagesProps = {
+  cluster: Cluster;
+};
+
+const ClusterDetailStatusMessages: React.FC<ClusterDetailStatusMessagesProps> = ({ cluster }) => {
+  const { inactiveDeletionHours } = useDefaultConfiguration(['inactiveDeletionHours']);
+  const inactiveDeletionDays = Math.round((inactiveDeletionHours || 0) / 24);
+  const dateDifference = calculateClusterDateDiff(inactiveDeletionDays, cluster.installCompletedAt);
+
+  return (
+    <>
+      <RenderIf condition={dateDifference > 0 && canDownloadKubeconfig(cluster.status)}>
+        <GridItem>
+          <KubeconfigDownload
+            status={cluster.status}
+            clusterId={cluster.id}
+            id={getClusterDetailId('button-download-kubeconfig')}
+          />
+        </GridItem>
+      </RenderIf>
+      <RenderIf
+        condition={
+          typeof inactiveDeletionHours === 'number' && canDownloadKubeconfig(cluster.status)
+        }
+      >
+        <Alert
+          variant="info"
+          isInline
+          title={
+            dateDifference > 0
+              ? `Download and save your kubeconfig file in a safe place. This file will be automatically ` +
+                `deleted from Assisted Installer's service in ${dateDifference} days.`
+              : `Kubeconfig file was automatically deleted ${inactiveDeletionDays} days after installation.`
+          }
+        />
+      </RenderIf>
+      <RenderIf condition={cluster.status === 'installed' && !isSNO(cluster)}>
+        <Alert
+          variant="info"
+          isInline
+          title={
+            <p>
+              Add new hosts by generating a new Discovery ISO under your cluster's "Add hosts” tab
+              on{' '}
+              <a href={REDHAT_CONSOLE_OPENSHIFT} target="_blank" rel="noopener noreferrer">
+                console.redhat.com/openshift <ExternalLinkAltIcon />
+              </a>
+              .
+            </p>
+          }
+        />
+      </RenderIf>
+      <RenderIf condition={cluster.platform?.type !== 'baremetal'}>
+        <Alert
+          variant="warning"
+          isInline
+          title={
+            <p>
+              Modify your platform configuration to access your platform's features directly in
+              OpenShift.{' '}
+              <a href={VSPHERE_CONFIG_LINK} target="_blank" rel="noopener noreferrer">
+                Learn more about configuration <i className="fas fa-external-link-alt" />
+              </a>
+            </p>
+          }
+        />
+      </RenderIf>
+    </>
+  );
+};
+
+export default ClusterDetailStatusMessages;

--- a/src/ocm/components/clusterDetail/ClusterDetailStatusVarieties.tsx
+++ b/src/ocm/components/clusterDetail/ClusterDetailStatusVarieties.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../../common';
 import { getClusterDetailId } from './utils';
 import { ClustersAPI } from '../../services/apis';
+import ClusterDetailStatusMessages from './ClusterDetailStatusMessages';
 
 type ClusterStatusVarieties = {
   credentials?: Credentials;
@@ -84,6 +85,7 @@ const ClusterDetailStatusVarieties: React.FC<{
           idPrefix={getClusterDetailId('cluster-creds')}
         />
       )}
+      <ClusterDetailStatusMessages cluster={cluster} />
     </>
   );
 };

--- a/src/ocm/components/clusterDetail/ClusterProperties.tsx
+++ b/src/ocm/components/clusterDetail/ClusterProperties.tsx
@@ -33,6 +33,7 @@ const getCpuArchTitle = () => (
 
 type ClusterPropertiesProps = {
   cluster: Cluster;
+  externalMode?: boolean;
 };
 
 const getNetworkType = (
@@ -75,26 +76,26 @@ const getDiskEncryptionEnabledOnStatus = (diskEncryption: DiskEncryption['enable
   return diskEncryptionType;
 };
 
-const ClusterProperties: React.FC<ClusterPropertiesProps> = ({ cluster }) => (
+const ClusterProperties: React.FC<ClusterPropertiesProps> = ({ cluster, externalMode = false }) => (
   <>
-    <GridItem>
-      <TextContent>
-        <Text component="h2">Cluster Details</Text>
-      </TextContent>
-    </GridItem>
+    {!externalMode && (
+      <GridItem>
+        <TextContent>
+          <Text component="h2">Cluster Details</Text>
+        </TextContent>
+      </GridItem>
+    )}
     <GridItem md={6} data-testid="cluster-details">
       <DetailList>
-        <DetailItem title="Cluster ID" value={cluster.id} testId="cluster-id" />
-        <DetailItem
-          title="OpenShift version"
-          value={cluster.openshiftVersion}
-          testId="openshift-version"
-        />
-        <DetailItem
-          title="Base DNS domain"
-          value={cluster.baseDnsDomain}
-          testId="base-dns-domain"
-        />
+        {externalMode ? undefined : (
+          <DetailItem
+            title="OpenShift version"
+            value={cluster.openshiftVersion}
+            testId="openshift-version"
+          />
+        )}
+
+        <DetailItem title="Base domain" value={cluster.baseDnsDomain} testId="base-dns-domain" />
         <DetailItem
           title={getCpuArchTitle()}
           value={cluster.cpuArchitecture}

--- a/src/ocm/components/clusterDetail/index.ts
+++ b/src/ocm/components/clusterDetail/index.ts
@@ -2,3 +2,4 @@ export * from './utils';
 export { default as ClusterDetail } from './ClusterDetail';
 export { default as ClusterInstallationProgressCard } from './ClusterInstallationProgressCard';
 export { default as AssistedInstallerDetailCard } from './AssistedInstallerDetailCard';
+export { default as AssistedInstallerExtraDetailCard } from './AssistedInstallerExtraDetailCard';


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-9795
Is used by https://gitlab.cee.redhat.com/service/uhc-portal/-/merge_requests/3248

To be able to show all details for AI clusters,
- A new component `AssistedInstallerExtraDetailCard` is created, which displays the AI cluster properties (IP, etc)

![extra-card](https://user-images.githubusercontent.com/829045/162229010-35205d67-910f-4e29-9bbf-6d584d627680.png)

- Made the warnings that appear during the installation process also visible in the `AssistedInstallerDetailCard`, as well as in the Installer as up until now. See the code moved from  `ClusterDetail` to  `ClusterDetailStatusVarieties`

![final-cluster-details-added](https://user-images.githubusercontent.com/829045/162228496-56351603-173a-4b89-a4c5-b78afb0961b9.png)

