### PR TITLE
Resets the version field to 0.0.0 in master

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openshift-assisted-ui-lib",
-  "version": "2.4.0",
+  "version": "0.0.0",
   "description": "React component library for the Bare Metal Installer",
   "license": "Apache-2.0",
   "repository": "openshift-assisted/assisted-ui-lib",


### PR DESCRIPTION
The reason behind this is that the version field is only useful for releases and therefore it must be bumped only in the release branch.
