### PR TITLE
NO_ISSUE: reduce eslint warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -86,7 +86,6 @@ module.exports = {
         '@typescript-eslint/no-unsafe-member-access': 'warn',
         '@typescript-eslint/no-unsafe-return': 'warn',
         '@typescript-eslint/no-unused-vars': 'error',
-        '@typescript-eslint/require-await': 'warn',
         '@typescript-eslint/restrict-template-expressions': 'warn',
         'react-hooks/rules-of-hooks': 'error',
         'react-hooks/exhaustive-deps': 'warn',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -87,7 +87,6 @@ module.exports = {
         '@typescript-eslint/no-unsafe-return': 'warn',
         '@typescript-eslint/no-unused-vars': 'error',
         '@typescript-eslint/require-await': 'warn',
-        '@typescript-eslint/restrict-plus-operands': 'warn',
         '@typescript-eslint/restrict-template-expressions': 'warn',
         'react-hooks/rules-of-hooks': 'error',
         'react-hooks/exhaustive-deps': 'warn',

--- a/src/common/components/clusterDetail/ClusterProgress.tsx
+++ b/src/common/components/clusterDetail/ClusterProgress.tsx
@@ -81,8 +81,8 @@ const ClusterProgress = ({
       </DetailList>
       <RenderIf condition={!minimizedView}>
         <Progress
-          value={totalPercentage}
-          label={`${totalPercentage}%`}
+          value={totalPercentage || 0}
+          label={`${totalPercentage || 0}%`}
           title=" "
           measureLocation={getMeasureLocation(status)}
           variant={getProgressVariant(status)}

--- a/src/common/components/clusterDetail/KubeconfigDownload.tsx
+++ b/src/common/components/clusterDetail/KubeconfigDownload.tsx
@@ -46,7 +46,7 @@ const KubeconfigDownload: React.FC<KubeconfigDownloadProps> = ({
           saveAs(response.data, fileName);
         }
       } catch (e) {
-        handleApiError(e, async (e) => {
+        handleApiError(e, (e) => {
           addAlert({ title: 'Could not download kubeconfig', message: getApiErrorMessage(e) });
         });
       }

--- a/src/common/components/hosts/AdditionalNTPSourcesDialog.tsx
+++ b/src/common/components/hosts/AdditionalNTPSourcesDialog.tsx
@@ -41,7 +41,7 @@ const AdditionalNTPSourcesForm: React.FC<AdditionalNTPSourcesFormProps> = ({
     additionalNtpSource: ntpSourceValidationSchema.required(),
   });
 
-  const handleSubmit = async (
+  const handleSubmit = (
     values: V2ClusterUpdateParams,
     formikHelpers: FormikHelpers<V2ClusterUpdateParams>,
   ) => {

--- a/src/common/components/hosts/HostProgress.tsx
+++ b/src/common/components/hosts/HostProgress.tsx
@@ -23,16 +23,12 @@ const getProgressVariant = (status: Host['status']) => {
 const getMeasureLocation = (status: Host['status']) =>
   status === 'installed' ? ProgressMeasureLocation.none : ProgressMeasureLocation.top;
 
-type HostProgressProps = {
-  host: Host;
-};
-
-const HostProgress: React.FC<HostProgressProps> = ({ host }) => {
+const HostProgress = ({ host }: { host: Host }) => {
   const { status } = host;
   const stages = getHostProgressStages(host);
   const { currentStage, progressInfo } = getHostProgress(host);
   const currentStageNumber = getHostProgressStageNumber(host);
-  const progressLabel = currentStage + (progressInfo ? `: ${progressInfo}` : ' ');
+  const progressLabel = `${currentStage}${progressInfo ? `: ${progressInfo}` : ' '}`;
 
   return (
     <Progress

--- a/src/common/components/ui/EventsList.tsx
+++ b/src/common/components/ui/EventsList.tsx
@@ -14,6 +14,7 @@ import { getHumanizedDateTime } from './utils';
 import { fitContent, noPadding } from './table';
 
 const getEventRowKey = ({ rowData }: ExtraParamsType) =>
+  // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
   rowData?.props?.event.sortableTime + rowData?.props?.event.message;
 
 const getLabelColor = (severity: Event['severity']) => {

--- a/src/common/components/ui/formik/NumberInputField.tsx
+++ b/src/common/components/ui/formik/NumberInputField.tsx
@@ -24,7 +24,10 @@ const NumberInputField: React.FC<NumberInputFieldProps> = React.forwardRef(
     },
     ref: React.Ref<HTMLInputElement>,
   ) => {
-    const [field, { touched, error }, { setValue }] = useField({ name: props.name, validate });
+    const [field, { touched, error }, { setValue }] = useField<number>({
+      name: props.name,
+      validate,
+    });
     const fieldId = getFieldId(props.name, 'numberinput', idPostfix);
     const isValid = !(touched && error);
     const errorMessage = !isValid ? error : '';

--- a/src/common/hooks/useFormikHelpers.ts
+++ b/src/common/hooks/useFormikHelpers.ts
@@ -14,6 +14,7 @@ export const useFormikHelpers = <R>(fieldID: string) => {
   const setTouchedRef = React.useRef(setTouched);
   setTouchedRef.current = setTouched;
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   const setFieldValue = React.useCallback(async (value: R, shouldValidate?: boolean) => {
     setValueRef.current(value, shouldValidate);
   }, []);

--- a/src/ocm/components/SingleCluster.tsx
+++ b/src/ocm/components/SingleCluster.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Redirect, RouteComponentProps } from 'react-router-dom';
+import { Redirect } from 'react-router-dom';
 import { PageSectionVariants, PageSection } from '@patternfly/react-core';
 import { Cluster, ErrorState, LoadingState } from '../../common';
 import { routeBasePath } from '../config';
@@ -7,9 +7,7 @@ import { NewClusterPage } from './clusters';
 import { ClustersAPI } from '../services/apis';
 import { handleApiError } from '../api';
 
-type SingleClusterProps = RouteComponentProps;
-
-const SingleCluster: React.FC<SingleClusterProps> = () => {
+const SingleCluster = () => {
   const [error, setError] = React.useState('');
   const [clusters, setClusters] = React.useState<Cluster[]>();
 

--- a/src/ocm/components/clusterConfiguration/staticIp/components/StaticIpViewRadioGroup.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/components/StaticIpViewRadioGroup.tsx
@@ -18,7 +18,7 @@ const StaticIpViewRadioGroup: React.FC<StaticIpViewRadioGroupProps> = ({
   const GROUP_NAME = 'select-static-ip-view';
   const [confirmView, setConfirmView] = React.useState<StaticIpView>();
   const [view, setView] = React.useState<StaticIpView>(initialView);
-  const handleChange = (checked: boolean, event: React.FormEvent<HTMLInputElement>) => {
+  const handleChange = (_checked: boolean, event: React.FormEvent<HTMLInputElement>) => {
     const selectedView = event.currentTarget.value as StaticIpView;
     if (confirmOnChangeView) {
       setConfirmView(selectedView);
@@ -28,7 +28,7 @@ const StaticIpViewRadioGroup: React.FC<StaticIpViewRadioGroupProps> = ({
     }
   };
 
-  const onConfirm = async (selectedView: StaticIpView) => {
+  const onConfirm = (selectedView: StaticIpView) => {
     setView(selectedView);
     setConfirmView(undefined);
     onChangeView(selectedView);

--- a/src/ocm/components/clusterConfiguration/staticIp/data/machineNetwork.ts
+++ b/src/ocm/components/clusterConfiguration/staticIp/data/machineNetwork.ts
@@ -1,5 +1,5 @@
 import { Cidr } from './dataTypes';
 
 export const getMachineNetworkCidr = (machineNetwork: Cidr) => {
-  return machineNetwork.ip + '/' + machineNetwork.prefixLength;
+  return `${machineNetwork.ip}/${machineNetwork.prefixLength}`;
 };

--- a/src/ocm/components/clusterDetail/ClusterDetailStatusVarieties.tsx
+++ b/src/ocm/components/clusterDetail/ClusterDetailStatusVarieties.tsx
@@ -11,23 +11,20 @@ import { getClusterDetailId } from './utils';
 import { ClustersAPI } from '../../services/apis';
 import ClusterDetailStatusMessages from './ClusterDetailStatusMessages';
 import { Grid } from '@patternfly/react-core';
-import { APIErrorMixin } from '../../api/types';
+import { getErrorMessage } from '../../api';
 
 type ClusterStatusVarieties = {
   credentials?: Credentials;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  credentialsError?: any;
+  credentialsError: string;
   olmOperators: MonitoredOperatorsList;
   failedOlmOperators: MonitoredOperatorsList;
   consoleOperator?: MonitoredOperator;
   fetchCredentials: () => void;
 };
 
-type ErrorType = APIErrorMixin & Error;
-
 export const useClusterStatusVarieties = (cluster?: Cluster): ClusterStatusVarieties => {
   const [credentials, setCredentials] = React.useState<Credentials>();
-  const [credentialsError, setCredentialsError] = React.useState<ErrorType>();
+  const [credentialsError, setCredentialsError] = React.useState('');
 
   const clusterId = cluster?.id;
   const clusterStatus = cluster?.status;
@@ -42,7 +39,7 @@ export const useClusterStatusVarieties = (cluster?: Cluster): ClusterStatusVarie
 
   const fetchCredentials = React.useCallback(() => {
     const fetch = async () => {
-      setCredentialsError(undefined);
+      setCredentialsError('');
       if (!clusterId) {
         return;
       }
@@ -50,7 +47,7 @@ export const useClusterStatusVarieties = (cluster?: Cluster): ClusterStatusVarie
         const response = await ClustersAPI.getCredentials(clusterId);
         setCredentials(response.data);
       } catch (err) {
-        setCredentialsError(err as ErrorType);
+        setCredentialsError(getErrorMessage(err));
       }
     };
     fetch();

--- a/src/ocm/components/clusterDetail/ClusterDetailStatusVarieties.tsx
+++ b/src/ocm/components/clusterDetail/ClusterDetailStatusVarieties.tsx
@@ -11,6 +11,7 @@ import { getClusterDetailId } from './utils';
 import { ClustersAPI } from '../../services/apis';
 import ClusterDetailStatusMessages from './ClusterDetailStatusMessages';
 import { Grid } from '@patternfly/react-core';
+import { APIErrorMixin } from '../../api/types';
 
 type ClusterStatusVarieties = {
   credentials?: Credentials;
@@ -22,9 +23,11 @@ type ClusterStatusVarieties = {
   fetchCredentials: () => void;
 };
 
+type ErrorType = APIErrorMixin & Error;
+
 export const useClusterStatusVarieties = (cluster?: Cluster): ClusterStatusVarieties => {
   const [credentials, setCredentials] = React.useState<Credentials>();
-  const [credentialsError, setCredentialsError] = React.useState();
+  const [credentialsError, setCredentialsError] = React.useState<ErrorType>();
 
   const clusterId = cluster?.id;
   const clusterStatus = cluster?.status;
@@ -47,7 +50,7 @@ export const useClusterStatusVarieties = (cluster?: Cluster): ClusterStatusVarie
         const response = await ClustersAPI.getCredentials(clusterId);
         setCredentials(response.data);
       } catch (err) {
-        setCredentialsError(err);
+        setCredentialsError(err as ErrorType);
       }
     };
     fetch();

--- a/src/ocm/components/clusterDetail/ClusterDetailStatusVarieties.tsx
+++ b/src/ocm/components/clusterDetail/ClusterDetailStatusVarieties.tsx
@@ -11,7 +11,7 @@ import { getClusterDetailId } from './utils';
 import { ClustersAPI } from '../../services/apis';
 import ClusterDetailStatusMessages from './ClusterDetailStatusMessages';
 import { Grid } from '@patternfly/react-core';
-import { getErrorMessage } from '../../api';
+import { getErrorMessage } from '../../../common/utils';
 
 type ClusterStatusVarieties = {
   credentials?: Credentials;

--- a/src/ocm/components/clusterDetail/utils.tsx
+++ b/src/ocm/components/clusterDetail/utils.tsx
@@ -30,7 +30,7 @@ export const downloadClusterInstallationLogs = async (
       saveAs(data, fileName);
     }
   } catch (e) {
-    handleApiError(e, async (e) => {
+    handleApiError(e, (e) => {
       addAlert({
         title: 'Could not download cluster installation logs.',
         message: getApiErrorMessage(e),

--- a/src/ocm/components/clusterDetail/utils.tsx
+++ b/src/ocm/components/clusterDetail/utils.tsx
@@ -72,6 +72,7 @@ const getClusterResources = (cluster: Cluster, resourcePath: string): number => 
     )
     .map((host) => stringToJSON<Inventory>(host.inventory) || {})
     .map((inventory) => get(inventory, resourcePath, 0))
+    // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
     .reduce((total, value) => total + value, 0);
 
   return result;

--- a/src/ocm/components/clusterDetail/utils.tsx
+++ b/src/ocm/components/clusterDetail/utils.tsx
@@ -71,8 +71,7 @@ const getClusterResources = (cluster: Cluster, resourcePath: string): number => 
         (host.role === 'master' && singleNodeMode),
     )
     .map((host) => stringToJSON<Inventory>(host.inventory) || {})
-    .map((inventory) => get(inventory, resourcePath, 0))
-    // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+    .map((inventory) => get(inventory, resourcePath, 0) as number)
     .reduce((total, value) => total + value, 0);
 
   return result;

--- a/src/ocm/components/hosts/DeleteHostModal.tsx
+++ b/src/ocm/components/hosts/DeleteHostModal.tsx
@@ -8,12 +8,7 @@ type DeleteHostModalProps = {
   onDelete: () => void;
 };
 
-const DeleteHostModal: React.FC<DeleteHostModalProps> = ({
-  isOpen,
-  hostname,
-  onClose,
-  onDelete,
-}) => (
+const DeleteHostModal = ({ isOpen, hostname, onClose, onDelete }: DeleteHostModalProps) => (
   <Modal
     title="Delete Host"
     isOpen={isOpen}
@@ -33,7 +28,7 @@ const DeleteHostModal: React.FC<DeleteHostModalProps> = ({
       </Button>,
     ]}
   >
-    Are you sure you want to delete host{` ${hostname}` || ''} ?
+    Are you sure you want to delete host{` ${hostname || ''}`} ?
   </Modal>
 );
 

--- a/src/ocm/components/hosts/ModalDialogsContext.tsx
+++ b/src/ocm/components/hosts/ModalDialogsContext.tsx
@@ -101,12 +101,13 @@ const ModalDialogsContextProvider: React.FC = ({ children }) => {
     dispatchDialogsAction(closeDialogAction({ dialogId }));
 
   const context = dialogIds.reduce((context, dialogId) => {
+    const dialogData: ModalDialogsDataTypes[typeof dialogId] = dialogsState[dialogId];
     context[dialogId] = {
-      isOpen: !!dialogsState[dialogId],
+      isOpen: !!dialogData,
       open: (data: ModalDialogsDataTypes[typeof dialogId]) =>
         getOpenDialog<ModalDialogsDataTypes[typeof dialogId]>(dialogId)(data),
       close: () => getCloseDialog(dialogId)(),
-      data: dialogsState[dialogId],
+      data: dialogData,
     };
     return context;
   }, {});

--- a/src/ocm/components/hosts/ResetHostModal.tsx
+++ b/src/ocm/components/hosts/ResetHostModal.tsx
@@ -28,7 +28,7 @@ const ResetHostModal: React.FC<ResetHostModalProps> = ({ isOpen, hostname, onClo
       </Button>,
     ]}
   >
-    Are you sure you want to reset host{` ${hostname}` || ''} ?
+    Are you sure you want to reset host{` ${hostname || ''}`} ?
   </Modal>
 );
 

--- a/src/ocm/components/hosts/utils.ts
+++ b/src/ocm/components/hosts/utils.ts
@@ -36,7 +36,7 @@ export const downloadHostInstallationLogs = async (
       saveAs(data, fileName);
     }
   } catch (e) {
-    handleApiError(e, async (e) => {
+    handleApiError(e, (e) => {
       addAlert({ title: 'Could not download host logs.', message: getApiErrorMessage(e) });
     });
   }

--- a/src/ocm/hooks/useInfraEnv.ts
+++ b/src/ocm/hooks/useInfraEnv.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useInfraEnvId } from '.';
 import { Cluster, InfraEnv, InfraEnvUpdateParams } from '../../common';
-import { getErrorMessage } from '../api';
+import { getErrorMessage } from '../../common/utils';
 import { InfraEnvsAPI } from '../services/apis';
 
 export default function useInfraEnv(clusterId: Cluster['id']) {

--- a/src/ocm/hooks/useInfraEnv.ts
+++ b/src/ocm/hooks/useInfraEnv.ts
@@ -1,14 +1,12 @@
 import React from 'react';
 import { useInfraEnvId } from '.';
 import { Cluster, InfraEnv, InfraEnvUpdateParams } from '../../common';
-import { APIErrorMixin } from '../api/types';
+import { getErrorMessage } from '../api';
 import { InfraEnvsAPI } from '../services/apis';
-
-type ErrorType = APIErrorMixin & Error;
 
 export default function useInfraEnv(clusterId: Cluster['id']) {
   const [infraEnv, setInfraEnv] = React.useState<InfraEnv>();
-  const [error, setError] = React.useState<ErrorType>();
+  const [error, setError] = React.useState('');
   const { infraEnvId, error: infraEnvIdError } = useInfraEnvId(clusterId);
 
   const getInfraEnv = React.useCallback(async () => {
@@ -18,7 +16,7 @@ export default function useInfraEnv(clusterId: Cluster['id']) {
         setInfraEnv(infraEnv);
       }
     } catch (e) {
-      setError(e as ErrorType);
+      setError(getErrorMessage(e));
     }
   }, [infraEnvId]);
 

--- a/src/ocm/hooks/useInfraEnv.ts
+++ b/src/ocm/hooks/useInfraEnv.ts
@@ -4,9 +4,11 @@ import { Cluster, InfraEnv, InfraEnvUpdateParams } from '../../common';
 import { APIErrorMixin } from '../api/types';
 import { InfraEnvsAPI } from '../services/apis';
 
+type ErrorType = APIErrorMixin & Error;
+
 export default function useInfraEnv(clusterId: Cluster['id']) {
   const [infraEnv, setInfraEnv] = React.useState<InfraEnv>();
-  const [error, setError] = React.useState<APIErrorMixin & Error>();
+  const [error, setError] = React.useState<ErrorType>();
   const { infraEnvId, error: infraEnvIdError } = useInfraEnvId(clusterId);
 
   const getInfraEnv = React.useCallback(async () => {
@@ -16,7 +18,7 @@ export default function useInfraEnv(clusterId: Cluster['id']) {
         setInfraEnv(infraEnv);
       }
     } catch (e) {
-      setError(e);
+      setError(e as ErrorType);
     }
   }, [infraEnvId]);
 

--- a/src/ocm/hooks/useInfraEnvId.ts
+++ b/src/ocm/hooks/useInfraEnvId.ts
@@ -3,16 +3,18 @@ import { Cluster, InfraEnv } from '../../common';
 import { APIErrorMixin } from '../api/types';
 import { InfraEnvsService } from '../services';
 
+type ErrorType = APIErrorMixin & Error;
+
 export default function useInfraEnvId(clusterId: Cluster['id']) {
   const [infraEnvId, setInfraEnv] = React.useState<InfraEnv['id']>();
-  const [error, setError] = React.useState<APIErrorMixin & Error>();
+  const [error, setError] = React.useState<ErrorType>();
 
   const findInfraEnvId = React.useCallback(async () => {
     try {
       const infraEnvId = await InfraEnvsService.getInfraEnvId(clusterId);
       setInfraEnv(infraEnvId);
     } catch (e) {
-      setError(e);
+      setError(e as ErrorType);
     }
   }, [clusterId]);
 

--- a/src/ocm/hooks/useInfraEnvId.ts
+++ b/src/ocm/hooks/useInfraEnvId.ts
@@ -1,20 +1,18 @@
 import React from 'react';
 import { Cluster, InfraEnv } from '../../common';
-import { APIErrorMixin } from '../api/types';
+import { getErrorMessage } from '../api';
 import { InfraEnvsService } from '../services';
-
-type ErrorType = APIErrorMixin & Error;
 
 export default function useInfraEnvId(clusterId: Cluster['id']) {
   const [infraEnvId, setInfraEnv] = React.useState<InfraEnv['id']>();
-  const [error, setError] = React.useState<ErrorType>();
+  const [error, setError] = React.useState('');
 
   const findInfraEnvId = React.useCallback(async () => {
     try {
       const infraEnvId = await InfraEnvsService.getInfraEnvId(clusterId);
       setInfraEnv(infraEnvId);
     } catch (e) {
-      setError(e as ErrorType);
+      setError(getErrorMessage(e));
     }
   }, [clusterId]);
 

--- a/src/ocm/hooks/useInfraEnvId.ts
+++ b/src/ocm/hooks/useInfraEnvId.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Cluster, InfraEnv } from '../../common';
-import { getErrorMessage } from '../api';
+import { getErrorMessage } from '../../common/utils';
 import { InfraEnvsService } from '../services';
 
 export default function useInfraEnvId(clusterId: Cluster['id']) {

--- a/src/ocm/hooks/useInfraEnvImageUrl.ts
+++ b/src/ocm/hooks/useInfraEnvImageUrl.ts
@@ -1,15 +1,13 @@
 import React from 'react';
 import useInfraEnvId from './useInfraEnvId';
 import { Cluster, PresignedUrl } from '../../common';
-import { APIErrorMixin } from '../api/types';
 import { InfraEnvsAPI } from '../services/apis';
-
-type errorType = (APIErrorMixin & Error) | string;
+import { getErrorMessage } from '../api';
 
 export default function useInfraEnvImageUrl(clusterId: Cluster['id']) {
   const { infraEnvId, error: infraEnvIdError } = useInfraEnvId(clusterId);
   const [imageUrl, setImageUrl] = React.useState<PresignedUrl['url']>();
-  const [error, setError] = React.useState<errorType>();
+  const [error, setError] = React.useState('');
 
   const getImageUrl = React.useCallback(async () => {
     try {
@@ -24,7 +22,7 @@ export default function useInfraEnvImageUrl(clusterId: Cluster['id']) {
       }
       setImageUrl(url);
     } catch (e) {
-      setError(e as errorType);
+      setError(getErrorMessage(e));
     }
   }, [infraEnvId]);
 

--- a/src/ocm/hooks/useInfraEnvImageUrl.ts
+++ b/src/ocm/hooks/useInfraEnvImageUrl.ts
@@ -2,7 +2,7 @@ import React from 'react';
 import useInfraEnvId from './useInfraEnvId';
 import { Cluster, PresignedUrl } from '../../common';
 import { InfraEnvsAPI } from '../services/apis';
-import { getErrorMessage } from '../api';
+import { getErrorMessage } from '../../common/utils';
 
 export default function useInfraEnvImageUrl(clusterId: Cluster['id']) {
   const { infraEnvId, error: infraEnvIdError } = useInfraEnvId(clusterId);

--- a/src/ocm/hooks/useOpenshiftVersions.tsx
+++ b/src/ocm/hooks/useOpenshiftVersions.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { CpuArchitecture, ImportClusterParams, OpenshiftVersionOptionType } from '../../common';
+import {
+  CpuArchitecture,
+  ImportClusterParams,
+  OpenshiftVersion,
+  OpenshiftVersionOptionType,
+} from '../../common';
 import { getApiErrorMessage, handleApiError } from '../api';
 import { SupportedOpenshiftVersionsAPI } from '../services/apis';
 
@@ -25,16 +30,18 @@ export default function useOpenshiftVersions(): UseOpenshiftVersionsType {
   const doAsync = React.useCallback(async () => {
     try {
       const { data } = await SupportedOpenshiftVersionsAPI.list();
-      const versions: OpenshiftVersionOptionType[] = Object.keys(data).map((key) => ({
-        label: `OpenShift ${data[key].displayName || key}`,
-        value: key,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        version: data[key].displayName,
-        default: Boolean(data[key].default),
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        supportLevel: data[key].supportLevel,
-        cpuArchitectures: data[key].cpuArchitectures as CpuArchitecture[],
-      }));
+      const versions: OpenshiftVersionOptionType[] = Object.keys(data).map((key) => {
+        const versionItem = data[key] as OpenshiftVersion;
+        const version = versionItem.displayName;
+        return {
+          label: `OpenShift ${version || key}`,
+          value: key,
+          version,
+          default: Boolean(versionItem.default),
+          supportLevel: versionItem.supportLevel,
+          cpuArchitectures: versionItem.cpuArchitectures as CpuArchitecture[],
+        };
+      });
       setVersions(sortVersions(versions));
     } catch (e) {
       handleApiError(e, (e) => {

--- a/src/ocm/hooks/useUsedClusterNames.ts
+++ b/src/ocm/hooks/useUsedClusterNames.ts
@@ -12,7 +12,7 @@ export default function useUsedClusterNames(clusterId: Cluster['id']) {
       const { data: clusters } = await ClustersAPI.list();
       const names = clusters
         .filter((c) => c.id !== clusterId)
-        .map((c) => `${c.name}.${c.baseDnsDomain}`);
+        .map((c) => `${c.name || ''}.${c.baseDnsDomain || ''}`);
       setUsedClusterNames(names);
     } catch (e) {
       setUsedClusterNames([]);

--- a/src/ocm/selectors/clusters.tsx
+++ b/src/ocm/selectors/clusters.tsx
@@ -31,7 +31,7 @@ export const selectClustersUIState = createSelector(
 );
 
 const clusterToClusterTableRow = (cluster: Cluster): IRow => {
-  const { id, name, openshiftVersion, baseDnsDomain, createdAt } = cluster;
+  const { id, name = '', openshiftVersion, baseDnsDomain, createdAt } = cluster;
   const dateTimeCell = getDateTimeCell(createdAt);
 
   return {

--- a/src/ocm/services/Day2ClusterService.ts
+++ b/src/ocm/services/Day2ClusterService.ts
@@ -67,7 +67,7 @@ const Day2ClusterService = {
     });
 
     await InfraEnvsService.create({
-      name: `${data.name}_infra-env`,
+      name: `${data.name || ''}_infra-env`,
       pullSecret,
       clusterId: data.id,
     });

--- a/src/ocm/services/apis/ClustersAPI.ts
+++ b/src/ocm/services/apis/ClustersAPI.ts
@@ -178,7 +178,7 @@ const ClustersAPI = {
 
   listByOpenshiftId(openshiftId: Cluster['openshiftClusterId']) {
     return client.get<Cluster[]>(
-      `${ClustersAPI.makeBaseURI()}?openshift_cluster_id=${openshiftId}`,
+      `${ClustersAPI.makeBaseURI()}?openshift_cluster_id=${openshiftId || ''}`,
     );
   },
 

--- a/src/ocm/services/apis/InfraEnvsAPI.ts
+++ b/src/ocm/services/apis/InfraEnvsAPI.ts
@@ -17,7 +17,7 @@ const InfraEnvsAPI = {
    * @param clusterId If provided, returns only infra-envs which directly reference the given clusterId.
    */
   list(clusterId = '') {
-    const query = clusterId && `?${new URLSearchParams({ ['cluster_id']: clusterId })}`;
+    const query = clusterId && `?${new URLSearchParams({ ['cluster_id']: clusterId }).toString()}`;
     return client.get<InfraEnv[]>(`${InfraEnvsAPI.makeBaseURI()}${query}`);
   },
 


### PR DESCRIPTION
Fixes a few ESlint warnings from the following rules:

Completely removed:
`@typescript-eslint/restrict-plus-operands`
`@typescript-eslint/require-await`

Partially fixed from `@typescript-eslint/restrict-template-expressions` and similar rules where TS sees the variable as potentially undefined. We will need to fix them individually so they have not been dropped entirely.

Drops about 50 errors.