### PR TITLE
MGMT-10110 Read-only cluster for non owner users

### DIFF
--- a/src/common/components/clusterConfiguration/SecurityFields.tsx
+++ b/src/common/components/clusterConfiguration/SecurityFields.tsx
@@ -22,9 +22,14 @@ const label = 'Host SSH Public Key for troubleshooting after installation';
 interface SecurityFieldsFieldsProps {
   clusterSshKey: Cluster['sshPublicKey'];
   imageSshKey?: Cluster['imageInfo']['sshPublicKey'];
+  isDisabled?: boolean;
 }
 
-const SecurityFields: React.FC<SecurityFieldsFieldsProps> = ({ clusterSshKey, imageSshKey }) => {
+const SecurityFields = ({
+  clusterSshKey,
+  imageSshKey,
+  isDisabled = false,
+}: SecurityFieldsFieldsProps) => {
   //shareSshKey shouldn't response to changes. imageSshKey stays the same, there's a loading state while it's requested
   //clusterSshKey updating causes the textarea to disappear when the user clears it to edit it
   const defaultShareSshKey = !!imageSshKey && (clusterSshKey === imageSshKey || !clusterSshKey);
@@ -41,10 +46,10 @@ const SecurityFields: React.FC<SecurityFieldsFieldsProps> = ({ clusterSshKey, im
   };
 
   React.useEffect(() => {
-    if (shareSshKey) {
+    if (!isDisabled && shareSshKey) {
       setFieldValue('sshPublicKey', imageSshKey);
     }
-  }, [shareSshKey, imageSshKey, setFieldValue]);
+  }, [shareSshKey, imageSshKey, setFieldValue, isDisabled]);
 
   const fieldId = getFieldId('shareDiscoverySshKey', 'checkbox');
   return (
@@ -62,6 +67,7 @@ const SecurityFields: React.FC<SecurityFieldsFieldsProps> = ({ clusterSshKey, im
             label="Use the same host discovery SSH key"
             aria-describedby={`${fieldId}-helper`}
             isChecked={shareSshKey}
+            isDisabled={isDisabled}
             onChange={setShareSshKey}
           />
         </RenderIf>
@@ -69,6 +75,7 @@ const SecurityFields: React.FC<SecurityFieldsFieldsProps> = ({ clusterSshKey, im
           <TextAreaField
             name="sshPublicKey"
             helperText={<SshPublicKeyHelperText />}
+            isDisabled={isDisabled}
             onBlur={handleSshKeyBlur}
           />
         </RenderIf>

--- a/src/common/components/clusterWizard/networkingSteps/NetworkTypeControlGroup.tsx
+++ b/src/common/components/clusterWizard/networkingSteps/NetworkTypeControlGroup.tsx
@@ -6,12 +6,14 @@ import { NETWORK_TYPE_OVN, NETWORK_TYPE_SDN } from '../../../config';
 
 const GROUP_NAME = 'networkType';
 export interface NetworkTypeControlGroupProps {
+  isDisabled?: boolean;
   isSDNSelectable: boolean;
 }
 
-export const NetworkTypeControlGroup: React.FC<NetworkTypeControlGroupProps> = ({
+export const NetworkTypeControlGroup = ({
+  isDisabled = false,
   isSDNSelectable,
-}) => {
+}: NetworkTypeControlGroupProps) => {
   return (
     <FormGroup fieldId={GROUP_NAME} label="Network type">
       <Split hasGutter>
@@ -25,7 +27,7 @@ export const NetworkTypeControlGroup: React.FC<NetworkTypeControlGroupProps> = (
             <RadioField
               id={GROUP_NAME}
               name={GROUP_NAME}
-              isDisabled={!isSDNSelectable}
+              isDisabled={isDisabled || !isSDNSelectable}
               value={NETWORK_TYPE_SDN}
               label={
                 <>
@@ -44,6 +46,7 @@ export const NetworkTypeControlGroup: React.FC<NetworkTypeControlGroupProps> = (
           <RadioField
             id={GROUP_NAME}
             name={GROUP_NAME}
+            isDisabled={isDisabled}
             value={NETWORK_TYPE_OVN}
             label={
               <>

--- a/src/common/components/ui/formik/CodeField.tsx
+++ b/src/common/components/ui/formik/CodeField.tsx
@@ -18,6 +18,7 @@ const CodeField: React.FC<CodeFieldProps> = ({
   language,
   name,
   description,
+  isDisabled,
 }) => {
   const [field, , { setValue, setTouched }] = useField({ name, validate });
   const fieldId = getFieldId(name, 'input', idPostfix);
@@ -74,9 +75,10 @@ const CodeField: React.FC<CodeFieldProps> = ({
         )}
         <CodeEditor
           code={field.value}
-          isUploadEnabled
           isDownloadEnabled
           isCopyEnabled
+          isUploadEnabled={!isDisabled}
+          isReadOnly={isDisabled}
           isLanguageLabelVisible
           height="400px"
           language={language}

--- a/src/common/features/featureGate.tsx
+++ b/src/common/features/featureGate.tsx
@@ -11,6 +11,11 @@ export type FeatureListType = {
   [key in AssistedInstallerFeatureType]?: boolean;
 };
 
+export type AssistedInstallerPermissionTypes = 'canEdit';
+export type AssistedInstallerPermissionTypesListType = {
+  [key in AssistedInstallerPermissionTypes]: boolean;
+};
+
 // Hardcoded for ACM
 export const ACM_ENABLED_FEATURES: FeatureListType = {
   ASSISTED_INSTALLER_SNO_FEATURE: true,

--- a/src/common/features/featureGate.tsx
+++ b/src/common/features/featureGate.tsx
@@ -11,7 +11,11 @@ export type FeatureListType = {
   [key in AssistedInstallerFeatureType]?: boolean;
 };
 
-export type AssistedInstallerPermissionTypes = 'canEdit';
+export type AssistedInstallerOCMPermissionTypes = 'canEdit';
+export type AssistedInstallerOCMPermissionTypesListType = {
+  [key in AssistedInstallerOCMPermissionTypes]: boolean;
+};
+export type AssistedInstallerPermissionTypes = 'isViewerMode';
 export type AssistedInstallerPermissionTypesListType = {
   [key in AssistedInstallerPermissionTypes]: boolean;
 };

--- a/src/ocm/components/AddHosts/AddHosts.tsx
+++ b/src/ocm/components/AddHosts/AddHosts.tsx
@@ -30,13 +30,15 @@ import { HostsService } from '../../services';
 import ClusterDetailStatusVarieties, {
   useClusterStatusVarieties,
 } from '../clusterDetail/ClusterDetailStatusVarieties';
+import useClusterPermissions from '../../hooks/useClusterPermissions';
 
 const { addAlert } = alertsSlice.actions;
 
-const AddHosts: React.FC = () => {
+const AddHosts = () => {
   const { cluster, resetCluster } = React.useContext(AddHostsContext);
   const [isSubmitting, setSubmitting] = React.useState(false);
   const clusterVarieties = useClusterStatusVarieties(cluster);
+  const { isViewerMode } = useClusterPermissions();
 
   if (!cluster || !resetCluster) {
     return null;
@@ -93,7 +95,7 @@ const AddHosts: React.FC = () => {
                 variant={ButtonVariant.primary}
                 name="install"
                 onClick={handleHostsInstall}
-                isDisabled={isSubmitting || getReadyHostCount(cluster) <= 0}
+                isDisabled={isViewerMode || isSubmitting || getReadyHostCount(cluster) <= 0}
               >
                 Install ready hosts
               </ToolbarButton>

--- a/src/ocm/components/clusterConfiguration/CnvCheckbox.tsx
+++ b/src/ocm/components/clusterConfiguration/CnvCheckbox.tsx
@@ -4,9 +4,12 @@ import { useFeatureSupportLevel } from '../../../common/components/featureSuppor
 import { FormGroup, Tooltip } from '@patternfly/react-core';
 import CNVHostRequirementsContent from '../hosts/CNVHostRequirementsContent';
 
-const CNVLabel: React.FC<{ clusterId: Cluster['id']; isSingleNode?: boolean }> = ({
+const CNVLabel = ({
   clusterId,
   isSingleNode,
+}: {
+  clusterId: Cluster['id'];
+  isSingleNode?: boolean;
 }) => {
   return (
     <>
@@ -23,12 +26,18 @@ const CNVLabel: React.FC<{ clusterId: Cluster['id']; isSingleNode?: boolean }> =
 };
 
 export type CnvCheckboxProps = {
+  clusterId: string;
   openshiftVersion?: string;
   isSNO: boolean;
-  clusterId: string;
+  isDisabled: boolean;
 };
 
-export const CnvCheckbox: React.FC<CnvCheckboxProps> = ({ openshiftVersion, isSNO, clusterId }) => {
+export const CnvCheckbox = ({
+  clusterId,
+  openshiftVersion,
+  isSNO,
+  isDisabled,
+}: CnvCheckboxProps) => {
   const featureSupportLevelContext = useFeatureSupportLevel();
   const name = 'useContainerNativeVirtualization';
   const fieldId = getFieldId(name, 'input');
@@ -42,7 +51,7 @@ export const CnvCheckbox: React.FC<CnvCheckboxProps> = ({ openshiftVersion, isSN
           name={name}
           label={<CNVLabel clusterId={clusterId} isSingleNode={isSNO} />}
           helperText="Run virtual machines along containers."
-          isDisabled={!!disabledReason}
+          isDisabled={isDisabled || !!disabledReason}
         />
       </Tooltip>
     </FormGroup>

--- a/src/ocm/components/clusterConfiguration/ODFCheckbox.tsx
+++ b/src/ocm/components/clusterConfiguration/ODFCheckbox.tsx
@@ -4,7 +4,7 @@ import { useFeatureSupportLevel } from '../../../common/components/featureSuppor
 import { FormGroup, Tooltip } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
-const ODFLabel: React.FC = () => (
+const ODFLabel = () => (
   <>
     Install OpenShift Data Foundation{' '}
     <PopoverIcon
@@ -21,9 +21,10 @@ const ODFLabel: React.FC = () => (
 
 export type ODFCheckboxProps = {
   openshiftVersion?: string;
+  isDisabled: boolean;
 };
 
-export const ODFCheckbox: React.FC<ODFCheckboxProps> = ({ openshiftVersion }) => {
+export const ODFCheckbox = ({ openshiftVersion, isDisabled }: ODFCheckboxProps) => {
   const featureSupportLevelContext = useFeatureSupportLevel();
   const name = 'useExtraDisksForLocalStorage';
   const fieldId = getFieldId(name, 'input');
@@ -36,7 +37,7 @@ export const ODFCheckbox: React.FC<ODFCheckboxProps> = ({ openshiftVersion }) =>
         <CheckboxField
           name={name}
           label={<ODFLabel />}
-          isDisabled={!!disabledReason}
+          isDisabled={isDisabled || !!disabledReason}
           helperText="Persistent software-defined storage for hybrid applications."
         />
       </Tooltip>

--- a/src/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
+++ b/src/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
@@ -60,7 +60,8 @@ export const OcmClusterDetailsFormFields: React.FC<ClusterDetailsFormFieldsProps
   clusterExists,
 }) => {
   const { values } = useFormikContext<ClusterDetailsValues>();
-  const { isViewerMode } = useClusterPermissions();
+  const { isViewerMode: realViewerMode } = useClusterPermissions();
+  const isViewerMode = clusterExists && realViewerMode;
   const { name, baseDnsDomain, highAvailabilityMode, useRedHatDnsService } = values;
   const nameInputRef = React.useRef<HTMLInputElement>();
   React.useEffect(() => {

--- a/src/ocm/components/clusterConfiguration/ReviewStep.tsx
+++ b/src/ocm/components/clusterConfiguration/ReviewStep.tsx
@@ -11,10 +11,12 @@ import ReviewCluster from './ReviewCluster';
 import ClusterWizardHeaderExtraActions from './ClusterWizardHeaderExtraActions';
 import { ClustersAPI } from '../../services/apis';
 import { useStateSafely } from '../../../common/hooks';
+import useClusterPermissions from '../../hooks/useClusterPermissions';
 
 const ReviewStep: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
   const { addAlert } = useAlerts();
   const clusterWizardContext = useClusterWizardContext();
+  const { isViewerMode } = useClusterPermissions();
   const [isStartingInstallation, setIsStartingInstallation] = useStateSafely(false);
   const dispatch = useDispatch();
 
@@ -49,7 +51,7 @@ const ReviewStep: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
             variant={ButtonVariant.primary}
             name="install"
             onClick={handleClusterInstall}
-            isDisabled={isStartingInstallation || cluster.status !== 'ready'}
+            isDisabled={isViewerMode || isStartingInstallation || cluster.status !== 'ready'}
           >
             Install cluster
           </Button>

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/AdvancedNetworkFields.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/AdvancedNetworkFields.tsx
@@ -13,6 +13,7 @@ import { useFeature } from '../../../../common/features';
 import { InputField } from '../../../../common/components/ui';
 import { DUAL_STACK, PREFIX_MAX_RESTRICTION } from '../../../../common/config/constants';
 import { NetworkTypeControlGroup } from '../../../../common/components/clusterWizard/networkingSteps/NetworkTypeControlGroup';
+import useClusterPermissions from '../../../hooks/useClusterPermissions';
 
 type AdvancedNetworkFieldsProps = {
   isSDNSelectable: boolean;
@@ -36,6 +37,7 @@ const serviceCidrHelperText =
 
 const AdvancedNetworkFields: React.FC<AdvancedNetworkFieldsProps> = ({ isSDNSelectable }) => {
   const { setFieldValue, values, errors } = useFormikContext<NetworkConfigurationValues>();
+  const { isViewerMode } = useClusterPermissions();
 
   const isNetworkTypeSelectionEnabled = useFeature(
     'ASSISTED_INSTALLER_NETWORK_TYPE_SELECTION_FEATURE',
@@ -52,7 +54,7 @@ const AdvancedNetworkFields: React.FC<AdvancedNetworkFieldsProps> = ({ isSDNSele
     e: React.ChangeEvent<HTMLInputElement>,
     index: number,
   ) => {
-    if (isNaN(parseInt(e.target.value))) {
+    if (!isViewerMode && isNaN(parseInt(e.target.value))) {
       setFieldValue(`clusterNetworks.${index}.hostPrefix`, clusterNetworkCidrPrefix(index));
     }
   };
@@ -74,13 +76,15 @@ const AdvancedNetworkFields: React.FC<AdvancedNetworkFieldsProps> = ({ isSDNSele
                   <InputField
                     name={`clusterNetworks.${index}.cidr`}
                     label={`Cluster network CIDR${networkSuffix}`}
-                    helperText={clusterCidrHelperText}
                     isRequired
+                    helperText={clusterCidrHelperText}
                     labelInfo={index === 0 && isDualStack ? 'Primary' : ''}
+                    isDisabled={isViewerMode}
                   />
                   <InputField
                     name={`clusterNetworks.${index}.hostPrefix`}
                     label={`Cluster network host prefix${networkSuffix}`}
+                    isRequired
                     type={TextInputTypes.number}
                     min={clusterNetworkCidrPrefix(index)}
                     max={
@@ -95,7 +99,7 @@ const AdvancedNetworkFields: React.FC<AdvancedNetworkFieldsProps> = ({ isSDNSele
                       )
                     }
                     helperText={clusterNetworkHostPrefixHelperText(index)}
-                    isRequired
+                    isDisabled={isViewerMode}
                   />
                 </StackItem>
               );
@@ -119,6 +123,7 @@ const AdvancedNetworkFields: React.FC<AdvancedNetworkFieldsProps> = ({ isSDNSele
                   helperText={serviceCidrHelperText}
                   isRequired
                   labelInfo={index === 0 && isDualStack ? 'Primary' : ''}
+                  isDisabled={isViewerMode}
                 />
               </StackItem>
             ))}
@@ -131,7 +136,7 @@ const AdvancedNetworkFields: React.FC<AdvancedNetworkFieldsProps> = ({ isSDNSele
       )}
 
       {isNetworkTypeSelectionEnabled && (
-        <NetworkTypeControlGroup isSDNSelectable={isSDNSelectable} />
+        <NetworkTypeControlGroup isDisabled={isViewerMode} isSDNSelectable={isSDNSelectable} />
       )}
     </Grid>
   );

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/AvailableSubnetsControl.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/AvailableSubnetsControl.tsx
@@ -81,7 +81,7 @@ export const AvailableSubnetsControl = ({
             toFormSelectOptions(machineSubnets),
           );
     },
-    [hostSubnets],
+    [],
   );
 
   return (

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
@@ -28,6 +28,7 @@ import ClusterWizardNavigation from '../../clusterWizard/ClusterWizardNavigation
 import ClusterWizardHeaderExtraActions from '../ClusterWizardHeaderExtraActions';
 import NetworkConfigurationTable from './NetworkConfigurationTable';
 import useInfraEnv from '../../../hooks/useInfraEnv';
+import useClusterPermissions from '../../../hooks/useClusterPermissions';
 import {
   getNetworkConfigurationValidationSchema,
   getNetworkInitialValues,
@@ -52,26 +53,29 @@ const NetworkConfigurationForm: React.FC<{
 }> = ({ cluster, hostSubnets, defaultNetworkSettings, infraEnv }) => {
   const { alerts } = useAlerts();
   const clusterWizardContext = useClusterWizardContext();
+  const { isViewerMode } = useClusterPermissions();
   const { errors, touched, isSubmitting, isValid } = useFormikContext<NetworkConfigurationValues>();
   const isAutoSaveRunning = useFormikAutoSave();
   const errorFields = getFormikErrorFields(errors, touched);
+
+  const isNextDisabled =
+    isSubmitting ||
+    isAutoSaveRunning ||
+    !!alerts.length ||
+    !isValid ||
+    !canNextNetwork({ cluster });
 
   const footer = (
     <ClusterWizardFooter
       cluster={cluster}
       errorFields={errorFields}
       isSubmitting={isSubmitting}
-      isNextDisabled={
-        isSubmitting ||
-        isAutoSaveRunning ||
-        !canNextNetwork({ cluster }) ||
-        !!alerts.length ||
-        !isValid
-      }
+      isNextDisabled={!isViewerMode && isNextDisabled}
       onNext={() => clusterWizardContext.moveNext()}
       onBack={() => clusterWizardContext.moveBack()}
     />
   );
+
   return (
     <ClusterWizardStep navigation={<ClusterWizardNavigation cluster={cluster} />} footer={footer}>
       <Form>
@@ -93,6 +97,7 @@ const NetworkConfigurationForm: React.FC<{
               <SecurityFields
                 clusterSshKey={cluster.sshPublicKey}
                 imageSshKey={infraEnv?.sshAuthorizedKey}
+                isDisabled={isViewerMode}
               />
             </Grid>
           </GridItem>
@@ -121,6 +126,8 @@ const NetworkConfigurationPage: React.FC<{
 
   const { addAlert, clearAlerts, alerts } = useAlerts();
   const dispatch = useDispatch();
+  const { isViewerMode } = useClusterPermissions();
+
   const hostSubnets = React.useMemo(() => getHostSubnets(cluster), [cluster]);
   const initialValues = React.useMemo(
     () => getNetworkInitialValues(cluster, defaultNetworkValues),
@@ -198,11 +205,13 @@ const NetworkConfigurationPage: React.FC<{
     return <LoadingState />;
   }
 
+  const onSubmit = isViewerMode ? () => Promise.resolve() : handleSubmit;
+
   return (
     <Formik
       initialValues={initialValues}
       validationSchema={memoizedValidationSchema}
-      onSubmit={handleSubmit}
+      onSubmit={onSubmit}
       validateOnMount
     >
       <NetworkConfigurationForm

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationTable.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationTable.tsx
@@ -5,14 +5,18 @@ import { isSNO } from '../../../../common/selectors/clusterSelectors';
 import { AdditionalNTPSourcesDialogToggle } from '../../hosts/AdditionaNTPSourceDialogToggle';
 import { HostsTableModals, useHostsTable } from '../../hosts/use-hosts-table';
 import CommonNetworkConfigurationTable from '../../../../common/components/clusterConfiguration/NetworkConfigurationTable';
+import useClusterPermissions from '../../../hooks/useClusterPermissions';
 
-const NetworkConfigurationTable: React.FC<ClusterHostsTableProps> = ({
+const NetworkConfigurationTable = ({
   cluster,
   setDiscoveryHintModalOpen,
   skipDisabled,
-}) => {
-  const { onEditHost, actionChecks, onEditRole, actionResolver, ...modalProps } =
-    useHostsTable(cluster);
+}: ClusterHostsTableProps) => {
+  const { isViewerMode } = useClusterPermissions();
+  const { onEditHost, actionChecks, onEditRole, actionResolver, ...modalProps } = useHostsTable(
+    cluster,
+    isViewerMode,
+  );
 
   return (
     <>

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/StackTypeControl.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/StackTypeControl.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ButtonVariant, FormGroup, Tooltip } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
+import { Address6 } from 'ip-address';
 import {
   Cluster,
   ClusterNetwork,
@@ -12,8 +13,8 @@ import { DUAL_STACK, IPV4_STACK, NO_SUBNET_SET } from '../../../../common/config
 import { getFieldId } from '../../../../common/components/ui/formik/utils';
 import { ConfirmationModal, PopoverIcon, RadioField } from '../../../../common/components/ui';
 import { getDefaultNetworkType } from '../../../../common';
+import useClusterPermissions from '../../../hooks/useClusterPermissions';
 import { useDefaultConfiguration } from '../ClusterDefaultConfigurationContext';
-import { Address6 } from 'ip-address';
 
 type StackTypeControlGroupProps = {
   clusterId: Cluster['id'];
@@ -53,6 +54,8 @@ export const StackTypeControlGroup = ({
 
   const IPv6Subnets = hostSubnets.filter((subnet) => Address6.isValid(subnet.subnet));
   const cidrIPv6 = IPv6Subnets.length >= 1 ? IPv6Subnets[0].subnet : NO_SUBNET_SET;
+  const { isViewerMode } = useClusterPermissions();
+  const shouldSetSingleStack = !isViewerMode && !isDualStackSelectable && values.stackType === DUAL_STACK;
 
   const setSingleStack = React.useCallback(() => {
     setFieldValue('stackType', IPV4_STACK);
@@ -135,10 +138,10 @@ export const StackTypeControlGroup = ({
   };
 
   React.useEffect(() => {
-    if (!isDualStackSelectable && values.stackType === DUAL_STACK) {
+    if (shouldSetSingleStack) {
       setSingleStack();
     }
-  }, [isDualStackSelectable, setSingleStack, values.stackType]);
+  }, [shouldSetSingleStack, setSingleStack]);
 
   return (
     <Tooltip
@@ -156,7 +159,7 @@ export const StackTypeControlGroup = ({
           <RadioField
             name={'stackType'}
             value={IPV4_STACK}
-            isDisabled={!isDualStackSelectable}
+            isDisabled={isViewerMode || !isDualStackSelectable}
             label={
               <>
                 {'IPv4'}
@@ -170,7 +173,7 @@ export const StackTypeControlGroup = ({
           <RadioField
             name={'stackType'}
             value={DUAL_STACK}
-            isDisabled={!isDualStackSelectable}
+            isDisabled={isViewerMode || !isDualStackSelectable}
             label={
               <>
                 {'Dual-stack'}

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/StackTypeControl.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/StackTypeControl.tsx
@@ -55,7 +55,8 @@ export const StackTypeControlGroup = ({
   const IPv6Subnets = hostSubnets.filter((subnet) => Address6.isValid(subnet.subnet));
   const cidrIPv6 = IPv6Subnets.length >= 1 ? IPv6Subnets[0].subnet : NO_SUBNET_SET;
   const { isViewerMode } = useClusterPermissions();
-  const shouldSetSingleStack = !isViewerMode && !isDualStackSelectable && values.stackType === DUAL_STACK;
+  const shouldSetSingleStack =
+    !isViewerMode && !isDualStackSelectable && values.stackType === DUAL_STACK;
 
   const setSingleStack = React.useCallback(() => {
     setFieldValue('stackType', IPV4_STACK);

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/VirtualIPControlGroup.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/VirtualIPControlGroup.tsx
@@ -175,7 +175,13 @@ export const VirtualIPControlGroup = ({
         </>
       ) : (
         <>
-          <InputField label="API IP" name="apiVip" helperText={apiVipHelperText} isRequired isDisabled={isViewerMode}/>
+          <InputField
+            label="API IP"
+            name="apiVip"
+            helperText={apiVipHelperText}
+            isRequired
+            isDisabled={isViewerMode}
+          />
 
           <InputField
             name="ingressVip"

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/VirtualIPControlGroup.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/VirtualIPControlGroup.tsx
@@ -8,6 +8,7 @@ import { CheckboxField, FormikStaticField, InputField } from '../../../../common
 import { FeatureSupportLevelBadge } from '../../../../common/components';
 import { NETWORK_TYPE_SDN } from '../../../../common/config/constants';
 import { selectMachineNetworkCIDR } from '../../../../common';
+import useClusterPermissions from '../../../hooks/useClusterPermissions';
 
 interface VipStaticValueProps {
   vipName: string;
@@ -88,6 +89,7 @@ export const VirtualIPControlGroup = ({
   isVipDhcpAllocationDisabled,
 }: VirtualIPControlGroupProps) => {
   const { values, setFieldValue } = useFormikContext<NetworkConfigurationValues>();
+  const { isViewerMode } = useClusterPermissions();
 
   const apiVipHelperText = `Provide an endpoint for users, both human and machine, to interact with and configure the platform. If needed, contact your IT manager for more information. ${getVipHelperSuffix(
     cluster.apiVip,
@@ -111,7 +113,7 @@ export const VirtualIPControlGroup = ({
   const enableAllocation = values.networkType === NETWORK_TYPE_SDN;
 
   React.useEffect(() => {
-    if (!enableAllocation) {
+    if (!isViewerMode && !enableAllocation) {
       setFieldValue('vipDhcpAllocation', false);
     }
   }, [enableAllocation, setFieldValue]);
@@ -137,7 +139,7 @@ export const VirtualIPControlGroup = ({
             </>
           }
           name="vipDhcpAllocation"
-          isDisabled={!enableAllocation}
+          isDisabled={isViewerMode || !enableAllocation}
         />
       )}
       {values.vipDhcpAllocation ? (
@@ -173,12 +175,14 @@ export const VirtualIPControlGroup = ({
         </>
       ) : (
         <>
-          <InputField label="API IP" name="apiVip" helperText={apiVipHelperText} isRequired />
+          <InputField label="API IP" name="apiVip" helperText={apiVipHelperText} isRequired isDisabled={isViewerMode}/>
+
           <InputField
             name="ingressVip"
             label="Ingress IP"
             helperText={ingressVipHelperText}
             isRequired
+            isDisabled={isViewerMode}
           />
         </>
       )}

--- a/src/ocm/components/clusterConfiguration/staticIp/components/FormViewHosts/FormViewHostsFields.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/components/FormViewHosts/FormViewHostsFields.tsx
@@ -7,15 +7,17 @@ import HostSummary from '../CollapsedHost';
 import { FormViewHost, StaticProtocolType } from '../../data/dataTypes';
 import { getProtocolVersionLabel, getShownProtocolVersions } from '../../data/protocolVersion';
 import { getEmptyFormViewHost } from '../../data/emptyData';
+import useClusterPermissions from '../../../../../hooks/useClusterPermissions';
 
-const getExpandedHostComponent = (protocolType: StaticProtocolType) => {
-  const Component: React.FC<HostComponentProps> = ({ fieldName, hostIdx }) => {
+const getExpandedHostComponent = (protocolType: StaticProtocolType, isDisabled: boolean) => {
+  const Component = ({ fieldName, hostIdx }: HostComponentProps) => {
     return (
       <Grid hasGutter>
         <InputField
           name={`${fieldName}.macAddress`}
           label="MAC Address"
           isRequired
+          isDisabled={isDisabled}
           data-testid={`mac-address-${hostIdx}`}
         />
         {getShownProtocolVersions(protocolType).map((protocolVersion) => (
@@ -26,7 +28,8 @@ const getExpandedHostComponent = (protocolType: StaticProtocolType) => {
           >
             <InputField
               name={`${fieldName}.ips.${protocolVersion}`}
-              isRequired={true}
+              isRequired
+              isDisabled={isDisabled}
               data-testid={`${protocolVersion}-address-${hostIdx}`}
             />{' '}
           </FormGroup>
@@ -38,7 +41,7 @@ const getExpandedHostComponent = (protocolType: StaticProtocolType) => {
 };
 
 const getCollapsedHostComponent = (protocolType: StaticProtocolType) => {
-  const Component: React.FC<HostComponentProps> = ({ fieldName, hostIdx }) => {
+  const Component = ({ fieldName, hostIdx }: HostComponentProps) => {
     const [{ value }, { error }] = useField<FormViewHost>({
       name: fieldName,
     });
@@ -64,8 +67,9 @@ export const FormViewHostsFields: React.FC<{ protocolType: StaticProtocolType }>
   protocolType,
 }) => {
   const emptyHost = getEmptyFormViewHost();
+  const { isViewerMode } = useClusterPermissions();
   const CollapsedHostComponent = getCollapsedHostComponent(protocolType);
-  const ExpandedHostComponent = getExpandedHostComponent(protocolType);
+  const ExpandedHostComponent = getExpandedHostComponent(protocolType, isViewerMode);
   return (
     <StaticIpHostsArray<FormViewHost>
       CollapsedHostComponent={CollapsedHostComponent}

--- a/src/ocm/components/clusterConfiguration/staticIp/components/FormViewNetworkWide/FormViewNetworkWideFields.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/components/FormViewNetworkWide/FormViewNetworkWideFields.tsx
@@ -39,6 +39,7 @@ import {
 import { getMachineNetworkCidr } from '../../data/machineNetwork';
 import '../staticIp.css';
 import useFieldErrorMsg from '../../../../../../common/hooks/useFieldErrorMsg';
+import useClusterPermissions from '../../../../../hooks/useClusterPermissions';
 const hostsConfiguredAlert = (
   <Alert
     variant={AlertVariant.warning}
@@ -48,9 +49,14 @@ const hostsConfiguredAlert = (
   ></Alert>
 );
 
-const MachineNetwork: React.FC<{ fieldName: string; protocolVersion: ProtocolVersion }> = ({
+const MachineNetwork = ({
   fieldName,
   protocolVersion,
+  isDisabled,
+}: {
+  fieldName: string;
+  protocolVersion: ProtocolVersion;
+  isDisabled: boolean;
 }) => {
   const [{ value }] = useField<Cidr>(fieldName);
   const ipFieldName = `${fieldName}.ip`;
@@ -85,6 +91,7 @@ const MachineNetwork: React.FC<{ fieldName: string; protocolVersion: ProtocolVer
             isRequired={true}
             data-testid={`${protocolVersion}-machine-network-ip`}
             showErrorMessage={false}
+            isDisabled={isDisabled}
           />
         </FlexItem>
         <FlexItem spacer={{ default: 'spacerSm' }}>{'/'}</FlexItem>
@@ -95,6 +102,7 @@ const MachineNetwork: React.FC<{ fieldName: string; protocolVersion: ProtocolVer
             data-testid={`${protocolVersion}-machine-network-prefix-length`}
             type={TextInputTypes.number}
             showErrorMessage={false}
+            isDisabled={isDisabled}
           />
         </FlexItem>
       </Flex>
@@ -102,13 +110,22 @@ const MachineNetwork: React.FC<{ fieldName: string; protocolVersion: ProtocolVer
   );
 };
 
-const IpConfigFields: React.FC<{
+const IpConfigFields = ({
+  protocolVersion,
+  fieldName,
+  isDisabled,
+}: {
   fieldName: string;
   protocolVersion: ProtocolVersion;
-}> = ({ protocolVersion, fieldName }) => {
+  isDisabled: boolean;
+}) => {
   return (
     <Grid hasGutter>
-      <MachineNetwork fieldName={`${fieldName}.machineNetwork`} protocolVersion={protocolVersion} />
+      <MachineNetwork
+        fieldName={`${fieldName}.machineNetwork`}
+        protocolVersion={protocolVersion}
+        isDisabled={isDisabled}
+      />
       <InputField
         isRequired
         label="Default gateway"
@@ -120,12 +137,14 @@ const IpConfigFields: React.FC<{
         }
         name={`${fieldName}.gateway`}
         data-testid={`${protocolVersion}-gateway`}
+        isDisabled={isDisabled}
       />
       <InputField
         isRequired
         label="DNS"
         name={`${fieldName}.dns`}
         data-testid={`${protocolVersion}-dns`}
+        isDisabled={isDisabled}
       />
     </Grid>
   );
@@ -142,7 +161,7 @@ const protocolVersionOptions: FormSelectOptionProps[] = [
   },
 ];
 
-export const ProtocolTypeSelect: React.FC = () => {
+export const ProtocolTypeSelect = ({ isDisabled }: { isDisabled: boolean }) => {
   const selectFieldName = 'protocolType';
   const [{ value: protocolType }, , { setValue: setProtocolType }] =
     useField<StaticProtocolType>(selectFieldName);
@@ -164,11 +183,13 @@ export const ProtocolTypeSelect: React.FC = () => {
       callFormikOnChange={false}
       onChange={onChange}
       data-testid="select-protocol-version"
+      isDisabled={isDisabled}
     />
   );
 };
 export const FormViewNetworkWideFields: React.FC<{ hosts: FormViewHost[] }> = ({ hosts }) => {
   const { values, setFieldValue } = useFormikContext<FormViewNetworkWideValues>();
+  const { isViewerMode } = useClusterPermissions();
   return (
     <>
       <TextContent>
@@ -180,7 +201,7 @@ export const FormViewNetworkWideFields: React.FC<{ hosts: FormViewHost[] }> = ({
 
       {hosts.length > 0 && hostsConfiguredAlert}
 
-      <ProtocolTypeSelect />
+      <ProtocolTypeSelect isDisabled={isViewerMode} />
 
       <CheckboxField
         label={
@@ -195,6 +216,7 @@ export const FormViewNetworkWideFields: React.FC<{ hosts: FormViewHost[] }> = ({
         name="useVlan"
         data-testid="use-vlan"
         onChange={() => setFieldValue('vlanId', '')}
+        isDisabled={isViewerMode}
       />
 
       {values.useVlan && (
@@ -205,6 +227,7 @@ export const FormViewNetworkWideFields: React.FC<{ hosts: FormViewHost[] }> = ({
             isRequired
             data-testid="vlan-id"
             type={TextInputTypes.number}
+            isDisabled={isViewerMode}
           />
         </div>
       )}
@@ -217,6 +240,7 @@ export const FormViewNetworkWideFields: React.FC<{ hosts: FormViewHost[] }> = ({
           <IpConfigFields
             fieldName={`ipConfigs.${protocolVersion}`}
             protocolVersion={protocolVersion}
+            isDisabled={isViewerMode}
           ></IpConfigFields>
         </FormGroup>
       ))}

--- a/src/ocm/components/clusterConfiguration/staticIp/components/StaticIpForm.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/components/StaticIpForm.tsx
@@ -7,6 +7,7 @@ import { useFormikAutoSave } from '../../../../../common/components/ui/formik/Fo
 import { useErrorMonitor } from '../../../../../common/components/ErrorHandling/ErrorMonitorContext';
 import { getApiErrorMessage } from '../../../../api';
 import { StaticIpFormProps } from './propTypes';
+import useClusterPermissions from '../../../../hooks/useClusterPermissions';
 
 const AutosaveWithParentUpdate = <StaticIpFormValues extends object>({
   onFormStateChange,
@@ -42,6 +43,7 @@ export const StaticIpForm = <StaticIpFormValues extends object>({
 }: PropsWithChildren<StaticIpFormProps<StaticIpFormValues>>) => {
   const { clearAlerts, addAlert } = useAlerts();
   const { captureException } = useErrorMonitor();
+  const { isViewerMode } = useClusterPermissions();
   const [initialValues, setInitialValues] = React.useState<StaticIpFormValues | undefined>();
   React.useEffect(() => {
     if (showEmptyValues) {
@@ -52,6 +54,10 @@ export const StaticIpForm = <StaticIpFormValues extends object>({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  if (!initialValues) {
+    return null;
+  }
 
   const handleSubmit: FormikConfig<StaticIpFormValues>['onSubmit'] = async (values) => {
     clearAlerts();
@@ -65,21 +71,21 @@ export const StaticIpForm = <StaticIpFormValues extends object>({
       addAlert({ title: getApiErrorMessage(error) });
     }
   };
-  if (!initialValues) {
-    return null;
-  }
+
   const validate = (values: StaticIpFormValues) => {
     try {
-      validationSchema.validateSync(values, { abortEarly: false, context: { values: values } });
+      validationSchema.validateSync(values, { abortEarly: false, context: { values } });
       return {};
     } catch (error) {
       return yupToFormErrors(error);
     }
   };
+
+  const onSubmit = isViewerMode ? () => Promise.resolve() : handleSubmit;
   return (
     <Formik
       initialValues={initialValues}
-      onSubmit={handleSubmit}
+      onSubmit={onSubmit}
       validate={validate}
       validateOnMount
       enableReinitialize

--- a/src/ocm/components/clusterConfiguration/staticIp/components/StaticIpPage.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/components/StaticIpPage.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Text, TextContent, TextVariants, Alert, AlertVariant, Grid } from '@patternfly/react-core';
-
 import { StaticIpInfo, StaticIpView } from '../data/dataTypes';
 import StaticIpViewRadioGroup from './StaticIpViewRadioGroup';
 import { getStaticIpInfo } from '../data/fromInfraEnv';
@@ -10,6 +9,7 @@ import { useClusterWizardContext } from '../../../clusterWizard/ClusterWizardCon
 import { FormViewHosts } from './FormViewHosts/FormViewHosts';
 import { FormViewNetworkWide } from './FormViewNetworkWide/FormViewNetworkWide';
 import './staticIp.css';
+
 const isoRegenerationAlert = (
   <Alert
     variant={AlertVariant.warning}

--- a/src/ocm/components/clusterConfiguration/staticIp/components/StaticIpViewRadioGroup.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/components/StaticIpViewRadioGroup.tsx
@@ -3,6 +3,7 @@ import { ButtonVariant, Form, FormGroup, Radio } from '@patternfly/react-core';
 import { getFieldId } from '../../../../../common';
 import { StaticIpView } from '../data/dataTypes';
 import ConfirmationModal from '../../../../../common/components/ui/ConfirmationModal';
+import useClusterPermissions from '../../../../hooks/useClusterPermissions';
 
 export type StaticIpViewRadioGroupProps = {
   initialView: StaticIpView;
@@ -16,6 +17,7 @@ const StaticIpViewRadioGroup: React.FC<StaticIpViewRadioGroupProps> = ({
   onChangeView,
 }) => {
   const GROUP_NAME = 'select-static-ip-view';
+  const { isViewerMode } = useClusterPermissions();
   const [confirmView, setConfirmView] = React.useState<StaticIpView>();
   const [view, setView] = React.useState<StaticIpView>(initialView);
   const handleChange = (_checked: boolean, event: React.FormEvent<HTMLInputElement>) => {
@@ -58,6 +60,7 @@ const StaticIpViewRadioGroup: React.FC<StaticIpViewRadioGroupProps> = ({
             id="select-form-view"
             value={StaticIpView.FORM}
             isChecked={view === StaticIpView.FORM}
+            isDisabled={isViewerMode}
             onChange={handleChange}
           />
           <Radio
@@ -66,8 +69,9 @@ const StaticIpViewRadioGroup: React.FC<StaticIpViewRadioGroupProps> = ({
             data-testid="select-yaml-view"
             id="select-yaml-view"
             value={StaticIpView.YAML}
-            onChange={handleChange}
             isChecked={view === StaticIpView.YAML}
+            isDisabled={isViewerMode}
+            onChange={handleChange}
           />
         </FormGroup>
       </Form>

--- a/src/ocm/components/clusterConfiguration/staticIp/components/YamlView/MacIpMapping.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/components/YamlView/MacIpMapping.tsx
@@ -25,13 +25,21 @@ const AddMapping: React.FC<{
   );
 };
 
-const MacMappingItem: React.FC<{
+const MacMappingItem = ({
+  fieldName,
+  onRemove,
+  mapIdx,
+  enableRemove,
+  hostIdx,
+  isDisabled,
+}: {
   fieldName: string;
   onRemove: () => void;
   mapIdx: number;
   hostIdx: number;
   enableRemove: boolean;
-}> = ({ fieldName, onRemove, mapIdx, enableRemove, hostIdx }) => {
+  isDisabled: boolean;
+}) => {
   return (
     <RemovableField hideRemoveButton={!enableRemove} onRemove={onRemove}>
       <Grid hasGutter>
@@ -39,6 +47,7 @@ const MacMappingItem: React.FC<{
           <InputField
             label="MAC address"
             isRequired
+            isDisabled={isDisabled}
             name={`${fieldName}.macAddress`}
             data-testid={`mac-address-${hostIdx}-${mapIdx}`}
           ></InputField>
@@ -47,6 +56,7 @@ const MacMappingItem: React.FC<{
           <InputField
             label="Interface name"
             isRequired
+            isDisabled={isDisabled}
             name={`${fieldName}.logicalNicName`}
             data-testid={`interface-name-${hostIdx}-${mapIdx}`}
           ></InputField>
@@ -56,11 +66,17 @@ const MacMappingItem: React.FC<{
   );
 };
 
-export const MacIpMapping: React.FC<{
+export const MacIpMapping = ({
+  fieldName,
+  macInterfaceMap,
+  hostIdx,
+  isDisabled,
+}: {
   fieldName: string;
   macInterfaceMap: MacInterfaceMap;
   hostIdx: number;
-}> = ({ fieldName, macInterfaceMap, hostIdx }) => {
+  isDisabled: boolean;
+}) => {
   return (
     <Grid className="mac-ip-mapping">
       <GridItem span={6}>
@@ -69,18 +85,19 @@ export const MacIpMapping: React.FC<{
           validateOnChange={false}
           render={({ push, remove }) => (
             <Grid hasGutter>
-              {macInterfaceMap.map((value, idx) => (
+              {macInterfaceMap.map((_, idx) => (
                 <MacMappingItem
                   key={getFormikArrayItemFieldName(fieldName, idx)}
                   fieldName={getFormikArrayItemFieldName(fieldName, idx)}
+                  isDisabled={isDisabled}
                   onRemove={() => remove(idx)}
                   mapIdx={idx}
-                  enableRemove={idx > 0}
+                  enableRemove={!isDisabled && idx > 0}
                   hostIdx={hostIdx}
                 />
               ))}
 
-              <AddMapping onPush={push} />
+              {!isDisabled && <AddMapping onPush={push} />}
             </Grid>
           )}
         ></FieldArray>

--- a/src/ocm/components/clusterConfiguration/staticIp/components/YamlView/YamlViewFields.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/components/YamlView/YamlViewFields.tsx
@@ -7,6 +7,7 @@ import StaticIpHostsArray, { HostComponentProps } from '../StaticIpHostsArray';
 import HostSummary from '../CollapsedHost';
 import { MacIpMapping } from './MacIpMapping';
 import { getEmptyYamlHost } from '../../data/emptyData';
+import useClusterPermissions from '../../../../../hooks/useClusterPermissions';
 
 const CollapsedHost: React.FC<HostComponentProps> = ({ fieldName, hostIdx }) => {
   const mapFieldName = `${fieldName}.macInterfaceMap`;
@@ -35,7 +36,8 @@ const CollapsedHost: React.FC<HostComponentProps> = ({ fieldName, hostIdx }) => 
   );
 };
 
-const ExpandedHost: React.FC<HostComponentProps> = ({ fieldName, hostIdx }) => {
+const ExpandedHost = ({ fieldName, hostIdx }: HostComponentProps) => {
+  const { isViewerMode } = useClusterPermissions();
   const mapFieldName = `${fieldName}.macInterfaceMap`;
   const [mapField] = useField<HostStaticNetworkConfig['macInterfaceMap']>({
     name: mapFieldName,
@@ -48,6 +50,7 @@ const ExpandedHost: React.FC<HostComponentProps> = ({ fieldName, hostIdx }) => {
           language={Language.yaml}
           name={`${fieldName}.networkYaml`}
           data-testid={`yaml-${hostIdx}`}
+          isDisabled={isViewerMode}
         />
       </FormGroup>
       <FormGroup
@@ -58,6 +61,7 @@ const ExpandedHost: React.FC<HostComponentProps> = ({ fieldName, hostIdx }) => {
           fieldName={mapFieldName}
           macInterfaceMap={macInterfaceMap}
           hostIdx={hostIdx}
+          isDisabled={isViewerMode}
         />
       </FormGroup>
     </>

--- a/src/ocm/components/clusterDetail/AssistedInstallerDetailCard.tsx
+++ b/src/ocm/components/clusterDetail/AssistedInstallerDetailCard.tsx
@@ -11,7 +11,7 @@ import {
   ErrorState,
   LoadingState,
   FeatureListType,
-  AssistedInstallerPermissionTypesListType,
+  AssistedInstallerOCMPermissionTypesListType,
 } from '../../../common';
 import { useClusterPolling, useFetchCluster } from '../clusters/clusterPolling';
 import ClusterWizard from '../clusterWizard/ClusterWizard';
@@ -25,12 +25,11 @@ import { FeatureSupportLevelProvider } from '../featureSupportLevels';
 import useInfraEnv from '../../hooks/useInfraEnv';
 import { SentryErrorMonitorContextProvider } from '../SentryErrorMonitorContextProvider';
 import ClusterWizardContextProvider from '../clusterWizard/ClusterWizardContextProvider';
-import useClusterPermissions from '../../hooks/useClusterPermissions';
 
 type AssistedInstallerDetailCardProps = {
   aiClusterId: string;
   allEnabledFeatures: FeatureListType;
-  permissions?: AssistedInstallerPermissionTypesListType;
+  permissions?: AssistedInstallerOCMPermissionTypesListType;
 };
 
 const errorStateActions: React.ReactNode[] = [];

--- a/src/ocm/components/clusterDetail/AssistedInstallerDetailCard.tsx
+++ b/src/ocm/components/clusterDetail/AssistedInstallerDetailCard.tsx
@@ -11,6 +11,7 @@ import {
   ErrorState,
   LoadingState,
   FeatureListType,
+  AssistedInstallerPermissionTypesListType,
 } from '../../../common';
 import { useClusterPolling, useFetchCluster } from '../clusters/clusterPolling';
 import ClusterWizard from '../clusterWizard/ClusterWizard';
@@ -24,10 +25,12 @@ import { FeatureSupportLevelProvider } from '../featureSupportLevels';
 import useInfraEnv from '../../hooks/useInfraEnv';
 import { SentryErrorMonitorContextProvider } from '../SentryErrorMonitorContextProvider';
 import ClusterWizardContextProvider from '../clusterWizard/ClusterWizardContextProvider';
+import useClusterPermissions from '../../hooks/useClusterPermissions';
 
 type AssistedInstallerDetailCardProps = {
   aiClusterId: string;
   allEnabledFeatures: FeatureListType;
+  permissions?: AssistedInstallerPermissionTypesListType;
 };
 
 const errorStateActions: React.ReactNode[] = [];
@@ -92,6 +95,7 @@ const LoadingDefaultConfigFailedCard: React.FC = () => (
 const AssistedInstallerDetailCard: React.FC<AssistedInstallerDetailCardProps> = ({
   aiClusterId,
   allEnabledFeatures,
+  permissions,
 }) => {
   const fetchCluster = useFetchCluster(aiClusterId);
   const { cluster, uiState } = useClusterPolling(aiClusterId);
@@ -116,16 +120,17 @@ const AssistedInstallerDetailCard: React.FC<AssistedInstallerDetailCardProps> = 
     return null;
   }
 
-  let content;
-  if (['insufficient', 'ready', 'pending-for-input'].includes(cluster.status)) {
-    content = (
-      <ClusterWizardContextProvider cluster={cluster} infraEnv={infraEnv}>
+  const showWizard = ['insufficient', 'ready', 'pending-for-input'].includes(cluster.status);
+
+  const content = (
+    <ClusterWizardContextProvider cluster={cluster} infraEnv={infraEnv} permissions={permissions}>
+      {showWizard ? (
         <ClusterWizard cluster={cluster} infraEnv={infraEnv} updateInfraEnv={updateInfraEnv} />
-      </ClusterWizardContextProvider>
-    );
-  } else {
-    content = <ClusterInstallationProgressCard cluster={cluster} />;
-  }
+      ) : (
+        <ClusterInstallationProgressCard cluster={cluster} />
+      )}
+    </ClusterWizardContextProvider>
+  );
 
   return (
     <FeatureGateContextProvider features={allEnabledFeatures}>

--- a/src/ocm/components/clusterDetail/ClusterInstallationProgressCard.tsx
+++ b/src/ocm/components/clusterDetail/ClusterInstallationProgressCard.tsx
@@ -16,7 +16,7 @@ import ClusterDetailStatusVarieties, {
   useClusterStatusVarieties,
 } from './ClusterDetailStatusVarieties';
 
-const ClusterInstallationProgressCard: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
+const ClusterInstallationProgressCard = ({ cluster }: { cluster: Cluster }) => {
   const [isCardExpanded, setIsCardExpanded] = React.useState(cluster.status !== 'installed');
   const clusterVarieties = useClusterStatusVarieties(cluster);
 

--- a/src/ocm/components/clusterWizard/ClusterDetailsForm.tsx
+++ b/src/ocm/components/clusterWizard/ClusterDetailsForm.tsx
@@ -38,7 +38,7 @@ type ClusterDetailsFormProps = {
   handleClusterUpdate: (clusterId: Cluster['id'], params: V2ClusterUpdateParams) => Promise<void>;
 };
 
-const ClusterDetailsForm: React.FC<ClusterDetailsFormProps> = (props) => {
+const ClusterDetailsForm = (props: ClusterDetailsFormProps) => {
   const {
     cluster,
     infraEnv,
@@ -53,7 +53,9 @@ const ClusterDetailsForm: React.FC<ClusterDetailsFormProps> = (props) => {
   } = props;
 
   const { search } = useLocation();
-  const { isViewerMode } = useClusterPermissions();
+  // Allow creation of new clusters on Standalone UI configured with isViewerMode
+  const { isViewerMode: realViewerMode } = useClusterPermissions();
+  const isViewerMode = !!cluster && realViewerMode;
   const featureSupportLevels = useFeatureSupportLevel();
   const handleSubmit = React.useCallback(
     async (values: OcmClusterDetailsValues) => {

--- a/src/ocm/components/clusterWizard/ClusterWizard.tsx
+++ b/src/ocm/components/clusterWizard/ClusterWizard.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { Cluster, InfraEnv, InfraEnvUpdateParams, LoadingState } from '../../../common';
+import {
+  AssistedInstallerPermissionTypesListType,
+  Cluster,
+  InfraEnv,
+  InfraEnvUpdateParams,
+  LoadingState,
+} from '../../../common';
 import NetworkConfigurationPage from '../clusterConfiguration/networkConfiguration/NetworkConfigurationForm';
 import ReviewStep from '../clusterConfiguration/ReviewStep';
 import { useClusterWizardContext } from './ClusterWizardContext';
@@ -8,6 +14,7 @@ import HostDiscovery from './HostDiscovery';
 import StaticIp from './StaticIp';
 import classNames from 'classnames';
 import { WithErrorBoundary } from '../../../common/components/ErrorHandling/WithErrorBoundary';
+
 type ClusterWizardProps = {
   cluster: Cluster;
   infraEnv: InfraEnv;

--- a/src/ocm/components/clusterWizard/ClusterWizard.tsx
+++ b/src/ocm/components/clusterWizard/ClusterWizard.tsx
@@ -1,11 +1,5 @@
 import React from 'react';
-import {
-  AssistedInstallerPermissionTypesListType,
-  Cluster,
-  InfraEnv,
-  InfraEnvUpdateParams,
-  LoadingState,
-} from '../../../common';
+import { Cluster, InfraEnv, InfraEnvUpdateParams, LoadingState } from '../../../common';
 import NetworkConfigurationPage from '../clusterConfiguration/networkConfiguration/NetworkConfigurationForm';
 import ReviewStep from '../clusterConfiguration/ReviewStep';
 import { useClusterWizardContext } from './ClusterWizardContext';

--- a/src/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
+++ b/src/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
@@ -41,7 +41,7 @@ const ClusterWizardContextProvider: React.FC<
     const firstStepIds = getWizardStepIds(staticIpInfo?.view);
     setCurrentStepId(firstStep);
     setWizardStepIds(firstStepIds);
-    setPermissions(permissions);
+    setPermissions(permissions, cluster);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   const contextValue = React.useMemo<ClusterWizardContextType | null>(() => {

--- a/src/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
+++ b/src/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
@@ -11,9 +11,8 @@ import { Cluster, InfraEnv } from '../../../common/api';
 import { StaticIpView } from '../clusterConfiguration/staticIp/data/dataTypes';
 import { getStaticIpInfo } from '../clusterConfiguration/staticIp/data/fromInfraEnv';
 import isEqual from 'lodash/isEqual';
-import { AssistedInstallerPermissionTypesListType } from '../../../common';
+import { AssistedInstallerOCMPermissionTypesListType } from '../../../common';
 import useClusterPermissions from '../../hooks/useClusterPermissions';
-import { getBasePermissions } from '../../config/constants';
 
 const getWizardStepIds = (staticIpView?: StaticIpView): ClusterWizardStepsType[] => {
   const stepIds: ClusterWizardStepsType[] = [...defaultWizardSteps];
@@ -29,7 +28,7 @@ const ClusterWizardContextProvider: React.FC<
   PropsWithChildren<{
     cluster?: Cluster;
     infraEnv?: InfraEnv;
-    permissions?: AssistedInstallerPermissionTypesListType;
+    permissions?: AssistedInstallerOCMPermissionTypesListType;
   }>
 > = ({ children, cluster, infraEnv, permissions }) => {
   const [currentStepId, setCurrentStepId] = React.useState<ClusterWizardStepsType>();
@@ -42,12 +41,7 @@ const ClusterWizardContextProvider: React.FC<
     const firstStepIds = getWizardStepIds(staticIpInfo?.view);
     setCurrentStepId(firstStep);
     setWizardStepIds(firstStepIds);
-
-    setPermissions({
-      ...getBasePermissions(),
-      ...permissions,
-    });
-
+    setPermissions(permissions);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   const contextValue = React.useMemo<ClusterWizardContextType | null>(() => {

--- a/src/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
+++ b/src/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
@@ -11,6 +11,9 @@ import { Cluster, InfraEnv } from '../../../common/api';
 import { StaticIpView } from '../clusterConfiguration/staticIp/data/dataTypes';
 import { getStaticIpInfo } from '../clusterConfiguration/staticIp/data/fromInfraEnv';
 import isEqual from 'lodash/isEqual';
+import { AssistedInstallerPermissionTypesListType } from '../../../common';
+import useClusterPermissions from '../../hooks/useClusterPermissions';
+import { getBasePermissions } from '../../config/constants';
 
 const getWizardStepIds = (staticIpView?: StaticIpView): ClusterWizardStepsType[] => {
   const stepIds: ClusterWizardStepsType[] = [...defaultWizardSteps];
@@ -26,16 +29,25 @@ const ClusterWizardContextProvider: React.FC<
   PropsWithChildren<{
     cluster?: Cluster;
     infraEnv?: InfraEnv;
+    permissions?: AssistedInstallerPermissionTypesListType;
   }>
-> = ({ children, cluster, infraEnv }) => {
+> = ({ children, cluster, infraEnv, permissions }) => {
   const [currentStepId, setCurrentStepId] = React.useState<ClusterWizardStepsType>();
   const [wizardStepIds, setWizardStepIds] = React.useState<ClusterWizardStepsType[]>();
+  const { setPermissions } = useClusterPermissions();
+
   React.useEffect(() => {
     const staticIpInfo = infraEnv ? getStaticIpInfo(infraEnv) : undefined;
     const firstStep = getClusterWizardFirstStep(staticIpInfo, cluster?.status);
     const firstStepIds = getWizardStepIds(staticIpInfo?.view);
     setCurrentStepId(firstStep);
     setWizardStepIds(firstStepIds);
+
+    setPermissions({
+      ...getBasePermissions(),
+      ...permissions,
+    });
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   const contextValue = React.useMemo<ClusterWizardContextType | null>(() => {

--- a/src/ocm/components/clusterWizard/HostDiscovery.tsx
+++ b/src/ocm/components/clusterWizard/HostDiscovery.tsx
@@ -20,6 +20,7 @@ import ClusterWizardFooter from './ClusterWizardFooter';
 import ClusterWizardNavigation from './ClusterWizardNavigation';
 import { ClustersAPI } from '../../services/apis';
 import { HostDiscoveryService } from '../../services';
+import useClusterPermissions from '../../hooks/useClusterPermissions';
 
 const HostDiscoveryForm: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
   const { alerts } = useAlerts();
@@ -27,19 +28,21 @@ const HostDiscoveryForm: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
   const clusterWizardContext = useClusterWizardContext();
   const isAutoSaveRunning = useFormikAutoSave();
   const errorFields = getFormikErrorFields(errors, touched);
+  const { isViewerMode } = useClusterPermissions();
+
   const isNextDisabled =
-    !canNextHostDiscovery({ cluster }) ||
-    isAutoSaveRunning ||
     !isValid ||
     !!alerts.length ||
-    isSubmitting;
+    isAutoSaveRunning ||
+    isSubmitting ||
+    !canNextHostDiscovery({ cluster });
 
   const footer = (
     <ClusterWizardFooter
       cluster={cluster}
       errorFields={errorFields}
       isSubmitting={isSubmitting}
-      isNextDisabled={isNextDisabled}
+      isNextDisabled={!isViewerMode && isNextDisabled}
       onNext={() => clusterWizardContext.moveNext()}
       onBack={() => clusterWizardContext.moveBack()}
     />
@@ -55,13 +58,14 @@ const HostDiscoveryForm: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
 const HostDiscovery: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
   const dispatch = useDispatch();
   const { addAlert, clearAlerts } = useAlerts();
+  const { isViewerMode } = useClusterPermissions();
   const initialValues = React.useMemo(
     () => getHostDiscoveryInitialValues(cluster),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [], // just once, Formik does not reinitialize
   );
 
-  const handleSubmit: FormikConfig<HostDiscoveryValues>['onSubmit'] = async (values) => {
+  const onSubmit: FormikConfig<HostDiscoveryValues>['onSubmit'] = async (values) => {
     clearAlerts();
 
     const params: V2ClusterUpdateParams = {};
@@ -79,6 +83,7 @@ const HostDiscovery: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
     }
   };
 
+  const handleSubmit = isViewerMode ? () => Promise.resolve() : onSubmit;
   return (
     <Formik initialValues={initialValues} onSubmit={handleSubmit}>
       <HostDiscoveryForm cluster={cluster} />

--- a/src/ocm/components/clusterWizard/StaticIp.tsx
+++ b/src/ocm/components/clusterWizard/StaticIp.tsx
@@ -9,6 +9,7 @@ import {
 } from '../clusterConfiguration/staticIp/components/propTypes';
 import { StaticIpPage } from '../clusterConfiguration/staticIp/components/StaticIpPage';
 import { WithErrorBoundary } from '../../../common/components/ErrorHandling/WithErrorBoundary';
+import useClusterPermissions from '../../hooks/useClusterPermissions';
 
 const getInitialFormStateProps = () => {
   return {
@@ -26,13 +27,16 @@ const StaticIp: React.FC<StaticIpProps & { cluster: Cluster }> = ({
   updateInfraEnv,
 }) => {
   const clusterWizardContext = useClusterWizardContext();
+  const { isViewerMode } = useClusterPermissions();
   const { alerts } = useAlerts();
   const [formState, setFormStateProps] = React.useState<StaticIpFormState>(
     getInitialFormStateProps(),
   );
 
   const onFormStateChange = (formState: StaticIpFormState) => {
-    setFormStateProps(formState);
+    if (!isViewerMode) {
+      setFormStateProps(formState);
+    }
   };
 
   const isNextDisabled =
@@ -47,7 +51,7 @@ const StaticIp: React.FC<StaticIpProps & { cluster: Cluster }> = ({
       isSubmitting={formState.isSubmitting}
       onNext={() => clusterWizardContext.moveNext()}
       onBack={() => clusterWizardContext.moveBack()}
-      isNextDisabled={isNextDisabled}
+      isNextDisabled={!isViewerMode && isNextDisabled}
     />
   );
 

--- a/src/ocm/components/hosts/ClusterHostsTable.tsx
+++ b/src/ocm/components/hosts/ClusterHostsTable.tsx
@@ -18,6 +18,7 @@ import HostsTable from '../../../common/components/hosts/HostsTable';
 import { ExpandComponentProps } from '../../../common/components/hosts/AITable';
 import { UpdateDay2ApiVipDialogToggle } from './UpdateDay2ApiVipDialogToggle';
 import HostsTableEmptyState from '../hosts/HostsTableEmptyState';
+import useClusterPermissions from '../../hooks/useClusterPermissions';
 
 const ExpandComponent: React.FC<ExpandComponentProps<Host>> = ({ obj }) => {
   return (
@@ -34,9 +35,12 @@ export interface ClusterHostsTableProps {
   skipDisabled?: boolean;
 }
 
-const ClusterHostsTable: React.FC<ClusterHostsTableProps> = ({ cluster, skipDisabled }) => {
-  const { onEditHost, actionChecks, onEditRole, actionResolver, ...modalProps } =
-    useHostsTable(cluster);
+const ClusterHostsTable = ({ cluster, skipDisabled }: ClusterHostsTableProps) => {
+  const { isViewerMode } = useClusterPermissions();
+  const { onEditHost, actionChecks, onEditRole, actionResolver, ...modalProps } = useHostsTable(
+    cluster,
+    isViewerMode,
+  );
 
   const content = React.useMemo(
     () => [

--- a/src/ocm/components/hosts/HostsDiscoveryTable.tsx
+++ b/src/ocm/components/hosts/HostsDiscoveryTable.tsx
@@ -139,7 +139,7 @@ const HostsDiscoveryTable = ({ cluster, isDisabled }: HostsDiscoveryTableProps) 
             content={content}
             actionResolver={actionResolver}
             ExpandComponent={getExpandComponent(onDiskRole, actionChecks.canEditDisks)}
-            onSelect={showBulkActions ? undefined : onSelect}
+            onSelect={showBulkActions ? onSelect : undefined}
             selectedIDs={selectedHostIDs}
             setSelectedIDs={setSelectedHostIDs}
             {...paginationProps}

--- a/src/ocm/components/hosts/HostsDiscoveryTable.tsx
+++ b/src/ocm/components/hosts/HostsDiscoveryTable.tsx
@@ -77,10 +77,10 @@ const getExpandComponent =
 
 type HostsDiscoveryTableProps = {
   cluster: Cluster;
-  skipDisabled?: boolean;
+  isDisabled: boolean;
 };
 
-const HostsDiscoveryTable: React.FC<HostsDiscoveryTableProps> = ({ cluster }) => {
+const HostsDiscoveryTable = ({ cluster, isDisabled }: HostsDiscoveryTableProps) => {
   const {
     onEditHost,
     actionChecks,
@@ -93,7 +93,7 @@ const HostsDiscoveryTable: React.FC<HostsDiscoveryTableProps> = ({ cluster }) =>
     onMassChangeHostname,
     onMassDeleteHost,
     ...modalProps
-  } = useHostsTable(cluster);
+  } = useHostsTable(cluster, isDisabled);
 
   const isSNOCluster = isSNO(cluster);
   const content = React.useMemo(
@@ -113,11 +113,12 @@ const HostsDiscoveryTable: React.FC<HostsDiscoveryTableProps> = ({ cluster }) =>
   const hosts = cluster.hosts || [];
   const paginationProps = usePagination(hosts.length);
   const itemIDs = hosts.map((h) => h.id);
+  const showBulkActions = !isDisabled && !isSNOCluster;
 
   return (
     <>
       <Stack hasGutter>
-        {!isSNOCluster && (
+        {showBulkActions && (
           <StackItem>
             <TableToolbar
               selectedIDs={selectedHostIDs || []}
@@ -138,7 +139,7 @@ const HostsDiscoveryTable: React.FC<HostsDiscoveryTableProps> = ({ cluster }) =>
             content={content}
             actionResolver={actionResolver}
             ExpandComponent={getExpandComponent(onDiskRole, actionChecks.canEditDisks)}
-            onSelect={isSNOCluster ? undefined : onSelect}
+            onSelect={showBulkActions ? undefined : onSelect}
             selectedIDs={selectedHostIDs}
             setSelectedIDs={setSelectedHostIDs}
             {...paginationProps}

--- a/src/ocm/components/hosts/use-hosts-table.tsx
+++ b/src/ocm/components/hosts/use-hosts-table.tsx
@@ -50,7 +50,7 @@ import { UpdateDay2ApiVipFormProps } from './UpdateDay2ApiVipForm';
 import { ClustersAPI } from '../../services/apis';
 import { usePagination } from '../../../common/components/hosts/usePagination';
 
-export const useHostsTable = (cluster: Cluster) => {
+export const useHostsTable = (cluster: Cluster, isViewerMode: boolean) => {
   const { addAlert } = useAlerts();
   const {
     eventsDialog,
@@ -163,17 +163,17 @@ export const useHostsTable = (cluster: Cluster) => {
 
   const actionChecks = React.useMemo(
     () => ({
-      canEditRole: () => canEditRoleUtil(cluster),
-      canInstallHost: (host: Host) => canInstallHostUtil(cluster, host.status),
-      canEditDisks: (host: Host) => canEditDisksUtil(cluster.status, host.status),
-      canEnable: (host: Host) => canEnableUtil(cluster.status, host.status),
-      canDisable: (host: Host) => canDisableUtil(cluster.status, host.status),
-      canDelete: (host: Host) => canDeleteUtil(cluster.status, host.status),
-      canEditHost: (host: Host) => canEditHostUtil(cluster.status, host.status),
-      canReset: (host: Host) => canResetUtil(cluster.status, host.status),
-      canEditHostname: () => canEditHostnameUtil(cluster.status),
+      canEditRole: () => !isViewerMode && canEditRoleUtil(cluster),
+      canInstallHost: (host: Host) => !isViewerMode && canInstallHostUtil(cluster, host.status),
+      canEditDisks: (host: Host) => !isViewerMode && canEditDisksUtil(cluster.status, host.status),
+      canEnable: (host: Host) => !isViewerMode && canEnableUtil(cluster.status, host.status),
+      canDisable: (host: Host) => !isViewerMode && canDisableUtil(cluster.status, host.status),
+      canDelete: (host: Host) => !isViewerMode && canDeleteUtil(cluster.status, host.status),
+      canEditHost: (host: Host) => !isViewerMode && canEditHostUtil(cluster.status, host.status),
+      canReset: (host: Host) => !isViewerMode && canResetUtil(cluster.status, host.status),
+      canEditHostname: () => !isViewerMode && canEditHostnameUtil(cluster.status),
     }),
-    [cluster],
+    [cluster, isViewerMode],
   );
 
   const onReset = React.useCallback(() => {
@@ -297,7 +297,7 @@ export const useHostsTable = (cluster: Cluster) => {
     onDelete,
     onAdditionalNtpSource,
     onUpdateDay2ApiVip,
-    onSelect,
+    onSelect: isViewerMode ? undefined : onSelect,
     selectedHostIDs,
     setSelectedHostIDs,
     onMassChangeHostname,

--- a/src/ocm/config/constants.ts
+++ b/src/ocm/config/constants.ts
@@ -1,2 +1,10 @@
-export const isSingleClusterMode = () => process.env.REACT_APP_BUILD_MODE === 'single-cluster';
+export const isSingleClusterMode = () => {
+  return process.env.REACT_APP_BUILD_MODE === 'single-cluster';
+};
+export const getBasePermissions = () => {
+  if (!process.env.REACT_APP_CLUSTER_PERMISSIONS) {
+    return { canEdit: true };
+  }
+  return JSON.parse(process.env.REACT_APP_CLUSTER_PERMISSIONS);
+};
 export const OCM_CLUSTER_LIST_LINK = '/openshift'; // TODO(mlibra): Tweak it!!!

--- a/src/ocm/config/constants.ts
+++ b/src/ocm/config/constants.ts
@@ -1,10 +1,32 @@
+import {
+  AssistedInstallerOCMPermissionTypesListType,
+  AssistedInstallerPermissionTypesListType,
+} from '../../common';
+
 export const isSingleClusterMode = () => {
   return process.env.REACT_APP_BUILD_MODE === 'single-cluster';
 };
-export const getBasePermissions = () => {
+
+export const getBasePermissions = (): AssistedInstallerPermissionTypesListType => {
+  const basePermissions = { isViewerMode: false };
   if (!process.env.REACT_APP_CLUSTER_PERMISSIONS) {
-    return { canEdit: true };
+    return basePermissions;
   }
-  return JSON.parse(process.env.REACT_APP_CLUSTER_PERMISSIONS);
+  const ocmPermissions = JSON.parse(process.env.REACT_APP_CLUSTER_PERMISSIONS);
+  return {
+    ...basePermissions,
+    ...ocmPermissionsToAIPermissions(ocmPermissions),
+  };
 };
+
+export const ocmPermissionsToAIPermissions = (
+  ocmPermissions: AssistedInstallerOCMPermissionTypesListType,
+): Partial<AssistedInstallerPermissionTypesListType> => {
+  const permissions: Partial<AssistedInstallerPermissionTypesListType> = {};
+  if (ocmPermissions.canEdit !== undefined) {
+    permissions.isViewerMode = !ocmPermissions.canEdit;
+  }
+  return permissions;
+};
+
 export const OCM_CLUSTER_LIST_LINK = '/openshift'; // TODO(mlibra): Tweak it!!!

--- a/src/ocm/config/constants.ts
+++ b/src/ocm/config/constants.ts
@@ -1,18 +1,31 @@
 import {
   AssistedInstallerOCMPermissionTypesListType,
   AssistedInstallerPermissionTypesListType,
+  Cluster,
 } from '../../common';
 
 export const isSingleClusterMode = () => {
   return process.env.REACT_APP_BUILD_MODE === 'single-cluster';
 };
 
-export const getBasePermissions = (): AssistedInstallerPermissionTypesListType => {
+/* Used from e2e tests so we can mock the permissions */
+export type ExtendedCluster = Cluster & {
+  permissions: AssistedInstallerOCMPermissionTypesListType;
+};
+
+export const getBasePermissions = (
+  cluster?: ExtendedCluster,
+): AssistedInstallerPermissionTypesListType => {
+  if (cluster?.permissions) {
+    return { isViewerMode: !cluster.permissions.canEdit };
+  }
+
   const basePermissions = { isViewerMode: false };
   if (!process.env.REACT_APP_CLUSTER_PERMISSIONS) {
     return basePermissions;
   }
   const ocmPermissions = JSON.parse(process.env.REACT_APP_CLUSTER_PERMISSIONS);
+
   return {
     ...basePermissions,
     ...ocmPermissionsToAIPermissions(ocmPermissions),

--- a/src/ocm/hooks/useClusterPermissions.ts
+++ b/src/ocm/hooks/useClusterPermissions.ts
@@ -1,0 +1,11 @@
+import React from 'react';
+import { AssistedInstallerPermissionTypesListType } from '../../common';
+
+export default function useClusterPermissions() {
+  const [permissions, setPermissions] = React.useState<AssistedInstallerPermissionTypesListType>();
+
+  return {
+    isViewerMode: !permissions?.canEdit,
+    setPermissions,
+  };
+}

--- a/src/ocm/hooks/useClusterPermissions.ts
+++ b/src/ocm/hooks/useClusterPermissions.ts
@@ -1,6 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux';
-import { AssistedInstallerOCMPermissionTypesListType } from '../../common';
-import { getBasePermissions, ocmPermissionsToAIPermissions } from '../config';
+import { AssistedInstallerOCMPermissionTypesListType, Cluster } from '../../common';
+import { ExtendedCluster, getBasePermissions, ocmPermissionsToAIPermissions } from '../config';
 import { updateClusterPermissions } from '../reducers/clusters';
 import { selectCurrentClusterState } from '../selectors';
 
@@ -9,8 +9,11 @@ export default function useClusterPermissions() {
 
   const { permissions } = useSelector(selectCurrentClusterState);
 
-  const updatePermissions = (ocmPermissions?: AssistedInstallerOCMPermissionTypesListType) => {
-    let newPermissions = getBasePermissions();
+  const updatePermissions = (
+    ocmPermissions?: AssistedInstallerOCMPermissionTypesListType,
+    cluster?: Cluster,
+  ) => {
+    let newPermissions = getBasePermissions(cluster as ExtendedCluster);
     if (ocmPermissions) {
       newPermissions = {
         ...newPermissions,

--- a/src/ocm/hooks/useClusterPermissions.ts
+++ b/src/ocm/hooks/useClusterPermissions.ts
@@ -1,11 +1,27 @@
-import React from 'react';
-import { AssistedInstallerPermissionTypesListType } from '../../common';
+import { useDispatch, useSelector } from 'react-redux';
+import { AssistedInstallerOCMPermissionTypesListType } from '../../common';
+import { getBasePermissions, ocmPermissionsToAIPermissions } from '../config';
+import { updateClusterPermissions } from '../reducers/clusters';
+import { selectCurrentClusterState } from '../selectors';
 
 export default function useClusterPermissions() {
-  const [permissions, setPermissions] = React.useState<AssistedInstallerPermissionTypesListType>();
+  const dispatch = useDispatch();
+
+  const { permissions } = useSelector(selectCurrentClusterState);
+
+  const updatePermissions = (ocmPermissions?: AssistedInstallerOCMPermissionTypesListType) => {
+    let newPermissions = getBasePermissions();
+    if (ocmPermissions) {
+      newPermissions = {
+        ...newPermissions,
+        ...ocmPermissionsToAIPermissions(ocmPermissions || {}),
+      };
+    }
+    dispatch(updateClusterPermissions(newPermissions));
+  };
 
   return {
-    isViewerMode: !permissions?.canEdit,
-    setPermissions,
+    ...permissions,
+    setPermissions: updatePermissions,
   };
 }

--- a/src/ocm/reducers/clusters/currentClusterSlice.ts
+++ b/src/ocm/reducers/clusters/currentClusterSlice.ts
@@ -1,7 +1,7 @@
 import findIndex from 'lodash/findIndex';
 import set from 'lodash/set';
 import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
-import { Cluster, Host } from '../../../common';
+import { AssistedInstallerPermissionTypesListType, Cluster, Host } from '../../../common';
 import { handleApiError } from '../../api/utils';
 import { ResourceUIState } from '../../../common';
 import { ClustersAPI } from '../../services/apis';
@@ -16,6 +16,7 @@ type CurrentClusterStateSlice = {
   data?: Cluster;
   uiState: ResourceUIState;
   isReloadScheduled: number;
+  permissions: AssistedInstallerPermissionTypesListType;
   errorDetail?: RetrievalErrorType;
 };
 
@@ -41,6 +42,7 @@ export const fetchClusterAsync = createAsyncThunk<
 const initialState: CurrentClusterStateSlice = {
   data: undefined,
   uiState: ResourceUIState.LOADING,
+  permissions: { isViewerMode: false },
   errorDetail: undefined,
   isReloadScheduled: 0,
 };
@@ -74,6 +76,13 @@ export const currentClusterSlice = createSlice({
       ...state,
       isReloadScheduled: 0,
     }),
+    updateClusterPermissions: (
+      state,
+      action: PayloadAction<AssistedInstallerPermissionTypesListType>,
+    ) => ({
+      ...state,
+      permissions: action.payload,
+    }),
   },
   extraReducers: (builder) => {
     builder
@@ -104,5 +113,6 @@ export const {
   cleanCluster,
   forceReload,
   cancelForceReload,
+  updateClusterPermissions,
 } = currentClusterSlice.actions;
 export default currentClusterSlice.reducer;


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-10110

### Related PRs:
https://github.com/openshift-assisted/assisted-ui/pull/569  (mostly for documentation purposes)
https://gitlab.cee.redhat.com/service/uhc-portal/-/merge_requests/3398  (for the real behaviour on OCM)

### Description
When users other that the cluster owner are accessing assisted installer, they may not have edit permissions. Therefore the UI should not allow them to edit the cluster in any way, only to see the wizard and navigate through it.

There are different ways to do it depending on the application:

1. For standalone UI, we simulate this behaviour by defining a new Environment variable in `assisted-ui`.
The variable name is `REACT_APP_CLUSTER_PERMISSIONS`. See the README in `assisted-ui` for more details.
https://github.com/celdrake/assisted-ui/blob/MGMG-10110-read-only-cluster/README.md

When `canEdit` is set to `false`,  fields on the wizard become disabled for existing clusters, and the user can move to the next steps even if there are errors in previous ones. No PATCH should happen on the cluster.

2. For OCM, we receive the actual permissions from the subscription details.


**Note** This PR only covers Day 1 wizard. Day 2 would be separate to keep the PR smaller.
