### PR TITLE
MGMT-9477: Link to day2 cluster is irrelevant for non cloud AI

### DIFF
--- a/src/ocm/components/clusterDetail/ClusterDetailStatusMessages.tsx
+++ b/src/ocm/components/clusterDetail/ClusterDetailStatusMessages.tsx
@@ -14,15 +14,22 @@ import { VSPHERE_CONFIG_LINK } from '../../../common/config/constants';
 import { isSNO } from '../../../common/selectors/clusterSelectors';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { calculateClusterDateDiff } from '../../../common/sevices/DateAndTime';
+import { isSingleClusterMode } from '../../config';
 
 type ClusterDetailStatusMessagesProps = {
   cluster: Cluster;
+  showAddHostsInfo?: boolean;
 };
 
-const ClusterDetailStatusMessages: React.FC<ClusterDetailStatusMessagesProps> = ({ cluster }) => {
+const ClusterDetailStatusMessages: React.FC<ClusterDetailStatusMessagesProps> = ({
+  cluster,
+  showAddHostsInfo = true,
+}) => {
   const { inactiveDeletionHours } = useDefaultConfiguration(['inactiveDeletionHours']);
   const inactiveDeletionDays = Math.round((inactiveDeletionHours || 0) / 24);
   const dateDifference = calculateClusterDateDiff(inactiveDeletionDays, cluster.installCompletedAt);
+  const showAddHostsAlert =
+    showAddHostsInfo && !isSingleClusterMode() && cluster.status === 'installed' && !isSNO(cluster);
 
   return (
     <>
@@ -51,7 +58,7 @@ const ClusterDetailStatusMessages: React.FC<ClusterDetailStatusMessagesProps> = 
           }
         />
       </RenderIf>
-      <RenderIf condition={cluster.status === 'installed' && !isSNO(cluster)}>
+      <RenderIf condition={showAddHostsAlert}>
         <Alert
           variant="info"
           isInline

--- a/src/ocm/components/clusterDetail/ClusterDetailStatusVarieties.tsx
+++ b/src/ocm/components/clusterDetail/ClusterDetailStatusVarieties.tsx
@@ -68,7 +68,8 @@ export const useClusterStatusVarieties = (cluster: Cluster): ClusterStatusVariet
 const ClusterDetailStatusVarieties: React.FC<{
   cluster: Cluster;
   clusterVarieties: ClusterStatusVarieties;
-}> = ({ cluster, clusterVarieties }) => {
+  showAddHostsInfo?: boolean;
+}> = ({ cluster, clusterVarieties, showAddHostsInfo = true }) => {
   const { credentials, credentialsError, consoleOperator, fetchCredentials } = clusterVarieties;
 
   const showClusterCredentials =
@@ -85,7 +86,7 @@ const ClusterDetailStatusVarieties: React.FC<{
           idPrefix={getClusterDetailId('cluster-creds')}
         />
       )}
-      <ClusterDetailStatusMessages cluster={cluster} />
+      <ClusterDetailStatusMessages cluster={cluster} showAddHostsInfo={showAddHostsInfo} />
     </>
   );
 };

--- a/src/ocm/components/clusterDetail/ClusterInstallationProgressCard.tsx
+++ b/src/ocm/components/clusterDetail/ClusterInstallationProgressCard.tsx
@@ -51,7 +51,11 @@ const ClusterInstallationProgressCard: React.FC<{ cluster: Cluster }> = ({ clust
       <CardExpandableContent>
         <CardBody>
           <Grid hasGutter>
-            <ClusterDetailStatusVarieties cluster={cluster} clusterVarieties={clusterVarieties} />
+            <ClusterDetailStatusVarieties
+              cluster={cluster}
+              clusterVarieties={clusterVarieties}
+              showAddHostsInfo={false}
+            />
             <GridItem>
               <ClusterHostsTable cluster={cluster} skipDisabled />
             </GridItem>


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-9477

Removed from Cluster detail card in OCM:
![image](https://user-images.githubusercontent.com/87187179/166457639-c5a4ab5d-68e9-4298-82a4-f825570b4990.png)

Still showing when viewed through assisted installer (unless it's on-prem single cluster mode):
![image](https://user-images.githubusercontent.com/87187179/166457726-931be84c-ae7f-429f-a23e-7da2dd7d4a97.png)
