### PR TITLE
Revert "MGMT-10226 Show ignition-downloadable message (#1391)"

### DIFF
--- a/src/ocm/components/clusterWizard/wizardTransition.ts
+++ b/src/ocm/components/clusterWizard/wizardTransition.ts
@@ -83,7 +83,6 @@ const hostDiscoveryStepValidationsMap: WizardStepValidationMap = {
     validationIds: [
       'connected',
       'media-connected',
-      'ignition-downloadable',
       'odf-requirements-satisfied',
       'lso-requirements-satisfied',
       'cnv-requirements-satisfied',

--- a/src/ocm/components/hosts/HardwareStatus.tsx
+++ b/src/ocm/components/hosts/HardwareStatus.tsx
@@ -10,7 +10,6 @@ import {
 import { ValidationsInfo } from '../../../common/types/hosts';
 import { wizardStepsValidationsMap } from '../clusterWizard/wizardTransition';
 import { AdditionalNTPSourcesDialogToggle } from './AdditionaNTPSourceDialogToggle';
-import { UpdateDay2ApiVipDialogToggle } from './UpdateDay2ApiVipDialogToggle';
 
 type HardwareStatusProps = {
   host: Host;
@@ -44,7 +43,6 @@ const HardwareStatus: React.FC<HardwareStatusProps> = (props) => {
       status={status}
       validationsInfo={validationsInfo}
       AdditionalNTPSourcesDialogToggleComponent={AdditionalNTPSourcesDialogToggle}
-      UpdateDay2ApiVipDialogToggleComponent={UpdateDay2ApiVipDialogToggle}
     />
   );
 };


### PR DESCRIPTION
The 'ignition-downloadable' validation is not available in day 1 so reverted change does not really fix [MGMT-10226 problem](https://github.com/openshift-assisted/assisted-ui-lib/pull/1391).

When [checking the host validations for a wizard step](https://github.com/openshift-assisted/assisted-ui-lib/blob/master/src/common/components/clusterWizard/validationsInfoUtils.ts#L99) we're comparing the length of the required validations from validations map with the length of required validations from real host validations info. We should probably replace this with a debug console warning as part of this change to prevent unwanted behaviour in case when validations info does not include some validation which is defined in validations map. (For example in case when some validation is removed from the backend but still required on the frontend).

Fixes https://issues.redhat.com/browse/MGMT-10577

This reverts commit 69d684d8dc93e3e6298e865e41a1b714de6f3242.