### PR TITLE
Fix: Do not set network type automatically

### DIFF
--- a/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
@@ -6,7 +6,6 @@ import { Cluster } from '../../../../common/api/types';
 import { useFeatureSupportLevel } from '../../../../common/components/featureSupportLevels';
 import { NetworkConfigurationValues } from '../../../../common/types';
 import { getLimitedFeatureSupportLevels } from '../../../../common/components/featureSupportLevels/utils';
-import { useFeature } from '../../../../common/features';
 import {
   canSelectNetworkTypeSDN,
   getDefaultNetworkType,
@@ -19,12 +18,7 @@ import {
 import { StackTypeControlGroup } from './StackTypeControl';
 import { AvailableSubnetsControl } from './AvailableSubnetsControl';
 import AdvancedNetworkFields from './AdvancedNetworkFields';
-import {
-  clusterNetworksEqual,
-  DUAL_STACK,
-  NETWORK_TYPE_OVN,
-  serviceNetworksEqual,
-} from '../../../../common';
+import { clusterNetworksEqual, DUAL_STACK, serviceNetworksEqual } from '../../../../common';
 
 export type NetworkConfigurationProps = VirtualIPControlGroupProps & {
   defaultNetworkSettings: Partial<Cluster>;
@@ -72,10 +66,6 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
   const clusterFeatureSupportLevels = React.useMemo(() => {
     return getLimitedFeatureSupportLevels(cluster, featureSupportLevelData);
   }, [cluster, featureSupportLevelData]);
-
-  const isNetworkTypeSelectionEnabled = useFeature(
-    'ASSISTED_INSTALLER_NETWORK_TYPE_SELECTION_FEATURE',
-  );
   const isMultiNodeCluster = !isSNO(cluster);
   const isUserManagedNetworking = values.managedNetworkingType === 'userManaged';
   const isDualStack = values.stackType === DUAL_STACK;
@@ -139,15 +129,6 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
       toggleAdvConfiguration(true);
     }
   }, [toggleAdvConfiguration, isUserManagedNetworking, isDualStack]);
-
-  useEffect(() => {
-    if (isNetworkTypeSelectionEnabled && !isSDNSelectable) {
-      setFieldValue('vipDhcpAllocation', false);
-      setFieldValue('networkType', NETWORK_TYPE_OVN);
-      toggleAdvConfiguration(true);
-    }
-  }, [isNetworkTypeSelectionEnabled, isSDNSelectable, setFieldValue, toggleAdvConfiguration]);
-
   return (
     <Grid hasGutter>
       {!hideManagedNetworking && (


### PR DESCRIPTION
The UI was forcing advanced networking on SNO clusters. There is no scenario in which the `Network type` needs to be automatically set to OVN like this, so the code for that was removed.