### PR TITLE
MGMT-10642: Hostname in UI chars limit is 253 (BE limit is 63)

### DIFF
--- a/src/common/components/ui/formik/constants.tsx
+++ b/src/common/components/ui/formik/constants.tsx
@@ -31,6 +31,7 @@ export const NAME_VALIDATION_MESSAGES = {
   NOT_UNIQUE: 'Must be unique',
   INVALID_VALUE: 'Use lowercase alphanumberic characters, dot (.) or hyphen (-)',
   INVALID_START_END: 'Must start and end with an lowercase alphanumeric character',
+  INVALID_FORMAT: 'Number of characters between dots (.) must be 1-63',
 };
 
 export const HOSTNAME_VALIDATION_MESSAGES = {

--- a/src/common/components/ui/formik/validationSchemas.ts
+++ b/src/common/components/ui/formik/validationSchemas.ts
@@ -29,6 +29,7 @@ const PROXY_DNS_REGEX =
 const IP_V4_ZERO = '0.0.0.0';
 const IP_V6_ZERO = '0000:0000:0000:0000:0000:0000:0000:0000';
 const MAC_REGEX = /^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$/;
+const HOST_NAME_REGEX = /^[^.]{1,63}(?:[.][^.]{1,63})*$/;
 
 //Source of information: https://github.com/metal3-io/baremetal-operator/blob/main/docs/api.md#baremetalhost-spec
 const BMC_REGEX =
@@ -348,6 +349,7 @@ export const richNameValidationSchema = (usedNames: string[], origName?: string)
         );
       },
     )
+    .matches(HOST_NAME_REGEX, NAME_VALIDATION_MESSAGES.INVALID_FORMAT)
     .matches(NAME_CHARS_REGEX, {
       message: NAME_VALIDATION_MESSAGES.INVALID_VALUE,
       excludeEmptyString: true,


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-10642

Added hostname validation regex. Hostnames must be valid (maximum of 62 characters between dots).

Before:
![image](https://user-images.githubusercontent.com/87187179/171435079-6f7eeb45-e052-47db-aaf3-887d7bd2d10b.png)

After:
![image](https://user-images.githubusercontent.com/87187179/171591824-4ed3280f-220b-441e-9516-1045aa2ba11f.png)
![image](https://user-images.githubusercontent.com/87187179/171591390-c03ba8b8-466c-43d7-8ad1-78a71094c52b.png)
![image](https://user-images.githubusercontent.com/87187179/171591919-0bb9acb2-b291-4153-88e9-121594044ade.png)
