### PR TITLE
MGMT-10058: Dual Stack should not be offered when hosts have only IPv4 addresses

### DIFF
--- a/src/common/selectors/clusterSelectors.ts
+++ b/src/common/selectors/clusterSelectors.ts
@@ -1,6 +1,11 @@
 import head from 'lodash/fp/head';
 import { stringToJSON } from '../api/utils';
-import { CpuArchitecture, NetworkConfigurationValues, ValidationsInfo } from '../types';
+import {
+  CpuArchitecture,
+  HostSubnets,
+  NetworkConfigurationValues,
+  ValidationsInfo,
+} from '../types';
 import { Cluster, ClusterNetwork, MachineNetwork, ServiceNetwork } from '../api/types';
 import { NETWORK_TYPE_OVN, NETWORK_TYPE_SDN } from '../config';
 import { Address4, Address6 } from 'ip-address';
@@ -51,6 +56,9 @@ export const allSubnetsIPv4 = (
 ) => {
   return !!networks?.every((network) => network.cidr && Address4.isValid(network.cidr));
 };
+
+export const allHostSubnetsIPv4 = (subnets: HostSubnets) =>
+  subnets.every((subnet) => Address4.isValid(subnet.subnet));
 
 export const isIPv4 = ({
   machineNetworks,

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/AdvancedNetworkFields.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/AdvancedNetworkFields.tsx
@@ -68,14 +68,16 @@ const AdvancedNetworkFields: React.FC<AdvancedNetworkFieldsProps> = ({ isSDNSele
                 <StackItem key={index} className={'network-field-group'}>
                   <InputField
                     name={`clusterNetworks.${index}.cidr`}
-                    label="Cluster network CIDR"
+                    label={`Cluster network CIDR (${isDualStack && index === 0 ? 'IPv4' : 'IPv6'})`}
                     helperText={clusterCidrHelperText}
                     isRequired
                     labelInfo={index === 0 && isDualStack ? 'Primary' : ''}
                   />
                   <InputField
                     name={`clusterNetworks.${index}.hostPrefix`}
-                    label="Cluster network host prefix"
+                    label={`Cluster network host prefix (${
+                      isDualStack && index === 0 ? 'IPv4' : 'IPv6'
+                    })`}
                     type={TextInputTypes.number}
                     min={clusterNetworkCidrPrefix(index)}
                     max={
@@ -110,7 +112,7 @@ const AdvancedNetworkFields: React.FC<AdvancedNetworkFieldsProps> = ({ isSDNSele
               <StackItem key={index} className={'network-field-group'}>
                 <InputField
                   name={`serviceNetworks.${index}.cidr`}
-                  label="Service network CIDR"
+                  label={`Service network CIDR (${isDualStack && index === 0 ? 'IPv4' : 'IPv6'})`}
                   helperText={serviceCidrHelperText}
                   isRequired
                   labelInfo={index === 0 && isDualStack ? 'Primary' : ''}

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
@@ -8,6 +8,7 @@ import { NetworkConfigurationValues } from '../../../../common/types';
 import { getLimitedFeatureSupportLevels } from '../../../../common/components/featureSupportLevels/utils';
 import { useFeature } from '../../../../common/features';
 import {
+  allHostSubnetsIPv4,
   canSelectNetworkTypeSDN,
   getDefaultNetworkType,
   isSNO,
@@ -79,6 +80,10 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
   const isMultiNodeCluster = !isSNO(cluster);
   const isUserManagedNetworking = values.managedNetworkingType === 'userManaged';
   const isDualStack = values.stackType === DUAL_STACK;
+
+  const isDualStackSelectable = React.useMemo(() => !allHostSubnetsIPv4(hostSubnets), [
+    hostSubnets,
+  ]);
 
   const { defaultNetworkType, isSDNSelectable } = React.useMemo(() => {
     return {
@@ -177,7 +182,12 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
         clusterFeatureSupportLevels['CLUSTER_MANAGED_NETWORKING_WITH_VMS'] === 'unsupported' &&
         vmsAlert}
 
-      {!isUserManagedNetworking && <StackTypeControlGroup clusterId={cluster.id} />}
+      {!isUserManagedNetworking && (
+        <StackTypeControlGroup
+          clusterId={cluster.id}
+          isDualStackSelectable={isDualStackSelectable}
+        />
+      )}
 
       {!(isUserManagedNetworking && isMultiNodeCluster) && (
         <AvailableSubnetsControl


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-10058

- Dual-stack will not be offered if the hosts aren't using IPv6.

![Screenshot from 2022-04-25 14-36-55](https://user-images.githubusercontent.com/87187179/165090542-40938574-e1e9-4a2d-97cb-4da23a8130da.png)

- I've also added filtering to the machine network options (IPv4 for single stack and first subnet in dual-stack, IPv6 for second subnet in dual-stack):

![image](https://user-images.githubusercontent.com/87187179/165089589-4c99f323-d1ec-4b60-9b82-a29e921301f8.png)
![image](https://user-images.githubusercontent.com/87187179/165089643-da7bb393-5782-4330-91a2-09efe1232323.png)
![image](https://user-images.githubusercontent.com/87187179/165089628-c2abd25c-2f21-4b58-a433-3dea80168e8d.png)

- Added more specific field titles for Cluster and Service networks in dual stack:

![image](https://user-images.githubusercontent.com/87187179/166207214-29f76bee-7403-4f84-9b58-ba153fbc17c3.png)
