### PR TITLE
MGMT-10420: Extra spaces in installation page

### DIFF
--- a/src/common/components/clusterDetail/ClusterProgressItem.tsx
+++ b/src/common/components/clusterDetail/ClusterProgressItem.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Stack, StackItem, TextContent } from '@patternfly/react-core';
+import BorderedIcon from '../ui/BorderedIcon/BorderedIcon';
+
+const ClusterProgressItem = ({
+  icon,
+  children,
+}: {
+  icon: React.ReactElement;
+  children: React.ReactNode;
+}) => (
+  <Stack>
+    <StackItem>
+      <BorderedIcon>{icon}</BorderedIcon>
+    </StackItem>
+    <StackItem>
+      <TextContent>{children}</TextContent>
+    </StackItem>
+  </Stack>
+);
+
+export default ClusterProgressItem;

--- a/src/common/components/clusterDetail/ClusterProgressItems.tsx
+++ b/src/common/components/clusterDetail/ClusterProgressItems.tsx
@@ -24,19 +24,21 @@ const ClusterProgressItems = ({
   fallbackEventsURL,
 }: ClusterProgressItemsProps) => {
   const enabledHosts = getEnabledHosts(cluster.hosts);
-  const isWorkersPresent = enabledHosts && enabledHosts.some((host) => host.role === 'worker');
   const olmOperators = selectOlmOperators(cluster);
+
+  const masterHosts = enabledHosts.filter((host) => host.role && 'master' === host.role);
+  const workerHosts = enabledHosts.filter((host) => host.role && 'worker' === host.role);
 
   return (
     <>
       <RenderIf condition={!minimizedView}>
         <Grid hasGutter>
           <GridItem span={3}>
-            <ProgressBarTexts hosts={enabledHosts} hostRole="master" />
+            <ProgressBarTexts hosts={masterHosts} hostRole="master" />
           </GridItem>
-          <RenderIf condition={isWorkersPresent}>
+          <RenderIf condition={workerHosts.length > 0}>
             <GridItem span={3}>
-              <ProgressBarTexts hosts={enabledHosts} hostRole="worker" />
+              <ProgressBarTexts hosts={workerHosts} hostRole="worker" />
             </GridItem>
           </RenderIf>
           <GridItem span={3}>

--- a/src/common/components/clusterDetail/FinalizingProgress.tsx
+++ b/src/common/components/clusterDetail/FinalizingProgress.tsx
@@ -2,15 +2,7 @@ import { Cluster } from '../../api/types';
 import { EventListFetchProps } from '../../types';
 import React from 'react';
 import { EventsModal } from '../ui';
-import {
-  Button,
-  ButtonVariant,
-  Popover,
-  Stack,
-  StackItem,
-  Text,
-  TextContent,
-} from '@patternfly/react-core';
+import { Button, ButtonVariant, Popover, Text, TextContent } from '@patternfly/react-core';
 import {
   CheckCircleIcon,
   ExclamationCircleIcon,
@@ -19,7 +11,7 @@ import {
 } from '@patternfly/react-icons';
 import { global_success_color_100 as okColor } from '@patternfly/react-tokens/dist/esm/global_success_color_100';
 import { global_danger_color_100 as dangerColor } from '@patternfly/react-tokens/dist/esm/global_danger_color_100';
-import BorderedIcon from '../ui/BorderedIcon/BorderedIcon';
+import ClusterProgressItem from './ClusterProgressItem';
 import capitalize from 'lodash/capitalize';
 
 type FinalizingProgressProps = {
@@ -88,47 +80,36 @@ export const FinalizingProgress: React.FC<FinalizingProgressProps> = ({
         onFetchEvents={onFetchEvents}
         fallbackEventsURL={fallbackEventsURL}
       />
-      <Stack hasGutter>
-        <StackItem>
-          <BorderedIcon>{finalizingIcon}</BorderedIcon>
-        </StackItem>
-        <StackItem>
-          <>
-            {['finalizing', 'pending'].includes(initializationStatus) ? (
-              <Popover
-                zIndex={300} // set the zIndex below Cluster Events Modal
-                headerContent={<>Initialization</>}
-                bodyContent={
-                  <TextContent>
-                    <Text>
-                      This stage may take a while to finish. To view detailed information, click the
-                      events log link below.
-                    </Text>
-                  </TextContent>
-                }
-                footerContent={
-                  <Button
-                    variant={ButtonVariant.link}
-                    isInline
-                    onClick={() => setIsModalOpen(true)}
-                  >
-                    Open Events Log
-                  </Button>
-                }
-              >
-                <Button variant={ButtonVariant.link} isInline>
-                  Initialization
+      <ClusterProgressItem icon={finalizingIcon}>
+        <>
+          {['finalizing', 'pending'].includes(initializationStatus) ? (
+            <Popover
+              zIndex={300} // set the zIndex below Cluster Events Modal
+              headerContent={<>Initialization</>}
+              bodyContent={
+                <TextContent>
+                  <Text>
+                    This stage may take a while to finish. To view detailed information, click the
+                    events log link below.
+                  </Text>
+                </TextContent>
+              }
+              footerContent={
+                <Button variant={ButtonVariant.link} isInline onClick={() => setIsModalOpen(true)}>
+                  Open Events Log
                 </Button>
-              </Popover>
-            ) : (
-              'Initialization'
-            )}
-          </>
-          <TextContent>
-            <small>{capitalize(initializationStatus)}</small>
-          </TextContent>
-        </StackItem>
-      </Stack>
+              }
+            >
+              <Button variant={ButtonVariant.link} isInline>
+                Initialization
+              </Button>
+            </Popover>
+          ) : (
+            'Initialization'
+          )}
+          <small>{capitalize(initializationStatus)}</small>
+        </>
+      </ClusterProgressItem>
     </>
   );
 };

--- a/src/common/components/clusterDetail/OperatorsProgressItem.tsx
+++ b/src/common/components/clusterDetail/OperatorsProgressItem.tsx
@@ -1,14 +1,5 @@
 import React from 'react';
-import {
-  Button,
-  ButtonVariant,
-  Stack,
-  StackItem,
-  List,
-  ListItem,
-  Popover,
-  TextContent,
-} from '@patternfly/react-core';
+import { Button, ButtonVariant, List, ListItem, Popover } from '@patternfly/react-core';
 import {
   CheckCircleIcon,
   ExclamationCircleIcon,
@@ -22,7 +13,7 @@ import {
 import { pluralize } from 'humanize-plus';
 import { MonitoredOperatorsList, OperatorStatus } from '../../api/types';
 import { OPERATOR_LABELS } from '../../config';
-import BorderedIcon from '../ui/BorderedIcon/BorderedIcon';
+import ClusterProgressItem from './ClusterProgressItem';
 
 import './OperatorsProgressItem.css';
 
@@ -111,21 +102,16 @@ const OperatorsProgressItem: React.FC<OperatorsProgressItemProps> = ({ operators
   const label = getOperatorsLabel(operators);
 
   return (
-    <Stack hasGutter>
-      <StackItem>
-        <BorderedIcon>{icon}</BorderedIcon>
-      </StackItem>
-      <StackItem>
+    <ClusterProgressItem icon={icon}>
+      <>
         <OperatorsPopover operators={operators}>
           <Button variant={ButtonVariant.link} isInline data-testid="operators-progress-item">
             Operators
           </Button>
         </OperatorsPopover>
-        <TextContent>
-          <small>{label}</small>
-        </TextContent>
-      </StackItem>
-    </Stack>
+        <small>{label}</small>
+      </>
+    </ClusterProgressItem>
   );
 };
 

--- a/src/common/components/clusterDetail/ProgressBarTexts.tsx
+++ b/src/common/components/clusterDetail/ProgressBarTexts.tsx
@@ -12,45 +12,34 @@ type HostProgressProps = {
 };
 
 export const ProgressBarTexts = ({ hosts, hostRole }: HostProgressProps) => {
-  const filteredHosts = hosts.filter((host) => host.role && hostRole === host.role);
-  const failedHostsCount = filteredHosts.filter((host) => host.status === 'error').length;
-  const hostCountText = (hostRole: HostRole) =>
-    failedHostsCount === 0
-      ? `${filteredHosts.length} ${pluralize(
-          filteredHosts.length,
-          hostRole === 'master' ? 'control plane node' : 'worker',
-        )}`
-      : `${failedHostsCount}/${filteredHosts.length} ${pluralize(
-          filteredHosts.length,
-          hostRole === 'master' ? 'control plane node' : 'worker',
-        )}`;
+  const hostRoleText = pluralize(hosts.length, hostRole === 'master' ? 'Control Plane' : 'Worker');
+  const hostCountText = `${hosts.length} ${pluralize(
+    hosts.length,
+    hostRole === 'master' ? 'control plane node' : 'worker',
+  )}`;
 
-  const getHostName = (hostRole: HostRole): string => {
-    if (hostRole === 'master') {
-      return 'Control Plane';
-    }
-    return 'Workers';
-  };
-
-  if (filteredHosts.some((host) => ['cancelled', 'error'].includes(host.status))) {
+  if (hosts.some((host) => ['cancelled', 'error'].includes(host.status))) {
+    const failedHostsCount = hosts.filter((host) => host.status === 'error').length;
     return (
       <ClusterProgressItem icon={<ExclamationCircleIcon color={dangerColor.value} />}>
         <>
-          {getHostName(hostRole)}
+          {hostRoleText}
           <br />
-          <small>{hostCountText(hostRole)} failed</small>
+          <small>
+            {failedHostsCount}/{hostCountText} failed
+          </small>
         </>
       </ClusterProgressItem>
     );
   }
 
-  if (filteredHosts.every((host) => host.status === 'installed')) {
+  if (hosts.every((host) => host.status === 'installed')) {
     return (
       <ClusterProgressItem icon={<CheckCircleIcon color={okColor.value} />}>
         <>
-          {getHostName(hostRole)}
+          {hostRoleText}
           <br />
-          <small>{hostCountText(hostRole)} installed</small>
+          <small>{hostCountText} installed</small>
         </>
       </ClusterProgressItem>
     );
@@ -59,9 +48,9 @@ export const ProgressBarTexts = ({ hosts, hostRole }: HostProgressProps) => {
   return (
     <ClusterProgressItem icon={<InProgressIcon />}>
       <>
-        {getHostName(hostRole)}
+        {hostRoleText}
         <br />
-        <small>Installing {hostCountText(hostRole)}</small>
+        <small>Installing {hostCountText}</small>
       </>
     </ClusterProgressItem>
   );

--- a/src/common/components/clusterDetail/ProgressBarTexts.tsx
+++ b/src/common/components/clusterDetail/ProgressBarTexts.tsx
@@ -1,18 +1,17 @@
-import { Host, HostRole } from '../../api/types';
 import React from 'react';
+import { Host, HostRole } from '../../api/types';
 import { pluralize } from 'humanize-plus';
 import { CheckCircleIcon, ExclamationCircleIcon, InProgressIcon } from '@patternfly/react-icons';
 import { global_danger_color_100 as dangerColor } from '@patternfly/react-tokens/dist/esm/global_danger_color_100';
-import { Stack, StackItem, TextContent } from '@patternfly/react-core';
 import { global_success_color_100 as okColor } from '@patternfly/react-tokens/dist/esm/global_success_color_100';
-import BorderedIcon from '../ui/BorderedIcon/BorderedIcon';
+import ClusterProgressItem from './ClusterProgressItem';
 
 type HostProgressProps = {
   hosts: Host[];
   hostRole: HostRole;
 };
 
-export const ProgressBarTexts: React.FC<HostProgressProps> = ({ hosts, hostRole }) => {
+export const ProgressBarTexts = ({ hosts, hostRole }: HostProgressProps) => {
   const filteredHosts = hosts.filter((host) => host.role && hostRole === host.role);
   const failedHostsCount = filteredHosts.filter((host) => host.status === 'error').length;
   const hostCountText = (hostRole: HostRole) =>
@@ -25,6 +24,7 @@ export const ProgressBarTexts: React.FC<HostProgressProps> = ({ hosts, hostRole 
           filteredHosts.length,
           hostRole === 'master' ? 'control plane node' : 'worker',
         )}`;
+
   const getHostName = (hostRole: HostRole): string => {
     if (hostRole === 'master') {
       return 'Control Plane';
@@ -34,62 +34,35 @@ export const ProgressBarTexts: React.FC<HostProgressProps> = ({ hosts, hostRole 
 
   if (filteredHosts.some((host) => ['cancelled', 'error'].includes(host.status))) {
     return (
-      <>
-        <Stack hasGutter>
-          <StackItem>
-            <BorderedIcon>
-              <ExclamationCircleIcon color={dangerColor.value} />
-            </BorderedIcon>
-          </StackItem>
-          <StackItem>
-            <TextContent>
-              {getHostName(hostRole)}
-              <br />
-              <small>{hostCountText(hostRole)} failed</small>
-            </TextContent>
-          </StackItem>
-        </Stack>
-      </>
+      <ClusterProgressItem icon={<ExclamationCircleIcon color={dangerColor.value} />}>
+        <>
+          {getHostName(hostRole)}
+          <br />
+          <small>{hostCountText(hostRole)} failed</small>
+        </>
+      </ClusterProgressItem>
     );
   }
 
   if (filteredHosts.every((host) => host.status === 'installed')) {
     return (
-      <>
-        <Stack hasGutter>
-          <StackItem>
-            <BorderedIcon>
-              <CheckCircleIcon color={okColor.value} />
-            </BorderedIcon>
-          </StackItem>
-          <StackItem>
-            <TextContent>
-              {getHostName(hostRole)}
-              <br />
-              <small>{hostCountText(hostRole)} installed</small>
-            </TextContent>
-          </StackItem>
-        </Stack>
-      </>
+      <ClusterProgressItem icon={<CheckCircleIcon color={okColor.value} />}>
+        <>
+          {getHostName(hostRole)}
+          <br />
+          <small>{hostCountText(hostRole)} installed</small>
+        </>
+      </ClusterProgressItem>
     );
   }
 
   return (
-    <>
-      <Stack hasGutter>
-        <StackItem>
-          <BorderedIcon>
-            <InProgressIcon />
-          </BorderedIcon>
-        </StackItem>
-        <StackItem>
-          <TextContent>
-            {getHostName(hostRole)}
-            <br />
-            <small>Installing {hostCountText(hostRole)}</small>
-          </TextContent>
-        </StackItem>
-      </Stack>
-    </>
+    <ClusterProgressItem icon={<InProgressIcon />}>
+      <>
+        {getHostName(hostRole)}
+        <br />
+        <small>Installing {hostCountText(hostRole)}</small>
+      </>
+    </ClusterProgressItem>
   );
 };

--- a/src/ocm/components/clusterDetail/ProgressBarAlerts.tsx
+++ b/src/ocm/components/clusterDetail/ProgressBarAlerts.tsx
@@ -52,7 +52,6 @@ export const HostInstallationWarning: React.FC<installationProgressWarningProps>
 
   return (
     <>
-      &nbsp;
       <Alert
         isInline
         variant="warning"
@@ -120,7 +119,6 @@ export const HostsInstallationFailed: React.FC<installationProgressWarningProps>
 
   return (
     <>
-      &nbsp;
       <Alert
         isInline
         variant="danger"
@@ -158,7 +156,6 @@ export const HostsInstallationFailed: React.FC<installationProgressWarningProps>
 export const HostsInstallationSuccess: React.FC<successInstallationProps> = () => {
   return (
     <>
-      &nbsp;
       <Alert isInline variant="success" title={'Installation completed successfully'}>
         {' '}
       </Alert>

--- a/src/ocm/components/clusterDetail/getProgressBarAlerts.tsx
+++ b/src/ocm/components/clusterDetail/getProgressBarAlerts.tsx
@@ -43,9 +43,11 @@ export const getClusterProgressAlerts = (
     );
   } else {
     return (
-      <Stack>
+      <Stack hasGutter>
         <RenderIf condition={cluster.status === 'installed'}>
-          <HostsInstallationSuccess />
+          <StackItem>
+            <HostsInstallationSuccess />
+          </StackItem>
         </RenderIf>
         <RenderIf condition={failedWorkers > 0}>
           <StackItem>


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-10420

I have slightly decreased the spacing in and around the cluster progress item and also between the alerts. It's not exactly by half as the design says in the following image but this is the best that can be achieved without overwriting Patternfly variables.


![image](https://user-images.githubusercontent.com/87187179/176383478-88bfcebf-1c45-4c0c-83d9-cb3d5b3c0c9d.png)

### Before and after images:

**Before:**
![image](https://user-images.githubusercontent.com/87187179/176383636-81efb5fe-a09b-47ef-814a-e91c2eaa9d0b.png)

**After:**
![image](https://user-images.githubusercontent.com/87187179/176383677-f88e8b7d-83a1-4d90-b603-ee70b129473d.png)

---

**Before:**
![image](https://user-images.githubusercontent.com/87187179/176383724-f341af1c-87da-4e64-9b01-850a5cb8c877.png)

**After:**
![image](https://user-images.githubusercontent.com/87187179/176383765-07c833d2-fcad-48e7-8c43-6aef3113cdf2.png)

---

**Before:**
![image](https://user-images.githubusercontent.com/87187179/176383845-d3897d06-8a26-4616-83ca-adcf4b8e8263.png)

**After:**
![image](https://user-images.githubusercontent.com/87187179/176383811-48608474-9986-49b3-9bda-a8f3bb7116e8.png)
