### PR TITLE
NO_ISSUE: Remove default translation namespace override

### DIFF
--- a/src/common/hooks/use-translation-wrapper.ts
+++ b/src/common/hooks/use-translation-wrapper.ts
@@ -2,5 +2,5 @@
 import { useTranslation as useReactI18NextTranslation } from 'react-i18next';
 
 export function useTranslation() {
-  return useReactI18NextTranslation(`${process.env.TRANSLATION_NAMESPACE ?? 'assisted_installer'}`);
+  return useReactI18NextTranslation(process.env.TRANSLATION_NAMESPACE);
 }


### PR DESCRIPTION
Don't override a default translation namespace in case when
process.env.TRANSLATION_NAMESPACE is not defined.