### PR TITLE
MGMT-10596: Hostname validations won't allow for numbering in mass-actions [BACKPORT]

### DIFF
--- a/src/common/components/hosts/MassChangeHostnameModal.tsx
+++ b/src/common/components/hosts/MassChangeHostnameModal.tsx
@@ -263,6 +263,7 @@ const MassChangeHostnameModal: React.FC<MassChangeHostnameModalProps> = ({
     >
       <Formik
         initialValues={initialValues}
+        validateOnMount
         validate={withTemplate(
           selectedHosts,
           hosts,


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-10596

Before:
![image](https://user-images.githubusercontent.com/87187179/171411538-06e74d56-6df1-4e55-ac10-136615379fb7.png)

After:
![image](https://user-images.githubusercontent.com/87187179/171411503-fb19bc5f-0d16-4c5b-98f7-cf650b275831.png)
