### PR TITLE
MGMT-9454: Allow transforming day1 to day2 in on-prem environment

### DIFF
--- a/src/ocm/components/AddHosts/AddHosts.tsx
+++ b/src/ocm/components/AddHosts/AddHosts.tsx
@@ -2,7 +2,11 @@ import {
   ButtonVariant,
   Card,
   CardBody,
+  CardFooter,
   CardTitle,
+  Grid,
+  Stack,
+  StackItem,
   Title,
   Toolbar,
   ToolbarContent,
@@ -23,12 +27,16 @@ import {
 import InventoryAddHosts from './InventoryAddHost';
 import { onFetchEvents } from '../fetching/fetchEvents';
 import { HostsService } from '../../services';
+import ClusterDetailStatusVarieties, {
+  useClusterStatusVarieties,
+} from '../clusterDetail/ClusterDetailStatusVarieties';
 
 const { addAlert } = alertsSlice.actions;
 
 const AddHosts: React.FC = () => {
   const { cluster, resetCluster } = React.useContext(AddHostsContext);
   const [isSubmitting, setSubmitting] = React.useState(false);
+  const clusterVarieties = useClusterStatusVarieties(cluster);
 
   if (!cluster || !resetCluster) {
     return null;
@@ -62,7 +70,22 @@ const AddHosts: React.FC = () => {
           </Title>
         </CardTitle>
         <CardBody>
-          <InventoryAddHosts />
+          <Stack hasGutter>
+            <StackItem>
+              <Grid hasGutter>
+                <ClusterDetailStatusVarieties
+                  cluster={cluster}
+                  clusterVarieties={clusterVarieties}
+                />
+              </Grid>
+            </StackItem>
+            <StackItem>
+              <InventoryAddHosts />
+            </StackItem>
+          </Stack>
+        </CardBody>
+
+        <CardFooter>
           <Alerts />
           <Toolbar id="cluster-toolbar">
             <ToolbarContent>
@@ -89,7 +112,7 @@ const AddHosts: React.FC = () => {
               </ToolbarSecondaryGroup>
             </ToolbarContent>
           </Toolbar>
-        </CardBody>
+        </CardFooter>
       </Card>
       <DiscoveryImageModal />
     </ModalDialogsContextProvider>

--- a/src/ocm/components/clusterDetail/ClusterDetail.tsx
+++ b/src/ocm/components/clusterDetail/ClusterDetail.tsx
@@ -17,6 +17,7 @@ import {
   useAlerts,
   getEnabledHosts,
   getOlmOperators,
+  isSNO,
 } from '../../../common';
 import { Cluster } from '../../../common/api/types';
 import ClusterHostsTable from '../hosts/ClusterHostsTable';
@@ -35,6 +36,9 @@ import ClusterProgressItems from '../../../common/components/clusterDetail/Clust
 import { EventsModalButton } from '../../../common/components/ui/eventsModal';
 import { onFetchEvents } from '../fetching/fetchEvents';
 import { getClusterProgressAlerts } from './getProgressBarAlerts';
+import { ClustersAPI } from '../../services/apis';
+import { updateCluster } from '../../reducers/clusters';
+import { handleApiError, ocmClient } from '../../api';
 
 type ClusterDetailProps = {
   cluster: Cluster;
@@ -46,6 +50,7 @@ const ClusterDetail: React.FC<ClusterDetailProps> = ({ cluster }) => {
   const clusterVarieties = useClusterStatusVarieties(cluster);
   const { credentials, credentialsError } = clusterVarieties;
   const { monitoredOperators = [] } = cluster;
+  const canAddHosts = !ocmClient && !isSNO(cluster) && cluster.status === 'installed';
 
   return (
     <Stack hasGutter>
@@ -114,6 +119,25 @@ const ClusterDetail: React.FC<ClusterDetailProps> = ({ cluster }) => {
               consoleUrl={credentials?.consoleUrl}
               id={getClusterDetailId('button-launch-console')}
             />
+          )}
+          {canAddHosts && (
+            <ToolbarButton
+              variant={ButtonVariant.primary}
+              component={(props) => (
+                <Link to={`${routeBasePath}/clusters/${cluster.id}`} {...props} />
+              )}
+              id={getClusterDetailId('button-add-hosts')}
+              onClick={async () => {
+                try {
+                  const { data } = await ClustersAPI.allowAddHosts(cluster.id);
+                  updateCluster(data);
+                } catch (e) {
+                  handleApiError(e);
+                }
+              }}
+            >
+              Add hosts
+            </ToolbarButton>
           )}
           {!isSingleClusterMode() && (
             <ToolbarButton

--- a/src/ocm/components/clusterDetail/ClusterDetail.tsx
+++ b/src/ocm/components/clusterDetail/ClusterDetail.tsx
@@ -50,7 +50,7 @@ const ClusterDetail: React.FC<ClusterDetailProps> = ({ cluster }) => {
   const clusterVarieties = useClusterStatusVarieties(cluster);
   const { credentials, credentialsError } = clusterVarieties;
   const { monitoredOperators = [] } = cluster;
-  const canAddHosts = !ocmClient && !isSNO(cluster) && cluster.status === 'installed';
+  const canAddHosts = !isSNO(cluster) && cluster.status === 'installed' && !ocmClient;
 
   return (
     <Stack hasGutter>

--- a/src/ocm/components/clusterDetail/ClusterDetailStatusVarieties.tsx
+++ b/src/ocm/components/clusterDetail/ClusterDetailStatusVarieties.tsx
@@ -21,20 +21,23 @@ type ClusterStatusVarieties = {
   fetchCredentials: () => void;
 };
 
-export const useClusterStatusVarieties = (cluster: Cluster): ClusterStatusVarieties => {
+export const useClusterStatusVarieties = (cluster?: Cluster): ClusterStatusVarieties => {
   const [credentials, setCredentials] = React.useState<Credentials>();
   const [credentialsError, setCredentialsError] = React.useState();
 
-  const olmOperators = getOlmOperators(cluster.monitoredOperators);
+  const olmOperators = getOlmOperators(cluster?.monitoredOperators);
   const failedOlmOperators = olmOperators.filter((o) => o.status === 'failed');
   const consoleOperator = React.useMemo(
-    () => cluster.monitoredOperators?.find((o) => o.name === 'console'),
-    [cluster.monitoredOperators],
+    () => cluster?.monitoredOperators?.find((o) => o.name === 'console'),
+    [cluster],
   );
 
   const fetchCredentials = React.useCallback(() => {
     const fetch = async () => {
       setCredentialsError(undefined);
+      if (!cluster) {
+        return;
+      }
       try {
         const response = await ClustersAPI.getCredentials(cluster.id);
         setCredentials(response.data);
@@ -43,17 +46,17 @@ export const useClusterStatusVarieties = (cluster: Cluster): ClusterStatusVariet
       }
     };
     fetch();
-  }, [cluster.id]);
+  }, [cluster]);
 
   const consoleOperatorStatus = consoleOperator?.status;
   React.useEffect(() => {
     if (
-      (!consoleOperatorStatus && cluster.status === 'installed') || // Retain backwards compatibility with clusters which don't have monitored clusters
+      (!consoleOperatorStatus && cluster?.status === 'installed') || // Retain backwards compatibility with clusters which don't have monitored clusters
       consoleOperatorStatus === 'available'
     ) {
       fetchCredentials();
     }
-  }, [cluster.status, consoleOperatorStatus, fetchCredentials]);
+  }, [cluster, consoleOperatorStatus, fetchCredentials]);
 
   return {
     credentials,

--- a/src/ocm/components/clusterDetail/ClusterDetailStatusVarieties.tsx
+++ b/src/ocm/components/clusterDetail/ClusterDetailStatusVarieties.tsx
@@ -25,38 +25,42 @@ export const useClusterStatusVarieties = (cluster?: Cluster): ClusterStatusVarie
   const [credentials, setCredentials] = React.useState<Credentials>();
   const [credentialsError, setCredentialsError] = React.useState();
 
+  const clusterId = cluster?.id;
+  const clusterStatus = cluster?.status;
+  const clusterMonitoredOperators = cluster?.monitoredOperators;
+
   const olmOperators = getOlmOperators(cluster?.monitoredOperators);
   const failedOlmOperators = olmOperators.filter((o) => o.status === 'failed');
   const consoleOperator = React.useMemo(
-    () => cluster?.monitoredOperators?.find((o) => o.name === 'console'),
-    [cluster],
+    () => clusterMonitoredOperators?.find((o) => o.name === 'console'),
+    [clusterMonitoredOperators],
   );
 
   const fetchCredentials = React.useCallback(() => {
     const fetch = async () => {
       setCredentialsError(undefined);
-      if (!cluster) {
+      if (!clusterId) {
         return;
       }
       try {
-        const response = await ClustersAPI.getCredentials(cluster.id);
+        const response = await ClustersAPI.getCredentials(clusterId);
         setCredentials(response.data);
       } catch (err) {
         setCredentialsError(err);
       }
     };
     fetch();
-  }, [cluster]);
+  }, [clusterId]);
 
   const consoleOperatorStatus = consoleOperator?.status;
   React.useEffect(() => {
     if (
-      (!consoleOperatorStatus && cluster?.status === 'installed') || // Retain backwards compatibility with clusters which don't have monitored clusters
+      (!consoleOperatorStatus && clusterStatus === 'installed') || // Retain backwards compatibility with clusters which don't have monitored clusters
       consoleOperatorStatus === 'available'
     ) {
       fetchCredentials();
     }
-  }, [cluster, consoleOperatorStatus, fetchCredentials]);
+  }, [clusterStatus, consoleOperatorStatus, fetchCredentials]);
 
   return {
     credentials,

--- a/src/ocm/components/clusters/ClusterPage.tsx
+++ b/src/ocm/components/clusters/ClusterPage.tsx
@@ -32,6 +32,7 @@ import { FeatureSupportLevelProvider } from '../featureSupportLevels';
 import ClusterWizardContextProvider from '../clusterWizard/ClusterWizardContextProvider';
 import useInfraEnv from '../../hooks/useInfraEnv';
 import { SentryErrorMonitorContextProvider } from '../SentryErrorMonitorContextProvider';
+import { forceReload } from '../../reducers/clusters';
 
 type MatchParams = {
   clusterId: string;
@@ -62,7 +63,7 @@ const ClusterPage: React.FC<RouteComponentProps<MatchParams>> = ({ match }) => {
   const getContent = (cluster: Cluster, infraEnv: InfraEnv) => {
     if (cluster.status === 'adding-hosts') {
       return (
-        <AddHostsContextProvider cluster={cluster}>
+        <AddHostsContextProvider cluster={cluster} resetCluster={forceReload}>
           <AddHosts />
         </AddHostsContextProvider>
       );

--- a/src/ocm/reducers/clusters/clustersSlice.ts
+++ b/src/ocm/reducers/clusters/clustersSlice.ts
@@ -3,13 +3,15 @@ import { Cluster } from '../../../common';
 import { handleApiError } from '../../api/utils';
 import { ResourceUIState } from '../../../common';
 import { ClustersAPI } from '../../services/apis';
+import { ocmClient } from '../../api';
 
 export const fetchClustersAsync = createAsyncThunk<Cluster[] | void>(
   'clusters/fetchClustersAsync',
   async () => {
     try {
       const { data } = await ClustersAPI.list();
-      return data.filter((cluster) => cluster.kind === 'Cluster');
+      const isOcm = !!ocmClient;
+      return data.filter((cluster) => (isOcm ? cluster.kind === 'Cluster' : true));
     } catch (e) {
       handleApiError(e, () => Promise.reject('Failed to fetch clusters.'));
     }

--- a/src/ocm/services/apis/ClustersAPI.ts
+++ b/src/ocm/services/apis/ClustersAPI.ts
@@ -156,6 +156,12 @@ const ClustersAPI = {
     );
   },
 
+  addHosts(clusterId: Cluster['id']) {
+    return client.post<Cluster, AxiosResponse<Cluster>, never>(
+      `${ClustersAPI.makeActionsBaseURI(clusterId)}/allow-add-workers`,
+    );
+  },
+
   downloadLogs(clusterId: Cluster['id'], hostId?: Host['id']) {
     const queryParams = `logs_type=${!hostId ? 'all' : `host&host_id=${hostId}`}`;
     return client.get<Blob>(`${ClustersAPI.makeLogsBaseURI(clusterId)}?${queryParams}`, {

--- a/src/ocm/services/apis/ClustersAPI.ts
+++ b/src/ocm/services/apis/ClustersAPI.ts
@@ -156,7 +156,7 @@ const ClustersAPI = {
     );
   },
 
-  addHosts(clusterId: Cluster['id']) {
+  allowAddHosts(clusterId: Cluster['id']) {
     return client.post<Cluster, AxiosResponse<Cluster>, never>(
       `${ClustersAPI.makeActionsBaseURI(clusterId)}/allow-add-workers`,
     );


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-9454

**Installation page**:
- Added "Add hosts" button that transforms the cluster to AddHosts kind. (Only visible if cluster is multinode, installed and environment is in on-prem.)

![Screenshot from 2022-05-03 13-29-08](https://user-images.githubusercontent.com/87187179/166451655-f5af6f18-deaf-425d-a027-d433016abeee.png)
![Screenshot from 2022-05-03 13-40-13](https://user-images.githubusercontent.com/87187179/166451642-aa921e94-3b0d-45f9-8d8b-d2ecbaff565f.png)

**Add hosts page**:
- Shows the same console information like the Installation page.
- Shows all hosts in the cluster (including the day1 hosts)
- Allows to download ISO and install ready hosts

![Screenshot from 2022-05-03 13-58-44](https://user-images.githubusercontent.com/87187179/166451648-2b2e75cc-78cb-45c4-a47e-fe6365f7da41.png)
![Screenshot from 2022-05-03 13-55-59](https://user-images.githubusercontent.com/87187179/166451649-ff392038-f217-4073-abb5-60b490b89f5d.png)

---

Note: I couldn't successfully install a day2 host because of failing validations.