### PR TITLE
Bug 2071750: Fix labeling to correctly assign nmstate to infraEnv

### DIFF
--- a/src/cim/components/Agent/BMCForm.tsx
+++ b/src/cim/components/Agent/BMCForm.tsx
@@ -35,7 +35,11 @@ import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { AddBmcValues, BMCFormProps } from './types';
 import { NMStateK8sResource } from '../../types/k8s/nm-state';
 import { BareMetalHostK8sResource } from '../../types/k8s/bare-metal-host';
-import { AGENT_BMH_HOSTNAME_LABEL_KEY, BMH_HOSTNAME_ANNOTATION } from '../common';
+import {
+  AGENT_BMH_NAME_LABEL_KEY,
+  BMH_HOSTNAME_ANNOTATION,
+  INFRAENV_AGENTINSTALL_LABEL_KEY,
+} from '../common';
 
 const MacMapping = () => {
   const [field, { touched, error }] = useField<{ macAddress: string; name: string }[]>({
@@ -107,7 +111,8 @@ const getNMState = (values: AddBmcValues, infraEnv: InfraEnvK8sResource): NMStat
       generateName: `${infraEnv.metadata?.name}-`,
       namespace: infraEnv.metadata?.namespace,
       labels: {
-        [AGENT_BMH_HOSTNAME_LABEL_KEY]: values.hostname,
+        [AGENT_BMH_NAME_LABEL_KEY]: values.name,
+        [INFRAENV_AGENTINSTALL_LABEL_KEY]: infraEnv?.metadata?.name || '',
       },
     },
     spec: {

--- a/src/cim/components/Agent/tableUtils.tsx
+++ b/src/cim/components/Agent/tableUtils.tsx
@@ -17,7 +17,7 @@ import { AgentTableActions, ClusterDeploymentWizardStepsType } from '../ClusterD
 import { hostActionResolver } from '../../../common/components/hosts/tableUtils';
 import { getAgentClusterInstallOfAgent, getAIHosts, getInfraEnvNameOfAgent } from '../helpers';
 import { isInstallationInProgress } from '../ClusterDeployment/helpers';
-import { AGENT_BMH_HOSTNAME_LABEL_KEY } from '../common';
+import { AGENT_BMH_NAME_LABEL_KEY } from '../common';
 import { BareMetalHostK8sResource } from '../../types/k8s/bare-metal-host';
 import BMHStatus from './BMHStatus';
 import { getAgentStatus, getBMHStatus, getWizardStepAgentStatus } from '../helpers/status';
@@ -90,7 +90,7 @@ export const discoveryTypeColumn = (
     const agent = agents.find((a) => a.metadata?.uid === host.id);
     let discoveryType = 'Unknown';
     if (agent) {
-      discoveryType = agent?.metadata?.labels?.hasOwnProperty(AGENT_BMH_HOSTNAME_LABEL_KEY)
+      discoveryType = agent?.metadata?.labels?.hasOwnProperty(AGENT_BMH_NAME_LABEL_KEY)
         ? 'BMC'
         : 'Discovery ISO';
     } else {

--- a/src/cim/components/ClusterDeployment/ClusterDeploymentHostsDiscovery.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentHostsDiscovery.tsx
@@ -21,6 +21,7 @@ const ClusterDeploymentHostsDiscovery: React.FC<ClusterDeploymentHostsDiscoveryP
   bareMetalHosts,
   aiConfigMap,
   infraEnv,
+  infraNMStates,
   usedHostnames,
   onCreateBMH,
   onSaveAgent,
@@ -29,7 +30,6 @@ const ClusterDeploymentHostsDiscovery: React.FC<ClusterDeploymentHostsDiscoveryP
   onSaveISOParams,
   onFormSaveError,
   fetchSecret,
-  fetchNMState,
   onChangeBMHHostname,
   onApproveAgent,
   onDeleteHost,
@@ -97,11 +97,11 @@ const ClusterDeploymentHostsDiscovery: React.FC<ClusterDeploymentHostsDiscoveryP
         <EditBMHModal
           infraEnv={infraEnv}
           bmh={editBMH}
+          nmStates={infraNMStates}
           isOpen={!!editBMH}
           onClose={() => setEditBMH(undefined)}
           onEdit={onSaveBMH}
           fetchSecret={fetchSecret}
-          fetchNMState={fetchNMState}
           usedHostnames={usedHostnames || []}
         />
         <EditAgentModal

--- a/src/cim/components/ClusterDeployment/ClusterDeploymentHostsDiscoveryStep.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentHostsDiscoveryStep.tsx
@@ -16,6 +16,7 @@ const ClusterDeploymentHostsDiscoveryStep: React.FC<ClusterDeploymentHostsDiscov
   agentClusterInstall,
   agents: allAgents,
   infraEnv,
+  infraNMStates,
   clusterDeployment,
   bareMetalHosts,
   onCreateBMH,
@@ -25,7 +26,6 @@ const ClusterDeploymentHostsDiscoveryStep: React.FC<ClusterDeploymentHostsDiscov
   onSaveISOParams,
   onFormSaveError,
   fetchSecret,
-  fetchNMState,
   onChangeBMHHostname,
   onApproveAgent,
   onDeleteHost,
@@ -150,6 +150,7 @@ const ClusterDeploymentHostsDiscoveryStep: React.FC<ClusterDeploymentHostsDiscov
             agentClusterInstall={agentClusterInstall}
             agents={infraEnvAgents}
             infraEnv={infraEnv}
+            infraNMStates={infraNMStates}
             bareMetalHosts={bareMetalHosts}
             usedHostnames={usedHostnames}
             clusterDeployment={clusterDeployment}
@@ -160,7 +161,6 @@ const ClusterDeploymentHostsDiscoveryStep: React.FC<ClusterDeploymentHostsDiscov
             onSaveISOParams={onSaveISOParams}
             onFormSaveError={onFormSaveError}
             fetchSecret={fetchSecret}
-            fetchNMState={fetchNMState}
             onChangeBMHHostname={onChangeBMHHostname}
             onApproveAgent={onApproveAgent}
             onDeleteHost={onDeleteHost}

--- a/src/cim/components/ClusterDeployment/ClusterDeploymentWizard.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentWizard.tsx
@@ -32,13 +32,13 @@ const ClusterDeploymentWizard: React.FC<ClusterDeploymentWizardProps> = ({
   usedClusterNames,
   getClusterDeploymentLink,
   fetchSecret,
-  fetchNMState,
   clusterDeployment,
   agentClusterInstall,
   agents,
   clusterImages,
   aiConfigMap,
   infraEnv,
+  infraNMStates,
   fetchInfraEnv,
   initialStep,
   onApproveAgent,
@@ -95,10 +95,10 @@ const ClusterDeploymentWizard: React.FC<ClusterDeploymentWizardProps> = ({
               infraEnv={
                 infraEnv as InfraEnvK8sResource /* Must be available since isAIFlow === true */
               }
+              infraNMStates={infraNMStates}
               onSaveAgent={onSaveAgent}
               onSaveBMH={onSaveBMH}
               fetchSecret={fetchSecret}
-              fetchNMState={fetchNMState}
               getClusterDeploymentLink={getClusterDeploymentLink}
               onClose={onClose}
               onSaveISOParams={onSaveISOParams}

--- a/src/cim/components/ClusterDeployment/types.ts
+++ b/src/cim/components/ClusterDeployment/types.ts
@@ -8,6 +8,7 @@ import {
   InfraEnvK8sResource,
   SecretK8sResource,
   ConfigMapK8sResource,
+  NMStateK8sResource,
 } from '../../types';
 import { BareMetalHostK8sResource } from '../../types/k8s/bare-metal-host';
 import { ClusterImageSetK8sResource } from '../../types/k8s/cluster-image-set';
@@ -133,6 +134,7 @@ export type ClusterDeploymentWizardProps = {
   agents: AgentK8sResource[];
   aiConfigMap?: ConfigMapK8sResource;
   infraEnv?: InfraEnvK8sResource;
+  infraNMStates: NMStateK8sResource[];
   fetchInfraEnv: (name: string, namespace: string) => Promise<InfraEnvK8sResource>;
   initialStep?: ClusterDeploymentWizardStepsType;
   isPreviewOpen: boolean;
@@ -147,7 +149,6 @@ export type ClusterDeploymentWizardProps = {
   onCreateBMH?: AddHostModalProps['onCreateBMH'];
   getClusterDeploymentLink: InfraEnvAgentTableProps['getClusterDeploymentLink'];
   fetchSecret: EditBMHModalProps['fetchSecret'];
-  fetchNMState: EditBMHModalProps['fetchNMState'];
 };
 
 export type FetchSecret = (name: string, namespace: string) => Promise<SecretK8sResource>;
@@ -169,6 +170,7 @@ export type InfraEnvAgentTableProps = Pick<
   agents: AgentK8sResource[];
   bareMetalHosts: BareMetalHostK8sResource[];
   infraEnv: InfraEnvK8sResource;
+  nmStates: NMStateK8sResource[];
   getClusterDeploymentLink: (cd: { name: string; namespace: string }) => string | React.ReactNode;
   onChangeHostname: (agent: AgentK8sResource, hostname: string) => Promise<AgentK8sResource>;
   onChangeBMHHostname: (
@@ -204,6 +206,7 @@ export type ClusterDeploymentHostsDiscoveryProps = {
   bareMetalHosts: BareMetalHostK8sResource[];
   aiConfigMap?: ConfigMapK8sResource;
   infraEnv: InfraEnvK8sResource;
+  infraNMStates: NMStateK8sResource[];
   isBMPlatform: boolean;
 
   usedHostnames: EditAgentModalProps['usedHostnames'];
@@ -214,7 +217,6 @@ export type ClusterDeploymentHostsDiscoveryProps = {
   onSaveISOParams: AddHostModalProps['onSaveISOParams'];
   onFormSaveError?: EditAgentModalProps['onFormSaveError'];
   fetchSecret: EditBMHModalProps['fetchSecret'];
-  fetchNMState: EditBMHModalProps['fetchNMState'];
   getClusterDeploymentLink: InfraEnvAgentTableProps['getClusterDeploymentLink'];
   onChangeBMHHostname: InfraEnvAgentTableProps['onChangeBMHHostname'];
   onApproveAgent: InfraEnvAgentTableProps['onApprove'];

--- a/src/cim/components/InfraEnv/InfraEnvAgentTable.tsx
+++ b/src/cim/components/InfraEnv/InfraEnvAgentTable.tsx
@@ -58,6 +58,7 @@ const InfraEnvAgentTable: React.FC<InfraEnvAgentTableProps> = ({
   getClusterDeploymentLink,
   bareMetalHosts,
   infraEnv,
+  nmStates,
   onChangeHostname,
   onChangeBMHHostname,
   onMassDeleteHost,
@@ -241,6 +242,7 @@ const InfraEnvAgentTable: React.FC<InfraEnvAgentTableProps> = ({
           agents={selectedAgents}
           bmhs={selectedBMHs}
           infraEnv={infraEnv}
+          nmStates={nmStates}
           onDelete={onMassDeleteHost}
           onClose={() => setMassDeleteOpen(false)}
         />

--- a/src/cim/components/common/constants.ts
+++ b/src/cim/components/common/constants.ts
@@ -9,7 +9,7 @@ export const AGENT_NOLOCATION_VALUE = 'NOLOCATION';
 
 export const INFRAENV_AGENTINSTALL_LABEL_KEY = 'infraenvs.agent-install.openshift.io';
 
-export const AGENT_BMH_HOSTNAME_LABEL_KEY = 'agent-install.openshift.io/bmh';
+export const AGENT_BMH_NAME_LABEL_KEY = 'agent-install.openshift.io/bmh';
 
 export const INFRAENV_GENERATED_AI_FLOW = 'agentBareMetal-generated-infraenv-ai-flow'; // mind ai-template.hbs in ACM when changed here
 

--- a/src/cim/components/helpers/toAssisted.ts
+++ b/src/cim/components/helpers/toAssisted.ts
@@ -6,7 +6,7 @@ import { AgentClusterInstallK8sResource } from '../../types/k8s/agent-cluster-in
 import { getAgentStatus, getClusterStatus } from './status';
 import { getHostNetworks } from './network';
 import { BareMetalHostK8sResource, InfraEnvK8sResource } from '../../types';
-import { AGENT_BMH_HOSTNAME_LABEL_KEY, BMH_HOSTNAME_ANNOTATION } from '../common/constants';
+import { AGENT_BMH_NAME_LABEL_KEY, BMH_HOSTNAME_ANNOTATION } from '../common/constants';
 import { getAgentProgress, getAgentRole, getInfraEnvNameOfAgent } from './agents';
 
 export const getAIHosts = (
@@ -30,8 +30,8 @@ export const getAIHosts = (
         intf.ipv6Addresses = _.cloneDeep(intf.ipV6Addresses);
       });
 
-      if (agent.metadata?.labels?.[AGENT_BMH_HOSTNAME_LABEL_KEY]) {
-        const bmhName = agent.metadata?.labels?.[AGENT_BMH_HOSTNAME_LABEL_KEY];
+      if (agent.metadata?.labels?.[AGENT_BMH_NAME_LABEL_KEY]) {
+        const bmhName = agent.metadata?.labels?.[AGENT_BMH_NAME_LABEL_KEY];
         bmhAgents.push(bmhName);
         const bmh = bmhs?.find(
           (h) =>

--- a/src/cim/components/modals/MassDeleteAgentModal.tsx
+++ b/src/cim/components/modals/MassDeleteAgentModal.tsx
@@ -12,9 +12,14 @@ import {
 } from '../../../common';
 import { TableRow } from '../../../common/components/hosts/AITable';
 import HostsTable from '../../../common/components/hosts/HostsTable';
-import { AgentK8sResource, BareMetalHostK8sResource, InfraEnvK8sResource } from '../../types';
+import {
+  AgentK8sResource,
+  BareMetalHostK8sResource,
+  InfraEnvK8sResource,
+  NMStateK8sResource,
+} from '../../types';
 import { useAgentsTable } from '../Agent/tableUtils';
-import { AGENT_BMH_HOSTNAME_LABEL_KEY } from '../common/constants';
+import { AGENT_BMH_NAME_LABEL_KEY } from '../common/constants';
 import AgentStatus from '../Agent/AgentStatus';
 import BMHStatus from '../Agent/BMHStatus';
 import { getBMHStatus, getAgentStatus } from '../helpers';
@@ -116,8 +121,13 @@ type MassDeleteAgentModalProps = {
   onClose: VoidFunction;
   agents: AgentK8sResource[];
   bmhs: BareMetalHostK8sResource[];
+  nmStates: NMStateK8sResource[];
   // eslint-disable-next-line
-  onDelete: (agent?: AgentK8sResource, bmh?: BareMetalHostK8sResource) => Promise<any>;
+  onDelete: (
+    agent?: AgentK8sResource,
+    bmh?: BareMetalHostK8sResource,
+    nmStates?: NMStateK8sResource[],
+  ) => Promise<unknown>;
   infraEnv: InfraEnvK8sResource;
 };
 
@@ -128,11 +138,12 @@ const MassDeleteAgentModal: React.FC<MassDeleteAgentModalProps> = ({
   agents,
   bmhs,
   infraEnv,
+  nmStates,
 }) => {
   const [hosts] = useAgentsTable({ agents, bmhs, infraEnv });
   const onClick = async (host: Host) => {
     const agent = agents.find((a) => a.metadata?.uid === host.id);
-    const bmhLabel = agent?.metadata?.labels?.[AGENT_BMH_HOSTNAME_LABEL_KEY];
+    const bmhLabel = agent?.metadata?.labels?.[AGENT_BMH_NAME_LABEL_KEY];
     let bmh;
     if (!agent) {
       bmh = bmhs.find((bmh) => bmh.metadata?.uid === host.id);
@@ -143,7 +154,7 @@ const MassDeleteAgentModal: React.FC<MassDeleteAgentModalProps> = ({
       );
     }
     if (!agent?.spec?.clusterDeploymentName?.name) {
-      return onDelete(agent, bmh);
+      return onDelete(agent, bmh, nmStates);
     }
   };
 

--- a/src/cim/components/modals/types.ts
+++ b/src/cim/components/modals/types.ts
@@ -27,7 +27,7 @@ export type EditBMHModalProps = Pick<
     secret?: SecretK8sResource;
     nmState?: NMStateK8sResource;
   }) => BMCFormProps['onCreateBMH'];
-  fetchNMState: (namespace: string, name: string) => Promise<NMStateK8sResource>;
+  nmStates: NMStateK8sResource[];
   fetchSecret: (namespace: string, bmhName: string) => Promise<SecretK8sResource>;
 };
 


### PR DESCRIPTION
- update AGENT_BMH_HOSTNAME_LABEL_KEY to AGENT_BMH_NAME_LABEL_KEY
- set correct nmstate value for agent bmh label key (bmh name instead of hostname)
- set infraenv label on nmstate to allow BMO to correctly apply it
- use nmStates from recoil state instead of fetching them explicitly
- when mass-deleting BMHs, delete also related nmstates

Fixes BZ2071750