### PR TITLE
MGMT-9892: Change copy in CNV popover from "supervisors" to "control-plane node"

### DIFF
--- a/src/ocm/components/hosts/HostRequirementsContent.tsx
+++ b/src/ocm/components/hosts/HostRequirementsContent.tsx
@@ -160,7 +160,7 @@ export const CNVHostRequirementsContent: PreflightHWRequirementsContentComponent
           </ListItem>
         </RenderIf>
         <ListItem>
-          Each supervisor node requires an additional {masterRequirements?.ramMib || 150} MiB of
+          Each control plane node requires an additional {masterRequirements?.ramMib || 150} MiB of
           memory {masterRequirements?.diskSizeGb ? ',' : ' and'} {masterRequirements?.cpuCores || 4}{' '}
           CPUs
           {masterRequirements?.diskSizeGb


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-9892

Before:
![image](https://user-images.githubusercontent.com/87187179/167598210-de5a20bf-f7c8-427d-bb71-4b3b3ef32b35.png)


After:
![image](https://user-images.githubusercontent.com/87187179/167597950-e6d42bb5-083b-431e-b323-ea8e2d28036a.png)
