### PR TITLE
MGMT-10402 Show media-connected warning in Discovery step

### DIFF
--- a/src/ocm/components/clusterWizard/wizardTransition.ts
+++ b/src/ocm/components/clusterWizard/wizardTransition.ts
@@ -54,6 +54,7 @@ const hostDiscoveryStepValidationsMap: WizardStepValidationMap = {
     groups: ['hardware'],
     validationIds: [
       'connected',
+      'media-connected',
       'odf-requirements-satisfied',
       'lso-requirements-satisfied',
       'cnv-requirements-satisfied',


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-10402

The hosts validationInfo of type `media-connected` was not being displayed in the Host Discovery phase. For the next steps, the message was being shown because they show all failed validations.

After the fix:
![media-connected-ok](https://user-images.githubusercontent.com/829045/168754988-0cc036a9-0a0c-4bf0-b432-cccc0cd0c115.png)
.