### PR TITLE
[releases/v2.4] MGMT-10579 Fix host status and validations

### DIFF
--- a/src/cim/components/helpers/status.ts
+++ b/src/cim/components/helpers/status.ts
@@ -13,7 +13,7 @@ import { BareMetalHostK8sResource } from '../../types/k8s/bare-metal-host';
 import { StatusCondition } from '../../types/k8s/shared';
 import { ValidationsInfo } from '../../../common/types/hosts';
 import {
-  areOnlySoftValidationsFailing,
+  areOnlySoftValidationsOfWizardStepFailing,
   getWizardStepHostStatus,
   getWizardStepHostValidationsInfo,
 } from '../../../common/components/clusterWizard/validationsInfoUtils';
@@ -158,7 +158,7 @@ export const getWizardStepAgentStatus = (
     wizardStepId,
     wizardStepsValidationsMap,
   );
-  status.sublabel = areOnlySoftValidationsFailing(
+  status.sublabel = areOnlySoftValidationsOfWizardStepFailing(
     aStatus.validationsInfo,
     wizardStepId,
     wizardStepsValidationsMap,

--- a/src/common/components/clusterWizard/validationsInfoUtils.ts
+++ b/src/common/components/clusterWizard/validationsInfoUtils.ts
@@ -240,7 +240,7 @@ export const getFailingClusterWizardStepHostValidations = <ClusterWizardStepsTyp
     return [...curr, ...failingValidations];
   }, [] as Validation[]);
 
