### PR TITLE
chore: enforce @typescript-eslint/no-unused-vars": "error"

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,11 +27,12 @@
     "prettier/react"
   ],
   "rules": {
-    "eqeqeq": [2, "always"],
+    "eqeqeq": ["error", "always"],
     "indent": "off",
     "react/no-unescaped-entities": ["error", { "forbid": [">", "}"] }],
     "@typescript-eslint/explicit-member-accessibility": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/no-unused-vars": "error",
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
     "react/prop-types": "off"


### PR DESCRIPTION
Unused variables will make our GH actions fail because we don't tolerate warnings in PR builds or while releasing new versions. Marking this rule as "error" will make our IDEs prompt about the error sooner instead of just display a warning.
