### PR TITLE
MGMT-10392 Do not patch if no changes happened

### DIFF
--- a/src/common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionControlGroup.tsx
+++ b/src/common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionControlGroup.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import isEqual from 'lodash/isEqual';
 import { Stack, StackItem } from '@patternfly/react-core';
 import SwitchField from '../../ui/formik/SwitchField';
 import { DiskEncryptionMode } from './DiskEncryptionMode';
@@ -6,6 +7,19 @@ import { RenderIf } from '../../ui';
 import { DiskEncryptionValues } from './DiskEncryptionValues';
 import { useFormikContext } from 'formik';
 import { ClusterDetailsValues } from '../../clusterWizard/types';
+
+const hasFilledTangServers = (tangServers: any[]): boolean => {
+  const emptyServer = [
+    {
+      url: '',
+      thumbprint: '',
+    },
+  ];
+  if (!tangServers || tangServers.length === 0) {
+    return false;
+  }
+  return tangServers.every((server) => !isEqual(server, emptyServer) && !isEqual(server, {}));
+};
 
 export interface DiskEncryptionControlGroupProps {
   values: DiskEncryptionValues;
@@ -18,20 +32,30 @@ const DiskEncryptionControlGroup: React.FC<DiskEncryptionControlGroupProps> = ({
   isSNO = false,
   isDisabled,
 }) => {
-  const { enableDiskEncryptionOnMasters, enableDiskEncryptionOnWorkers, diskEncryptionMode } =
-    values;
+  const {
+    enableDiskEncryptionOnMasters,
+    enableDiskEncryptionOnWorkers,
+    diskEncryptionMode,
+    diskEncryptionTangServers,
+  } = values;
 
   const { setFieldValue, setFieldTouched } = useFormikContext<ClusterDetailsValues>();
 
   React.useEffect(() => {
     if (!enableDiskEncryptionOnWorkers && !enableDiskEncryptionOnMasters) {
-      setFieldValue('diskEncryptionMode', 'tpmv2');
-      setFieldTouched('diskEncryptionTangServers', false, false);
-      setFieldValue('diskEncryptionTangServers', [{}], false);
+      if (diskEncryptionMode !== 'tpmv2') {
+        setFieldValue('diskEncryptionMode', 'tpmv2');
+      }
+      if (hasFilledTangServers(diskEncryptionTangServers)) {
+        setFieldTouched('diskEncryptionTangServers', false, false);
+        setFieldValue('diskEncryptionTangServers', [{}], false);
+      }
     }
   }, [
     enableDiskEncryptionOnMasters,
     enableDiskEncryptionOnWorkers,
+    diskEncryptionMode,
+    diskEncryptionTangServers,
     setFieldTouched,
     setFieldValue,
   ]);

--- a/src/common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionControlGroup.tsx
+++ b/src/common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionControlGroup.tsx
@@ -4,21 +4,26 @@ import { Stack, StackItem } from '@patternfly/react-core';
 import SwitchField from '../../ui/formik/SwitchField';
 import { DiskEncryptionMode } from './DiskEncryptionMode';
 import { RenderIf } from '../../ui';
-import { DiskEncryptionValues } from './DiskEncryptionValues';
+import { DiskEncryptionValues, TangServer } from './DiskEncryptionValues';
 import { useFormikContext } from 'formik';
 import { ClusterDetailsValues } from '../../clusterWizard/types';
 
-const hasFilledTangServers = (tangServers: any[]): boolean => {
+const hasFilledTangServers = (tangServers: TangServer[]): boolean => {
+  if (!tangServers || tangServers.length === 0) {
+    return false;
+  }
+
   const emptyServer = [
     {
       url: '',
       thumbprint: '',
     },
   ];
-  if (!tangServers || tangServers.length === 0) {
-    return false;
-  }
-  return tangServers.every((server) => !isEqual(server, emptyServer) && !isEqual(server, {}));
+  return (
+    tangServers.find(
+      (server: typeof tangServers[number]) => !isEqual(server, emptyServer) && !isEqual(server, {}),
+    ) !== undefined
+  );
 };
 
 export interface DiskEncryptionControlGroupProps {

--- a/src/common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionValues.ts
+++ b/src/common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionValues.ts
@@ -4,4 +4,5 @@ export interface DiskEncryptionValues {
   enableDiskEncryptionOnMasters: boolean;
   enableDiskEncryptionOnWorkers: boolean;
   diskEncryptionMode: DiskEncryption['mode'];
+  diskEncryptionTangServers: any;
 }

--- a/src/common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionValues.ts
+++ b/src/common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionValues.ts
@@ -1,8 +1,13 @@
 import { DiskEncryption } from '../../../api';
 
+export type TangServer = {
+  url: string;
+  thumbprint: string;
+};
+
 export interface DiskEncryptionValues {
   enableDiskEncryptionOnMasters: boolean;
   enableDiskEncryptionOnWorkers: boolean;
   diskEncryptionMode: DiskEncryption['mode'];
-  diskEncryptionTangServers: any;
+  diskEncryptionTangServers: TangServer[];
 }

--- a/src/common/components/clusterWizard/clusterDetailsValidation.ts
+++ b/src/common/components/clusterWizard/clusterDetailsValidation.ts
@@ -1,6 +1,7 @@
 import * as Yup from 'yup';
 import { Cluster, ManagedDomain } from '../../api';
 import { OpenshiftVersionOptionType } from '../../types';
+import { TangServer } from '../clusterConfiguration/DiskEncryptionFields/DiskEncryptionValues';
 import { FeatureSupportLevelData } from '../featureSupportLevels';
 import {
   dnsNameValidationSchema,
@@ -10,7 +11,7 @@ import {
 } from '../ui';
 import { ClusterDetailsValues } from './types';
 
-const emptyTangServers = () => {
+const emptyTangServers = (): TangServer[] => {
   return [
     {
       url: '',
@@ -19,7 +20,7 @@ const emptyTangServers = () => {
   ];
 };
 
-const parseTangServers = (tangServersString?: string) => {
+export const parseTangServers = (tangServersString?: string): TangServer[] => {
   if (!tangServersString) {
     return emptyTangServers();
   }

--- a/src/common/components/clusterWizard/types.ts
+++ b/src/common/components/clusterWizard/types.ts
@@ -8,6 +8,7 @@ import {
   ValidationGroup as HostValidationGroup,
   Validation as HostValidation,
 } from '../../types/hosts';
+import { TangServer } from '../clusterConfiguration/DiskEncryptionFields/DiskEncryptionValues';
 import { WizardStepsValidationMap } from './validationsInfoUtils';
 
 export type ClusterDetailsValues = {
@@ -21,7 +22,7 @@ export type ClusterDetailsValues = {
   enableDiskEncryptionOnMasters: boolean;
   enableDiskEncryptionOnWorkers: boolean;
   diskEncryptionMode: DiskEncryption['mode'];
-  diskEncryptionTangServers: { url: string; thumbprint: string }[];
+  diskEncryptionTangServers: TangServer[];
   diskEncryption: DiskEncryption;
 };
 

--- a/src/ocm/components/clusterWizard/ClusterDetailsForm.tsx
+++ b/src/ocm/components/clusterWizard/ClusterDetailsForm.tsx
@@ -70,12 +70,10 @@ const ClusterDetailsForm: React.FC<ClusterDetailsFormProps> = (props) => {
     submitForm: FormikHelpers<unknown>['submitForm'],
     cluster?: Cluster,
   ): (() => Promise<void> | void) => {
-    let fn: () => Promise<void> | void = submitForm;
     if (!dirty && !isUndefined(cluster) && canNextClusterDetails({ cluster })) {
-      fn = moveNext;
+      return moveNext;
     }
-
-    return fn;
+    return submitForm;
   };
 
   const initialValues = React.useMemo(


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-10392

The issue is happening because when the form mounts, it runs the effect where I made the changes was setting the  `touched` value for field `diskEncryptionTangServers`.

I have assumed that the empty object  is the same as {url: '', thumbprint: ''} so if the value is either of those, we are not updating the cluster to avoid the dirty form.