### PR TITLE
MGMT-10636 Allow to set-up an SNO with Dual-Stack

### DIFF
--- a/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
@@ -67,7 +67,8 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
   const clusterFeatureSupportLevels = React.useMemo(() => {
     return getLimitedFeatureSupportLevels(cluster, featureSupportLevelData);
   }, [cluster, featureSupportLevelData]);
-  const isMultiNodeCluster = !isSNO(cluster);
+  const isSNOCluster = isSNO(cluster);
+  const isMultiNodeCluster = !isSNOCluster;
   const isUserManagedNetworking = values.managedNetworkingType === 'userManaged';
   const isDualStack = values.stackType === DUAL_STACK;
 
@@ -78,10 +79,10 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
 
   const { defaultNetworkType, isSDNSelectable } = React.useMemo(() => {
     return {
-      defaultNetworkType: getDefaultNetworkType(!isMultiNodeCluster, isDualStack),
-      isSDNSelectable: canSelectNetworkTypeSDN(!isMultiNodeCluster, isDualStack),
+      defaultNetworkType: getDefaultNetworkType(isSNOCluster, isDualStack),
+      isSDNSelectable: canSelectNetworkTypeSDN(isSNOCluster, isDualStack),
     };
-  }, [isMultiNodeCluster, isDualStack]);
+  }, [isSNOCluster, isDualStack]);
 
   const [isAdvanced, setAdvanced] = React.useState(
     isAdvNetworkConf(cluster, defaultNetworkSettings, defaultNetworkType) || isDualStack,
@@ -118,14 +119,14 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
       if (!checked) {
         setFieldValue('clusterNetworks', defaultNetworkSettings.clusterNetworks, true);
         setFieldValue('serviceNetworks', defaultNetworkSettings.serviceNetworks, true);
-        setFieldValue('networkType', getDefaultNetworkType(!isMultiNodeCluster, isDualStack));
+        setFieldValue('networkType', getDefaultNetworkType(isSNOCluster, isDualStack));
       }
     },
     [
       setFieldValue,
       defaultNetworkSettings.clusterNetworks,
       defaultNetworkSettings.serviceNetworks,
-      isMultiNodeCluster,
+      isSNOCluster,
       isDualStack,
     ],
   );
@@ -164,10 +165,11 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
         clusterFeatureSupportLevels['CLUSTER_MANAGED_NETWORKING_WITH_VMS'] === 'unsupported' &&
         vmsAlert}
 
-      {!isUserManagedNetworking && (
+      {(isSNOCluster || !isUserManagedNetworking) && (
         <StackTypeControlGroup
           clusterId={cluster.id}
           isDualStackSelectable={isDualStackSelectable}
+          isSNO={isSNOCluster}
         />
       )}
 

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/StackTypeControl.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/StackTypeControl.tsx
@@ -3,26 +3,26 @@ import { ButtonVariant, FormGroup, Tooltip } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
 import { Cluster } from '../../../../common/api/types';
 import { NetworkConfigurationValues } from '../../../../common/types';
-import {
-  DUAL_STACK,
-  IPV4_STACK,
-  NETWORK_TYPE_OVN,
-  NETWORK_TYPE_SDN,
-  NO_SUBNET_SET,
-} from '../../../../common/config/constants';
+import { DUAL_STACK, IPV4_STACK, NO_SUBNET_SET } from '../../../../common/config/constants';
 import { getFieldId } from '../../../../common/components/ui/formik/utils';
 import { ConfirmationModal, PopoverIcon, RadioField } from '../../../../common/components/ui';
+import { getDefaultNetworkType, isSNO } from '../../../../common';
 
-export const StackTypeControlGroup: React.FC<{
+export const StackTypeControlGroup = ({
+  clusterId,
+  isSNO,
+  isDualStackSelectable,
+}: {
   clusterId: Cluster['id'];
   isDualStackSelectable: boolean;
-}> = ({ clusterId, isDualStackSelectable }) => {
+  isSNO: boolean;
+}) => {
   const { setFieldValue, values, validateForm } = useFormikContext<NetworkConfigurationValues>();
   const [openConfirmModal, setConfirmModal] = React.useState(false);
 
   const setSingleStack = React.useCallback(() => {
     setFieldValue('stackType', IPV4_STACK);
-    setFieldValue('networkType', NETWORK_TYPE_SDN);
+    setFieldValue('networkType', getDefaultNetworkType(isSNO, false));
     setFieldValue('vipDhcpAllocation', true);
 
     if (values.machineNetworks && values.machineNetworks?.length >= 2) {
@@ -46,7 +46,7 @@ export const StackTypeControlGroup: React.FC<{
 
   const setDualStack = () => {
     setFieldValue('stackType', DUAL_STACK);
-    setFieldValue('networkType', NETWORK_TYPE_OVN);
+    setFieldValue('networkType', getDefaultNetworkType(isSNO, true));
     setFieldValue('vipDhcpAllocation', false);
 
     if (values.machineNetworks && values.machineNetworks?.length < 2) {


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-10636

- Enable the StackType selector when the cluster is an SNO
- Patch netwokType when changing the stackType to the default for that cluster's configuration:
   * If the cluster is an SNO (Single Stack or Dual Stack), OVNKubernetes is mandatory .
   * If the cluster is a multi-cluster using Dual Stack, the default value is OVNKubernetes.
   * If the cluster is a multi-cluster using Single Stack, the default value is SDN.

Installed cluster using SNO + Dual Stack:
![sno-dual-stack](https://user-images.githubusercontent.com/829045/174056451-91e1df9f-0827-4ece-b0c7-7a9d4d270c3a.png)

