### PR TITLE
MGMT-10212: Avoid false positives checking version features

### DIFF
--- a/src/ocm/components/featureSupportLevels/FeatureSupportLevelProvider.tsx
+++ b/src/ocm/components/featureSupportLevels/FeatureSupportLevelProvider.tsx
@@ -72,10 +72,14 @@ export const FeatureSupportLevelProvider: React.FC<SupportLevelProviderProps> = 
 
   const getVersionSupportLevelsMap = React.useCallback(
     (versionName: string): FeatureIdToSupportLevel | undefined => {
-      const versionKey = Object.keys(supportLevelData).find((key) => versionName.startsWith(key));
+      const versionKey = Object.keys(supportLevelData).find((key) => {
+        const versionNameMatch = new RegExp(`^${key}(\\..*)?$`); // For version 4.10 match 4.10, 4.10.3, not 4.1, 4.1.5
+        return versionNameMatch.test(versionName);
+      });
       if (!versionKey) {
         return undefined;
       }
+
       return supportLevelData[versionKey];
     },
     [supportLevelData],


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-10212

Avoid partial version matches resulting in wrong support data identification.

Eg. If we received versions `4.1` and `4.10`, the previous code would match to version `4.1`.
The regular expression would allow only `4.10`, `4.10.`, `4.10.123` etc.