### PR TITLE
NO_ISSUE: Fix build scripts to correctly emit types

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,10 @@
   "scripts": {
     "clean": "rimraf dist",
     "prebuild": "run-s clean test",
-    "build": "node ./scripts/esbuild/prod.js",
-    "start": "yarn clean && node ./scripts/esbuild/dev.js",
+    "esbuild:prod": "node ./scripts/esbuild/prod.js",
+    "esbuild:dev": "node ./scripts/esbuild/dev.js",
+    "build": "run-s clean esbuild:prod",
+    "start": "run-s clean esbuild:dev",
     "sync-dist": "./scripts/sync-dist.sh",
     "prepare": "install-peers",
     "test": "run-s test:circular lint format:check",


### PR DESCRIPTION
Before:
```
# rm -rf dist 
# ls dist
ls: cannot access 'dist': No such file or directory
# yarn start 
$ yarn clean && node ./scripts/esbuild/dev.js
$ rimraf dist
Build succeeded and started watching { errors: [], warnings: [], stop: [Function: stop] }
Package content has not changed, skipping publishing.
^C
# ls dist                                                                                                                                                                                                         cim  index.css  index.css.map  index.js  index.js.map  ocm
```
You can see that the `src` directory with emitted types is not included

After:
```
# yarn start
$ run-s clean esbuild:dev
$ rimraf dist
$ node ./scripts/esbuild/dev.js
Build succeeded and started watching { errors: [], warnings: [], stop: [Function: stop] }
openshift-assisted-ui-lib@2.4.0 published in store.
Pushing openshift-assisted-ui-lib@2.4.0 in /root/assisted-ui
Package openshift-assisted-ui-lib@2.4.0 linked ==> /root/assisted-ui/node_modules/openshift-assisted-ui-lib
Pushing openshift-assisted-ui-lib@2.4.0 in /root/open-cluster-management-console/frontend
Package openshift-assisted-ui-lib@2.4.0 linked ==> /root/open-cluster-management-console/frontend/node_modules/openshift-assisted-ui-lib
^C
# ls dist
cim  index.css  index.css.map  index.js  index.js.map  ocm  src
```
The `src` directory is included