-export const areOnlySoftValidationsFailing = <ClusterWizardStepsType extends string>(
+export const areOnlySoftValidationsOfWizardStepFailing = <ClusterWizardStepsType extends string>(
   validationsInfo: HostValidationsInfo,
   wizardStepId: ClusterWizardStepsType,
   wizardStepsValidationsMap: WizardStepsValidationMap<ClusterWizardStepsType>,

--- a/src/common/components/hosts/HostStatus.tsx
+++ b/src/common/components/hosts/HostStatus.tsx
@@ -7,8 +7,6 @@ import {
   FlexItem,
   Flex,
   ButtonProps,
-  Stack,
-  StackItem,
 } from '@patternfly/react-core';
 import { PopoverProps } from '@patternfly/react-core/dist/js/components/Popover/Popover';
 import hdate from 'human-date';
@@ -215,16 +213,12 @@ const HostStatus: React.FC<HostStatusProps> = ({
       {<FlexItem>{icon || <UnknownIcon />}</FlexItem>}
 
       <Flex direction={{ default: 'column' }} spaceItems={{ default: 'spaceItemsXs' }}>
-        {!sublabel && !noPopover ? (
+        {!children && !sublabel && !noPopover ? (
           <WithHostStatusPopover {...popoverProps}>{titleWithProgress}</WithHostStatusPopover>
         ) : (
-          <FlexItem>
-            <Stack>
-              <StackItem>{titleWithProgress}</StackItem>
-              {children && <StackItem>{children}</StackItem>}
-            </Stack>
-          </FlexItem>
+          <FlexItem>{titleWithProgress}</FlexItem>
         )}
+        {children && <FlexItem>{children}</FlexItem>}
         {sublabel && (
           <FlexItem
             className="pf-u-font-size-xs"

--- a/src/common/components/hosts/HostValidationGroups.tsx
+++ b/src/common/components/hosts/HostValidationGroups.tsx
@@ -200,10 +200,10 @@ export const HostValidationGroups: React.FC<HostValidationGroupsProps> = ({
       {Object.keys(validationsInfo).map((groupName: string) => {
         const groupLabel = HOST_VALIDATION_GROUP_LABELS[groupName];
 
-        const pendingValidations = validationsInfo[groupName].filter(
+        const pendingValidations = (validationsInfo[groupName] as Validation[]).filter(
           (v: Validation) => v.status === 'pending',
         );
-        const failedValidations = validationsInfo[groupName].filter(
+        const failedValidations = (validationsInfo[groupName] as Validation[]).filter(
           (v: Validation) => v.status === 'failure' || v.status === 'error',
         );
 

--- a/src/common/components/hosts/status.tsx
+++ b/src/common/components/hosts/status.tsx
@@ -21,7 +21,7 @@ import {
 import { Host } from '../../api';
 import { HostStatus } from './types';
 
-export const hostStatus: HostStatus<Host['status']> = {
+export const hostStatus: HostStatus<Host['status']> = Object.freeze({
   'unbinding-pending-user-action': {
     key: 'unbinding-pending-user-action',
     title: 'Removing from cluster',
@@ -212,4 +212,4 @@ export const hostStatus: HostStatus<Host['status']> = {
     category: 'Installation related',
     icon: <AddCircleOIcon />,
   },
-};
+});

--- a/src/common/components/hosts/tableUtils.tsx
+++ b/src/common/components/hosts/tableUtils.tsx
@@ -2,7 +2,7 @@ import { breakWord, expandable, sortable } from '@patternfly/react-table';
 import * as React from 'react';
 import { Address4, Address6 } from 'ip-address';
 import { Cluster, Host, HostUpdateParams, Interface, stringToJSON } from '../../api';
-import { ValidationsInfo } from '../../types/hosts';
+import { ValidationsInfo as HostValidationsInfo } from '../../types/hosts';
 import { getSubnet } from '../clusterConfiguration';
 import { DASH } from '../constants';
 import { getDateTimeCell } from '../ui';
@@ -14,7 +14,7 @@ import HostsCount from './HostsCount';
 import { HostsTableActions } from './types';
 import HostStatus from './HostStatus';
 import RoleCell from './RoleCell';
-import { getHostname, getHostRole, getInventory } from './utils';
+import { areOnlySoftValidationsFailing, getHostname, getHostRole, getInventory } from './utils';
 import { selectMachineNetworkCIDR } from '../../selectors/clusterSelectors';
 import { hostStatus } from './status';
 import { DropdownProps } from '@patternfly/react-core';
@@ -131,13 +131,18 @@ export const statusColumn = (
       transforms: [sortable],
     },
     cell: (host) => {
-      const validationsInfo = stringToJSON<ValidationsInfo>(host.validationsInfo) || {};
+      const validationsInfo = stringToJSON<HostValidationsInfo>(host.validationsInfo) || {};
       const editHostname = onEditHostname ? () => onEditHostname(host) : undefined;
+      const sublabel =
+        areOnlySoftValidationsFailing(validationsInfo) &&
+        ['known', 'known-unbound'].includes(host.status)
+          ? 'Some validations failed'
+          : undefined;
       return {
         title: (
           <HostStatus
             host={host}
-            status={hostStatus[host.status]}
+            status={{ ...hostStatus[host.status], sublabel }}
             onEditHostname={editHostname}
             validationsInfo={validationsInfo}
             AdditionalNTPSourcesDialogToggleComponent={AdditionalNTPSourcesDialogToggleComponent}
@@ -181,7 +186,7 @@ export const cpuCoresColumn: TableRow<Host> = {
   cell: (host) => {
     const inventory = getInventory(host);
     const { cores } = getHostRowHardwareInfo(inventory);
-    const validationsInfo = stringToJSON<ValidationsInfo>(host.validationsInfo) || {};
+    const validationsInfo = stringToJSON<HostValidationsInfo>(host.validationsInfo) || {};
     const cpuCoresValidation = validationsInfo?.hardware?.find(
       (v) => v.id === 'has-cpu-cores-for-role',
     );
@@ -208,7 +213,7 @@ export const memoryColumn: TableRow<Host> = {
   cell: (host) => {
     const inventory = getInventory(host);
     const { memory } = getHostRowHardwareInfo(inventory);
-    const validationsInfo = stringToJSON<ValidationsInfo>(host.validationsInfo) || {};
+    const validationsInfo = stringToJSON<HostValidationsInfo>(host.validationsInfo) || {};
     const memoryValidation = validationsInfo?.hardware?.find((v) => v.id === 'has-memory-for-role');
     return {
       title: (
@@ -233,7 +238,7 @@ export const disksColumn: TableRow<Host> = {
   cell: (host) => {
     const inventory = getInventory(host);
     const { disk } = getHostRowHardwareInfo(inventory);
-    const validationsInfo = stringToJSON<ValidationsInfo>(host.validationsInfo) || {};
+    const validationsInfo = stringToJSON<HostValidationsInfo>(host.validationsInfo) || {};
     const diskValidation = validationsInfo?.hardware?.find((v) => v.id === 'has-min-valid-disks');
     return {
       title: (

--- a/src/common/components/hosts/utils.ts
+++ b/src/common/components/hosts/utils.ts
@@ -5,6 +5,7 @@ import { HOST_ROLES, TIME_ZERO } from '../../config';
 import { DASH } from '../constants';
 import { stringToJSON } from '../../api';
 import { isSNO } from '../../selectors';
+import { Validation, ValidationsInfo as HostValidationsInfo } from '../../types/hosts';
 
 export const canEnable = (clusterStatus: Cluster['status'], status: Host['status']) =>
   ['pending-for-input', 'insufficient', 'ready', 'adding-hosts'].includes(clusterStatus) &&
@@ -212,4 +213,25 @@ export const filterByHostname = (hosts: Host[], hostnameFilter: string | undefin
     keys: ['hostname'],
   });
   return fuse.search(hostnameFilter).map(({ item }) => item.host);
+};
+
+export const getFailingHostValidations = (validationsInfo: HostValidationsInfo) =>
+  Object.keys(validationsInfo).reduce((curr, group) => {
+    const failingValidations: Validation[] = (validationsInfo[group] as Validation[]).filter(
+      (validation: Validation) => validation.status === 'failure',
+    );
+    return [...curr, ...failingValidations];
+  }, [] as Validation[]);
+
+export const areOnlySoftValidationsFailing = (validationsInfo: HostValidationsInfo) => {
+  const failingValidationIds = getFailingHostValidations(validationsInfo).map(
+    (validation) => validation.id,
+  );
+  if (!failingValidationIds.length) return false;
+  for (const id of failingValidationIds) {
+    if (!['ntp-synced', 'container-images-available'].includes(id)) {
+      return false;
+    }
+  }
+  return true;
 };

--- a/src/ocm/components/hosts/HardwareStatus.tsx
+++ b/src/ocm/components/hosts/HardwareStatus.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  areOnlySoftValidationsFailing,
+  areOnlySoftValidationsOfWizardStepFailing,
   getWizardStepHostStatus,
   getWizardStepHostValidationsInfo,
   Host,
@@ -29,7 +29,7 @@ const HardwareStatus: React.FC<HardwareStatusProps> = (props) => {
     'host-discovery',
     wizardStepsValidationsMap,
   );
-  status.sublabel = areOnlySoftValidationsFailing(
+  const sublabel = areOnlySoftValidationsOfWizardStepFailing(
     validationsInfo,
     'host-discovery',
     wizardStepsValidationsMap,
@@ -40,7 +40,7 @@ const HardwareStatus: React.FC<HardwareStatusProps> = (props) => {
   return (
     <HostStatus
       {...props}
-      status={status}
+      status={{ ...status, sublabel }}
       validationsInfo={validationsInfo}
       AdditionalNTPSourcesDialogToggleComponent={AdditionalNTPSourcesDialogToggle}
     />

--- a/src/ocm/components/hosts/NetworkingStatus.tsx
+++ b/src/ocm/components/hosts/NetworkingStatus.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  areOnlySoftValidationsFailing,
+  areOnlySoftValidationsOfWizardStepFailing,
   getWizardStepHostStatus,
   getWizardStepHostValidationsInfo,
   HostNetworkingStatusComponentProps,
@@ -22,7 +22,7 @@ const NetworkingStatus: React.FC<HostNetworkingStatusComponentProps> = (props) =
     'networking',
     wizardStepsValidationsMap,
   );
-  status.sublabel = areOnlySoftValidationsFailing(
+  const sublabel = areOnlySoftValidationsOfWizardStepFailing(
     validationsInfo,
     'networking',
     wizardStepsValidationsMap,
@@ -33,7 +33,7 @@ const NetworkingStatus: React.FC<HostNetworkingStatusComponentProps> = (props) =
   return (
     <HostStatus
       {...props}
-      status={status}
+      status={{ ...status, sublabel }}
       validationsInfo={validationsInfo}
       AdditionalNTPSourcesDialogToggleComponent={AdditionalNTPSourcesDialogToggle}
     />


### PR DESCRIPTION
Backport of https://github.com/openshift-assisted/assisted-ui-lib/pull/1413

Host status sublabel has been leaking into unwanted places because
it was set by modifying the original host status definition object.