### PR TITLE
MGMT-10392 Fix broken comparison due to extra array

### DIFF
--- a/src/common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionControlGroup.tsx
+++ b/src/common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionControlGroup.tsx
@@ -13,12 +13,10 @@ const hasFilledTangServers = (tangServers: TangServer[]): boolean => {
     return false;
   }
 
-  const emptyServer = [
-    {
-      url: '',
-      thumbprint: '',
-    },
-  ];
+  const emptyServer = {
+    url: '',
+    thumbprint: '',
+  };
   return (
     tangServers.find(
       (server: typeof tangServers[number]) => !isEqual(server, emptyServer) && !isEqual(server, {}),


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-10392
There was a bug in the previous fix https://github.com/openshift-assisted/assisted-ui-lib/pull/1389

The comparison was not correct because of an extra array in the object.
Now the comparison is fixed, the PATCH should not happen if no changes exist.