### PR TITLE
MGMT-10171: Form fields get invalidated immediately before entering information

### DIFF
--- a/src/common/components/ui/formik/CodeField.tsx
+++ b/src/common/components/ui/formik/CodeField.tsx
@@ -5,6 +5,7 @@ import { CodeFieldProps } from './types';
 import { getFieldId } from './utils';
 import HelperText from './HelperText';
 import { CodeEditor } from '@patternfly/react-code-editor';
+import useFieldErrorMsg from '../../../hooks/useFieldErrorMsg';
 
 const CodeField: React.FC<CodeFieldProps> = ({
   label,
@@ -17,10 +18,10 @@ const CodeField: React.FC<CodeFieldProps> = ({
   name,
   description,
 }) => {
-  const [field, { touched, error }, { setValue, setTouched }] = useField({ name, validate });
+  const [field, , { setValue, setTouched }] = useField({ name, validate });
   const fieldId = getFieldId(name, 'input', idPostfix);
-  const isValid = !(touched && error);
-  const errorMessage = !isValid ? error : '';
+  const errorMessage = useFieldErrorMsg({ name });
+  const isValid = !errorMessage;
   return (
     <FormGroup
       fieldId={fieldId}
@@ -46,7 +47,6 @@ const CodeField: React.FC<CodeFieldProps> = ({
         code={field.value}
         isUploadEnabled
         isDownloadEnabled
-        isCopyEnabled
         isLanguageLabelVisible
         height="400px"
         language={language}

--- a/src/common/components/ui/formik/InputField.tsx
+++ b/src/common/components/ui/formik/InputField.tsx
@@ -4,6 +4,7 @@ import { FormGroup, HelperTextItem, Split, SplitItem, TextInput } from '@pattern
 import { InputFieldProps } from './types';
 import { getFieldId } from './utils';
 import HelperText from './HelperText';
+import useFieldErrorMsg from '../../../hooks/useFieldErrorMsg';
 
 const InputField: React.FC<
   InputFieldProps & { inputError?: string; description?: React.ReactNode; labelInfo?: string }
@@ -26,10 +27,13 @@ const InputField: React.FC<
     },
     ref: React.Ref<HTMLInputElement>,
   ) => {
-    const [field, { touched, error }] = useField({ name: props.name, validate });
+    const [field] = useField({
+      name: props.name,
+      validate,
+    });
     const fieldId = getFieldId(props.name, 'input', idPostfix);
-    const isValid = inputError ? false : !(touched && error);
-    const errorMessage = (!isValid ? error : '') || inputError;
+    const errorMessage = useFieldErrorMsg({ name: props.name, inputError, validate });
+    const isValid = !errorMessage;
     return (
       <FormGroup
         fieldId={fieldId}

--- a/src/common/hooks/useFieldErrorMsg.tsx
+++ b/src/common/hooks/useFieldErrorMsg.tsx
@@ -13,7 +13,7 @@ const useFieldErrorMsg = ({ name, inputError, validate }: Props): string | undef
     for none empty values - always show the error if there is one
   */
   const [field, { error }] = useField({
-    name: name,
+    name,
     validate,
   });
   const [hadValue, setHadValue] = React.useState<boolean>(false);

--- a/src/common/hooks/useFieldErrorMsg.tsx
+++ b/src/common/hooks/useFieldErrorMsg.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react';
+import { FieldValidator, useField } from 'formik';
+
+type Props = {
+  name: string;
+  inputError?: string;
+  validate?: FieldValidator;
+};
+
+const useFieldErrorMsg = ({ name, inputError, validate }: Props): string | undefined => {
+  /*
+    for empty values - show an error only if at a certain point it was none empty, to avoid new items in a field array shown as invalid right away
+    for none empty values - always show the error if there is one
+  */
+  const [field, { error }] = useField({
+    name: name,
+    validate,
+  });
+  const [hadValue, setHadValue] = React.useState<boolean>(false);
+  React.useEffect(() => {
+    if (field.value) {
+      setHadValue(field.value);
+    }
+  }, [field.value, setHadValue]);
+  const showError = field.value || (!field.value && hadValue);
+  const errorMessage = (showError ? error : '') || inputError;
+  return errorMessage;
+};
+
+export default useFieldErrorMsg;


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-10171

Right now we show errors on an input field if it was touched.
This causes required array fields new items to become invalid right away.
Instead I propose the following:
If the value is empty - show the error only if it was previously none empty
If the value is not empty - show the error 
This change effects all input fields across the lib
