### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,7 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*        @openshift-assisted/ui-dev
+/src/cim/    @openshift-assisted/ui-dev-cim
+/src/ocm/    @openshift-assisted/ui-dev-ocm


### PR DESCRIPTION
Adding CODEOWNERS in order to enforce at least 2 reviewers from each team on shared changes

## See:
- [About code owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)