### PR TITLE
NO-ISSUE: Fixes the tooltips for disabled CMN/UMN controls

### DIFF
--- a/src/common/components/clusterWizard/networkingSteps/ManagedNetworkingControlGroup.tsx
+++ b/src/common/components/clusterWizard/networkingSteps/ManagedNetworkingControlGroup.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { FormGroup, Tooltip } from '@patternfly/react-core';
-import { getFieldId, RadioField } from '../../ui';
+import { FormGroup, TooltipProps } from '@patternfly/react-core';
+import { getFieldId } from '../../ui';
+import RadioFieldWithTooltip from '../../ui/formik/RadioFieldWithTooltip';
 export interface ManagedNetworkingControlGroupProps {
   disabled: boolean;
   tooltip?: string;
@@ -11,22 +12,28 @@ export const ManagedNetworkingControlGroup = ({
   disabled = false,
   tooltip,
 }: ManagedNetworkingControlGroupProps) => {
+  const tooltipProps: TooltipProps = {
+    hidden: !tooltip || !disabled,
+    content: tooltip,
+    position: 'top',
+  };
+
   return (
-    <Tooltip hidden={!tooltip || !disabled} content={tooltip} position={'top-start'}>
-      <FormGroup label="Network Management" fieldId={getFieldId(GROUP_NAME, 'radio')} isInline>
-        <RadioField
-          name={GROUP_NAME}
-          isDisabled={disabled}
-          value={'clusterManaged'}
-          label="Cluster-Managed Networking"
-        />
-        <RadioField
-          name={GROUP_NAME}
-          isDisabled={disabled}
-          value={'userManaged'}
-          label="User-Managed Networking"
-        />
-      </FormGroup>
-    </Tooltip>
+    <FormGroup label="Network Management" fieldId={getFieldId(GROUP_NAME, 'radio')} isInline>
+      <RadioFieldWithTooltip
+        tooltipProps={tooltipProps}
+        name={GROUP_NAME}
+        isDisabled={disabled}
+        value={'clusterManaged'}
+        label="Cluster-Managed Networking"
+      />
+      <RadioFieldWithTooltip
+        tooltipProps={tooltipProps}
+        name={GROUP_NAME}
+        isDisabled={disabled}
+        value={'userManaged'}
+        label="User-Managed Networking"
+      />
+    </FormGroup>
   );
 };

--- a/src/common/components/ui/formik/RadioFieldWithTooltip.tsx
+++ b/src/common/components/ui/formik/RadioFieldWithTooltip.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Tooltip, RadioProps, TooltipProps } from '@patternfly/react-core';
+import RadioField from './RadioField';
+
+type RadioFieldWithTooltipProps = Optional<RadioProps, 'id'> & { tooltipProps: TooltipProps };
+
+const RadioFieldWithTooltip = ({
+  tooltipProps,
+  ...radioFieldProps
+}: RadioFieldWithTooltipProps) => {
+  return (
+    <Tooltip {...tooltipProps}>
+      <RadioField {...radioFieldProps} />
+    </Tooltip>
+  );
+};
+
+export default RadioFieldWithTooltip;


### PR DESCRIPTION
Now:
![image](https://user-images.githubusercontent.com/77008341/171747320-0bed4d34-1ace-43f9-be89-376c904aed94.png)

Before:
![image](https://user-images.githubusercontent.com/77008341/171747409-d913e3f5-d14e-4eb2-a54e-b3b33def9ed4.png)

Sample scenario: Multi-node cluster w/dual-stack won't allow UMN