### PR TITLE
MGMT-10453: Console URL appear only when installation complete

### DIFF
--- a/src/common/components/clusterDetail/ClusterCredentials.tsx
+++ b/src/common/components/clusterDetail/ClusterCredentials.tsx
@@ -1,9 +1,16 @@
 import React from 'react';
-import { GridItem, ClipboardCopy, clipboardCopyFunc, StackItem } from '@patternfly/react-core';
+import {
+  GridItem,
+  ClipboardCopy,
+  clipboardCopyFunc,
+  StackItem,
+  Button,
+} from '@patternfly/react-core';
 import { Credentials, Cluster } from '../../api/types';
 import { LoadingState, ErrorState } from '../../components/ui/uiState';
 import { DetailList, DetailItem } from '../../components/ui/DetailList';
 import { TroubleshootingOpenshiftConsoleButton } from './ConsoleModal';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 type ClusterCredentialsProps = {
   cluster: Cluster;
@@ -31,15 +38,30 @@ const ClusterCredentials: React.FC<ClusterCredentialsProps> = ({
     credentialsBody = (
       <DetailList>
         {credentials.consoleUrl && (
-          <StackItem>
-            <TroubleshootingOpenshiftConsoleButton
-              consoleUrl={credentials.consoleUrl}
-              cluster={cluster}
-              idPrefix={idPrefix}
-            />
-          </StackItem>
+          <DetailItem
+            title="Web Console URL"
+            value={
+              <>
+                <Button
+                  variant="link"
+                  icon={<ExternalLinkAltIcon />}
+                  iconPosition="right"
+                  isInline
+                  onClick={() => window.open(credentials.consoleUrl, '_blank', 'noopener')}
+                  data-testid={`${idPrefix}-link-console-url`}
+                >
+                  {credentials.consoleUrl}
+                </Button>
+                <br />
+                <TroubleshootingOpenshiftConsoleButton
+                  consoleUrl={credentials.consoleUrl}
+                  cluster={cluster}
+                  idPrefix={idPrefix}
+                />
+              </>
+            }
+          />
         )}
-        &nbsp;
         {credentials.username && (
           <>
             <DetailItem title="Username" value={credentials.username} />

--- a/src/ocm/components/clusterDetail/ProgressBarAlerts.tsx
+++ b/src/ocm/components/clusterDetail/ProgressBarAlerts.tsx
@@ -155,30 +155,11 @@ export const HostsInstallationFailed: React.FC<installationProgressWarningProps>
   );
 };
 
-export const HostsInstallationSuccess: React.FC<successInstallationProps> = ({ consoleUrl }) => {
+export const HostsInstallationSuccess: React.FC<successInstallationProps> = () => {
   return (
     <>
       &nbsp;
-      <Alert
-        isInline
-        variant="success"
-        title={'Installation completed successfully'}
-        actionLinks={
-          <>
-            <RenderIf condition={typeof consoleUrl !== undefined}>
-              <AlertActionLink
-                id="cluster-installation-logs-button"
-                onClick={() => window.open(consoleUrl, '_blank', 'noopener')}
-              >
-                Open web console
-              </AlertActionLink>
-            </RenderIf>
-            <AlertActionLink id="cluster-installation-feedback-button">
-              Send feedback
-            </AlertActionLink>
-          </>
-        }
-      >
+      <Alert isInline variant="success" title={'Installation completed successfully'}>
         {' '}
       </Alert>
     </>

--- a/src/ocm/components/clusterDetail/getProgressBarAlerts.tsx
+++ b/src/ocm/components/clusterDetail/getProgressBarAlerts.tsx
@@ -46,7 +46,7 @@ export const getClusterProgressAlerts = (
     return (
       <Stack>
         <RenderIf condition={cluster.status === 'installed'}>
-          <HostsInstallationSuccess consoleUrl={consoleUrl} />
+          <HostsInstallationSuccess />
         </RenderIf>
         <RenderIf condition={failedWorkers > 0}>
           <StackItem>


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-10453

**Part of:** https://github.com/openshift-assisted/assisted-ui-lib/pull/1397

The changes here:

Whenever the web console URL is available, we'll show it (together with the troubleshooter and the U/P)
In the success notification, we won't show any actions for now (we'll change it once the Pendo feedback form is available)

![image](https://user-images.githubusercontent.com/69599321/170028028-cff00e1e-5e2b-4d42-9f45-f8b596f23ab2.png)
