### PR TITLE
MGMT-10918 Discovery ISO to use minimal-iso by default

### DIFF
--- a/src/common/components/clusterConfiguration/DiscoveryImageConfigForm.tsx
+++ b/src/common/components/clusterConfiguration/DiscoveryImageConfigForm.tsx
@@ -85,7 +85,7 @@ export const DiscoveryImageConfigForm: React.FC<DiscoveryImageConfigFormProps> =
     httpsProxy: httpsProxy || '',
     noProxy: noProxy || '',
     enableProxy: !!(httpProxy || httpsProxy || noProxy),
-    imageType: imageType || 'full-iso',
+    imageType: imageType || 'minimal-iso',
   };
   const { t } = useTranslation();
 

--- a/src/common/components/clusterConfiguration/DiscoveryImageTypeControlGroup.tsx
+++ b/src/common/components/clusterConfiguration/DiscoveryImageTypeControlGroup.tsx
@@ -22,13 +22,14 @@ const DiscoveryImageTypeControlGroup = () => (
     <StackItem>
       <RadioField
         name={GROUP_NAME}
-        id={'full-iso'}
-        value={'full-iso'}
+        id={'minimal-iso'}
+        value={'minimal-iso'}
         label={
           <DiscoveryImageTypeControlGroupLabel
-            text={'Full image file: Provision with physical media'}
+            text={'Minimal image file: Provision with virtual media'}
             popoverContent={
-              'Recommended option. The generated discovery ISO will contain everything needed to boot.'
+              'Recommended option. The generated discovery ISO will be smaller, but will need to download additional data during boot. ' +
+              "This option is useful if ISO storage capacity is limited or if it's being served over a constrained network."
             }
           />
         }
@@ -37,15 +38,12 @@ const DiscoveryImageTypeControlGroup = () => (
     <StackItem>
       <RadioField
         name={GROUP_NAME}
-        id={'minimal-iso'}
-        value={'minimal-iso'}
+        id={'full-iso'}
+        value={'full-iso'}
         label={
           <DiscoveryImageTypeControlGroupLabel
-            text={'Minimal image file: Provision with virtual media'}
-            popoverContent={
-              'The generated discovery ISO will be smaller, but will need to download additional data during boot. ' +
-              "This option is useful if ISO storage capacity is limited or if it's being served over a constrained network."
-            }
+            text={'Full image file: Provision with physical media'}
+            popoverContent={'The generated discovery ISO will contain everything needed to boot.'}
           />
         }
       />


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-10918

When opening the Discovery ISO modal, the default selection should be the Minimal ISO.

Made the first option in the modal the one for "Minimal iso", and moved the text saying "Recommended option" from "full-iso" to "minimal-iso" tooltips.