### PR TITLE
NO_ISSUE: Generate errors for eslint - unused vars

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -76,6 +76,7 @@ module.exports = {
         '@typescript-eslint/no-unsafe-assignment': 'warn',
         '@typescript-eslint/no-unsafe-member-access': 'warn',
         '@typescript-eslint/no-unsafe-return': 'warn',
+        '@typescript-eslint/no-unused-vars': 'error',
         '@typescript-eslint/require-await': 'warn',
         '@typescript-eslint/restrict-plus-operands': 'warn',
         '@typescript-eslint/restrict-template-expressions': 'warn',

--- a/src/common/components/ui/formik/CodeField.tsx
+++ b/src/common/components/ui/formik/CodeField.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useField, useFormikContext } from 'formik';
+import { useField } from 'formik';
 import { FormGroup, HelperTextItem } from '@patternfly/react-core';
 import { CodeFieldProps } from './types';
 import { getFieldId } from './utils';

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/StackTypeControl.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/StackTypeControl.tsx
@@ -6,7 +6,7 @@ import { NetworkConfigurationValues } from '../../../../common/types';
 import { DUAL_STACK, IPV4_STACK, NO_SUBNET_SET } from '../../../../common/config/constants';
 import { getFieldId } from '../../../../common/components/ui/formik/utils';
 import { ConfirmationModal, PopoverIcon, RadioField } from '../../../../common/components/ui';
-import { getDefaultNetworkType, isSNO } from '../../../../common';
+import { getDefaultNetworkType } from '../../../../common';
 
 export const StackTypeControlGroup = ({
   clusterId,

--- a/src/ocm/components/clusterWizard/ClusterWizardFooter.tsx
+++ b/src/ocm/components/clusterWizard/ClusterWizardFooter.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { Alert, AlertGroup, AlertVariant } from '@patternfly/react-core';
 import {


### PR DESCRIPTION
- Added Eslint rule for `unused vars`

This would catch both unused imports in our code, as well as unused variables.

Currently there were 3 unused imports which were reported as errors and fixed.