### PR TITLE
MGMT-10226 Show ignition-downloadable message

### DIFF
--- a/src/ocm/components/clusterWizard/wizardTransition.ts
+++ b/src/ocm/components/clusterWizard/wizardTransition.ts
@@ -83,6 +83,7 @@ const hostDiscoveryStepValidationsMap: WizardStepValidationMap = {
     validationIds: [
       'connected',
       'media-connected',
+      'ignition-downloadable',
       'odf-requirements-satisfied',
       'lso-requirements-satisfied',
       'cnv-requirements-satisfied',

--- a/src/ocm/components/hosts/HardwareStatus.tsx
+++ b/src/ocm/components/hosts/HardwareStatus.tsx
@@ -10,6 +10,7 @@ import {
 import { ValidationsInfo } from '../../../common/types/hosts';
 import { wizardStepsValidationsMap } from '../clusterWizard/wizardTransition';
 import { AdditionalNTPSourcesDialogToggle } from './AdditionaNTPSourceDialogToggle';
+import { UpdateDay2ApiVipDialogToggle } from './UpdateDay2ApiVipDialogToggle';
 
 type HardwareStatusProps = {
   host: Host;
@@ -43,6 +44,7 @@ const HardwareStatus: React.FC<HardwareStatusProps> = (props) => {
       status={status}
       validationsInfo={validationsInfo}
       AdditionalNTPSourcesDialogToggleComponent={AdditionalNTPSourcesDialogToggle}
+      UpdateDay2ApiVipDialogToggleComponent={UpdateDay2ApiVipDialogToggle}
     />
   );
 };


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-10226

There were 2 reasons why it wasn't showing:
- The new signal "ignition-downloable" was not listed in the Host discovery step.
- The host status in Host Discovery did not have the needed component.


I simulated it with the e2e, as unfortunately I don't have a Day 2 cluster with the issue.
![ignition-downloadable-message](https://user-images.githubusercontent.com/829045/169331583-e4799584-ebfd-4710-aeec-3f8402b6f171.png)

