### PR TITLE
MGMT-8946: UI switches must display the variant containing the "V" mark

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,12 +52,12 @@
     "postswagger": "sed -i -r 's/([a-z1-9]+)_([a-z])/\\1\\U\\2/g' src/common/api/types.ts && yarn prettier"
   },
   "peerDependencies": {
-    "@patternfly/react-code-editor": "^4.2.92",
-    "@patternfly/react-core": "^4.135.0",
-    "@patternfly/react-icons": "^4.11.0",
-    "@patternfly/react-styles": "^4.12.5",
-    "@patternfly/react-table": "^4.29.0",
-    "@patternfly/react-tokens": "^4.12.0",
+    "@patternfly/react-code-editor": "^4.47.2",
+    "@patternfly/react-core": "^4.206.2",
+    "@patternfly/react-icons": "^4.57.2",
+    "@patternfly/react-styles": "^4.56.2",
+    "@patternfly/react-table": "^4.75.2",
+    "@patternfly/react-tokens": "^4.58.2",
     "@reduxjs/toolkit": "^1.5",
     "@sentry/browser": "^5.9 || ^6.0",
     "axios": ">=0.19.2 <1.0.0",

--- a/src/common/components/ui/formik/SwitchField.tsx
+++ b/src/common/components/ui/formik/SwitchField.tsx
@@ -29,6 +29,7 @@ const SwitchField: React.FC<SwitchFieldProps> = ({
     label: label,
     isDisabled: props.isDisabled,
     isChecked: field.value,
+    hasCheckIcon: true,
     onChange: (checked: boolean, event: React.FormEvent<HTMLInputElement>) => {
       if (onChangeCustomOverride) {
         onChangeCustomOverride(checked, event);


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-8946

The most recent update of PatternFly added the option to have both a label and a checkmark in the switch component. The checkmarks are now set to appear globally in AI.

![image](https://user-images.githubusercontent.com/87187179/166462591-e20c8c90-a299-4e76-b2fb-5691abca95d3.png)
