### PR TITLE
MGMT-10663 auto assign role

### DIFF
--- a/src/common/components/hosts/RoleCell.tsx
+++ b/src/common/components/hosts/RoleCell.tsx
@@ -11,17 +11,25 @@ export type RoleCellProps = {
   onEditRole?: (role: HostUpdateParams['hostRole']) => Promise<any>;
   displayTooltip?: boolean;
   position?: DropdownProps['position'];
+  schedulableMasters: boolean;
 };
 
-const RoleCell: React.FC<RoleCellProps> = ({
+const RoleCell = ({
   host,
   role,
   readonly = false,
+  schedulableMasters,
   onEditRole,
   position,
-}) =>
+}: RoleCellProps) =>
   !readonly && onEditRole ? (
-    <RoleDropdown host={host} onEditRole={onEditRole} current={role} position={position} />
+    <RoleDropdown
+      schedulableMasters={schedulableMasters}
+      host={host}
+      onEditRole={onEditRole}
+      current={role}
+      position={position}
+    />
   ) : (
     <span>{role}</span>
   );

--- a/src/common/components/hosts/RoleDropdown.tsx
+++ b/src/common/components/hosts/RoleDropdown.tsx
@@ -4,6 +4,7 @@ import { Host, HostUpdateParams } from '../../api';
 import { SimpleDropdown } from '../ui';
 import { useStateSafely } from '../../hooks';
 import { DropdownProps } from '@patternfly/react-core';
