### PR TITLE
MGMT-10674: Change the wording of the SNO notification

### DIFF
--- a/src/common/components/clusterConfiguration/SNODisclaimer.tsx
+++ b/src/common/components/clusterConfiguration/SNODisclaimer.tsx
@@ -18,7 +18,7 @@ const SNODisclaimer = ({ isDisabled = false, snoSupportLevel }: SNODisclaimerPro
       <ListItem>
         Installing SNO will result in a non-highly available OpenShift deployment.
       </ListItem>
-      <ListItem>Adding additional machines to your cluster is currently out of scope.</ListItem>
+      <ListItem>Adding additional machines to your cluster is currently not supported.</ListItem>
     </>
   );
   const unsupportedWarnings = (


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-10674

The wording changed from "Adding additional machines to your cluster is currently out of
scope." to "Adding additional machines to your cluster is currently not supported."