### PR TITLE
[release/v2.4]: Enable disk encryption should not be present in CIM

### DIFF
--- a/src/cim/components/ClusterDeployment/ClusterDeploymentDetailsForm.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentDetailsForm.tsx
@@ -47,6 +47,7 @@ const ClusterDeploymentDetailsForm: React.FC<ClusterDeploymentDetailsFormProps> 
           isOcm={false}
           defaultPullSecret={pullSecret}
           extensionAfter={extensionAfter}
+          hideDiskEncriptionControls
         />
       </StackItem>
     </Stack>

--- a/src/common/components/clusterWizard/ClusterDetailsFormFields.tsx
+++ b/src/common/components/clusterWizard/ClusterDetailsFormFields.tsx
@@ -32,6 +32,7 @@ export type ClusterDetailsFormFieldsProps = {
   versions: OpenshiftVersionOptionType[];
   toggleRedHatDnsService?: (checked: boolean) => void;
   isPullSecretSet: boolean;
+  hideDiskEncriptionControls?: boolean;
 };
 
 const BaseDnsHelperText: React.FC<{ name?: string; baseDnsDomain?: string }> = ({
@@ -59,6 +60,7 @@ export const ClusterDetailsFormFields: React.FC<ClusterDetailsFormFieldsProps> =
   extensionAfter,
   isOcm, // TODO(mlibra): make it optional, false by default
   isPullSecretSet,
+  hideDiskEncriptionControls,
 }) => {
   const { values } = useFormikContext<ClusterDetailsValues>();
   const { name, baseDnsDomain, highAvailabilityMode, useRedHatDnsService } = values;
@@ -126,7 +128,7 @@ export const ClusterDetailsFormFields: React.FC<ClusterDetailsFormFieldsProps> =
       {extensionAfter?.['openshiftVersion'] && extensionAfter['openshiftVersion']}
       {canEditPullSecret && <PullSecret isOcm={isOcm} defaultPullSecret={defaultPullSecret} />}
       {extensionAfter?.['pullSecret'] && extensionAfter['pullSecret']}
-      {isOcm && (
+      {!hideDiskEncriptionControls && (
         <DiskEncryptionControlGroup
           values={values}
           isDisabled={isPullSecretSet}


### PR DESCRIPTION
Related to https://bugzilla.redhat.com/show_bug.cgi?id=2059609
Solving the problem with disc encryption that disappeared from the stand-alone UI (in OCM is ok)