+import { HostRoleItem } from '../../types/hosts';
 
 type RoleDropdownProps = {
   host: Host;
@@ -11,9 +12,16 @@ type RoleDropdownProps = {
   onEditRole: (role: HostUpdateParams['hostRole']) => Promise<any>;
   current: string;
   position?: DropdownProps['position'];
+  schedulableMasters: boolean;
 };
 
-const RoleDropdown: React.FC<RoleDropdownProps> = ({ host, onEditRole, current, position }) => {
+const RoleDropdown = ({
+  host,
+  schedulableMasters,
+  onEditRole,
+  current,
+  position,
+}: RoleDropdownProps) => {
   const [isDisabled, setDisabled] = useStateSafely(false);
   const setRole = async (role?: string) => {
     setDisabled(true);
@@ -24,11 +32,21 @@ const RoleDropdown: React.FC<RoleDropdownProps> = ({ host, onEditRole, current, 
     }
   };
 
+  const roles: HostRoleItem[] = React.useMemo<HostRoleItem[]>(() => {
+    return HOST_ROLES.filter((hostRole) => {
+      if (schedulableMasters) {
+        return ['on', 'any'].includes(hostRole.schedulable_policy);
+      } else {
+        return ['off', 'any'].includes(hostRole.schedulable_policy);
+      }
+    });
+  }, [schedulableMasters]);
+
   return (
     <SimpleDropdown
-      defaultValue={HOST_ROLES[0].value}
+      items={roles}
+      defaultValue={roles[0].value}
       current={current}
-      items={HOST_ROLES}
       setValue={setRole}
       isDisabled={isDisabled}
       idPrefix={`role-${host.requestedHostname}`}

--- a/src/common/components/hosts/tableUtils.tsx
+++ b/src/common/components/hosts/tableUtils.tsx
@@ -14,7 +14,12 @@ import HostsCount from './HostsCount';
 import { HostsTableActions } from './types';
 import HostStatus from './HostStatus';
 import RoleCell from './RoleCell';
-import { areOnlySoftValidationsFailing, getHostname, getHostRole, getInventory } from './utils';
+import {
+  areOnlySoftValidationsFailing,
+  getHostname,
+  getHostRoleLabel,
+  getInventory,
+} from './utils';
 import { selectMachineNetworkCIDR } from '../../selectors/clusterSelectors';
 import { hostStatus } from './status';
 import { DropdownProps } from '@patternfly/react-core';
@@ -97,20 +102,21 @@ export const roleColumn = (
       const editRole = onEditRole
         ? (role: HostUpdateParams['hostRole']) => onEditRole(host, role)
         : undefined;
-      const hostRole = getHostRole(host, schedulableMasters);
+      const roleLabel = getHostRoleLabel(host, schedulableMasters);
       const isRoleEditable = canEditRole?.();
       return {
         title: (
           <RoleCell
             host={host}
             readonly={!isRoleEditable}
-            role={hostRole}
+            role={roleLabel}
+            schedulableMasters={schedulableMasters || false}
             onEditRole={editRole}
             position={position}
           />
         ),
         props: { 'data-testid': 'host-role' },
-        sortableValue: hostRole,
+        sortableValue: roleLabel,
       };
     },
   };

--- a/src/common/components/ui/SimpleDropdown.tsx
+++ b/src/common/components/ui/SimpleDropdown.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
 import { DropdownItem, DropdownToggle, Dropdown, DropdownProps } from '@patternfly/react-core';
 import { CaretDownIcon } from '@patternfly/react-icons';
-import { HostRole } from '../../../common/types/hosts';
+import { HostRoleItem } from '../../../common/types/hosts';
 
 type SimpleDropdownProps = {
   current?: string;
   defaultValue: string;
-  items: HostRole[];
+  items: HostRoleItem[];
   setValue: (value?: string) => void;
   isDisabled: boolean;
   idPrefix?: string;
   position?: DropdownProps['position'];
 };
 
-export const SimpleDropdown: React.FC<SimpleDropdownProps> = ({
+export const SimpleDropdown = ({
   current,
   defaultValue,
   items,
@@ -21,7 +21,7 @@ export const SimpleDropdown: React.FC<SimpleDropdownProps> = ({
   isDisabled,
   idPrefix,
   position,
-}) => {
+}: SimpleDropdownProps) => {
   const [isOpen, setOpen] = React.useState(false);
   const dropdownItems = items.map(({ value, label, description }) => (
     <DropdownItem key={value} id={value} description={description}>
@@ -43,8 +43,8 @@ export const SimpleDropdown: React.FC<SimpleDropdownProps> = ({
         onToggle={(val) => setOpen(!isDisabled && val)}
         toggleIndicator={CaretDownIcon}
         isDisabled={isDisabled}
+        isText
         id={idPrefix ? `${idPrefix}-dropdown-toggle-items` : undefined}
-        className="pf-m-text" // TODO(jtomasek): replace this with 'isText' prop once we update the PF
       >
         {current || defaultValue}
       </DropdownToggle>

--- a/src/common/config/constants.ts
+++ b/src/common/config/constants.ts
@@ -1,6 +1,6 @@
 import * as packageJson from '../../../package.json';
 
-import { ValidationsInfo, HostRole } from '../../common/types/hosts';
+import { ValidationsInfo, HostRoleItem } from '../../common/types/hosts';
 import { Cluster, ClusterValidationId, DiskRole, Event, HostValidationId } from '../api';
 import { ValidationGroup as ClusterValidationGroup } from '../types/clusters';
 
@@ -38,23 +38,26 @@ export const getProductBrandingCode = () => 'redhat';
 export const POLLING_INTERVAL = 10 * 1000;
 export const EVENTS_POLLING_INTERVAL = 10 * 1000;
 
-export const HOST_ROLES: HostRole[] = [
-  {
-    value: 'auto-assign',
-    label: 'Auto-assign',
-    description:
-      'A role will be chosen automatically based on detected hardware and network latency.',
-  },
+export const HOST_ROLES: HostRoleItem[] = [
   {
     value: 'master',
     label: 'Control plane node',
-    description: 'Runs the control plane components of OpenShift, including the API server.',
+    description: 'Runs the container orchestration layer (like API server, Scheduler etc).',
+    schedulable_policy: 'off',
+  },
+  {
+    value: 'master',
+    label: 'Control plane, worker',
+    description:
+      'Runs the container orchestration layer (like API server, Scheduler etc), and also runs the application workloads',
+    schedulable_policy: 'on',
   },
   {
     value: 'worker',
     label: 'Worker',
     description:
       'Runs application workloads. Connect at least 5 hosts to enable dedicated workers.',
+    schedulable_policy: 'any',
   },
 ];
 

--- a/src/common/config/constants.ts
+++ b/src/common/config/constants.ts
@@ -42,14 +42,14 @@ export const HOST_ROLES: HostRoleItem[] = [
   {
     value: 'master',
     label: 'Control plane node',
-    description: 'Runs the container orchestration layer (like API server, Scheduler etc).',
+    description: 'Runs the container orchestration layer (such as API server, Scheduler, and more)',
     schedulable_policy: 'off',
   },
   {
     value: 'master',
     label: 'Control plane, worker',
     description:
-      'Runs the container orchestration layer (like API server, Scheduler etc), and also runs the application workloads',
+      'Runs the container orchestration layer (such as API server, Scheduler, and more), and also the application workloads',
     schedulable_policy: 'on',
   },
   {

--- a/src/common/types/hosts.ts
+++ b/src/common/types/hosts.ts
@@ -18,8 +18,9 @@ export type ClusterWizardStepHostStatusDeterminationObject = {
   validationsInfo?: Host['validationsInfo'] | ValidationsInfo;
 };
 
-export type HostRole = {
+export type HostRoleItem = {
   value: HostRoleUpdateParams;
   label: string;
   description: string;
+  schedulable_policy: 'on' | 'off' | 'any';
 };


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-10663



When a host has the "auto-assign" role, we show whether it would be a  `control plane node` or a `worker` based on the `suggested_role`. To avoid confusion for the user, the label and description of the Dropdown items has changed:

- If the cluster has schedulable_masters on, then the label for "Control plane nodes" becomes  "Control plane, worker".
- If the cluster has schedulable_masters off, then the label for "Control plane nodes" stays the same
The description also takes into consideration the value of `schedulable_masters`

Dropdown items: label and description for `master` with `schedulable_masters`
![host-role-desc-master](https://user-images.githubusercontent.com/829045/174977679-d1b42764-9a31-4ac2-8371-520a0e8e8ed9.png)


Dropdown items: Label 
![host-role-master-worker](https://user-images.githubusercontent.com/829045/174977690-f9064e9a-47a5-4039-96ca-98c961a3f89a.png)

Dropdown toggle: 
![role-2-schedulable](https://user-images.githubusercontent.com/829045/174248403-e697c9ff-248c-418a-8d2d-cfdabe74d664.png)
 