### PR TITLE
MGMT-11036: Update API for upgrade agent feature

### DIFF
--- a/src/common/api/swagger.yaml
+++ b/src/common/api/swagger.yaml
@@ -4156,6 +4156,7 @@ definitions:
       - stop-installation
       - logs-gather
       - next-step-runner
+      - upgrade-agent
 
   step:
     type: object
@@ -5734,6 +5735,7 @@ definitions:
       - 'disk-encryption-requirements-satisfied'
       - 'non-overlapping-subnets'
       - 'vsphere-disk-uuid-enabled'
+      - 'compatible-agent'
 
   dhcp_allocation_request:
     type: object
@@ -5989,6 +5991,31 @@ definitions:
     type: string
     enum: ['success', 'failure']
     description: Image availability result.
+
+  upgrade_agent_request:
+    type: object
+    properties:
+      agent_image:
+        type: string
+        description: |
+          Full image reference of the image that the agent should upgrade to, for example
+          `quay.io/registry-proxy.engineering.redhat.com/rh-osbs/openshift4-assisted-installer-agent-rhel8:v1.0.0-142`.
+
+  upgrade_agent_response:
+    type: object
+    properties:
+      agent_image:
+        type: string
+        description: |
+          Full image reference of the image that the agent has upgraded to, for example
+          `quay.io/registry-proxy.engineering.redhat.com/rh-osbs/openshift4-assisted-installer-agent-rhel8:v1.0.0-142`.
+      result:
+        $ref: '#/definitions/upgrade_agent_result'
+
+  upgrade_agent_result:
+    type: string
+    enum: ['success', 'failure']
+    description: Agent upgrade result.
 
   source_state:
     type: string

--- a/src/common/api/types.ts
+++ b/src/common/api/types.ts
@@ -1281,7 +1281,8 @@ export type HostValidationId =
   | 'dns-wildcard-not-configured'
   | 'disk-encryption-requirements-satisfied'
   | 'non-overlapping-subnets'
-  | 'vsphere-disk-uuid-enabled';
+  | 'vsphere-disk-uuid-enabled'
+  | 'compatible-agent';
 /**
  * Explicit ignition endpoint overrides the default ignition endpoint.
  */
@@ -2068,7 +2069,8 @@ export type StepType =
   | 'domain-resolution'
   | 'stop-installation'
   | 'logs-gather'
-  | 'next-step-runner';
+  | 'next-step-runner'
+  | 'upgrade-agent';
 export interface Steps {
   nextInstructionSeconds?: number;
   /**
@@ -2088,6 +2090,27 @@ export interface SystemVendor {
    */
   virtual?: boolean;
 }
+export interface UpgradeAgentRequest {
+  /**
+   * Full image reference of the image that the agent should upgrade to, for example
+   * `quay.io/registry-proxy.engineering.redhat.com/rh-osbs/openshift4-assisted-installer-agent-rhel8:v1.0.0-142`.
+   *
+   */
+  agentImage?: string;
+}
+export interface UpgradeAgentResponse {
+  /**
+   * Full image reference of the image that the agent has upgraded to, for example
+   * `quay.io/registry-proxy.engineering.redhat.com/rh-osbs/openshift4-assisted-installer-agent-rhel8:v1.0.0-142`.
+   *
+   */
+  agentImage?: string;
+  result?: UpgradeAgentResult;
+}
+/**
+ * Agent upgrade result.
+ */
+export type UpgradeAgentResult = 'success' | 'failure';
 export interface Usage {
   /**
    * Unique idenftifier of the feature

--- a/src/common/config/constants.ts
+++ b/src/common/config/constants.ts
@@ -134,6 +134,7 @@ export const HOST_VALIDATION_LABELS: { [key in HostValidationId]: string } = {
   'dns-wildcard-not-configured': 'DNS wildcard not configured',
   'non-overlapping-subnets': 'Non overlapping subnets',
   'vsphere-disk-uuid-enabled': 'Vsphere disk uuidenabled',
+  'compatible-agent': 'Agent compatibility',
 };
 
 export const HOST_VALIDATION_FAILURE_HINTS: { [key in HostValidationId]: string } = {
@@ -170,6 +171,7 @@ export const HOST_VALIDATION_FAILURE_HINTS: { [key in HostValidationId]: string 
   'dns-wildcard-not-configured': '',
   'non-overlapping-subnets': '',
   'vsphere-disk-uuid-enabled': '',
+  'compatible-agent': '',
 };
 
 export const CLUSTER_VALIDATION_LABELS: { [key in ClusterValidationId]: string } = {


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-11036

This patch updates the OpenAPI specification and the code generated from
it, so that it will be possible to use the new `compatible-agent`
validation.