### PR TITLE
MGMT-11009 Allow adding hosts to upgraded clusters

### DIFF
--- a/src/ocm/components/AddHosts/utils.ts
+++ b/src/ocm/components/AddHosts/utils.ts
@@ -1,4 +1,3 @@
-import { isSNO } from '../../../common';
 import Day2ClusterService from '../../services/Day2ClusterService';
 import { getFeatureSupported } from '../featureSupportLevels/FeatureSupportLevelProvider';
 import { OcmClusterType } from './types';
@@ -16,16 +15,10 @@ export const canAddHost = ({ cluster }: { cluster: OcmClusterType }) => {
     return false;
   }
 
-  const { aiCluster } = cluster;
-  if (aiCluster) {
-    const isMultiNode = !isSNO(aiCluster);
-    return aiCluster.status === 'installed' && (isMultiNode || isSNOExpansionAllowed(cluster));
-  } else {
-    const isMultiNode = (cluster.metrics?.nodes?.total || 0) > 1;
-    return (
-      cluster.state === 'ready' &&
-      cluster.product?.id === 'OCP-AssistedInstall' &&
-      (isMultiNode || isSNOExpansionAllowed(cluster))
-    );
-  }
+  const isMultiNode = (cluster.metrics?.nodes?.total || 0) > 1;
+  return (
+    cluster.state === 'ready' &&
+    cluster.product?.id === 'OCP-AssistedInstall' &&
+    (isMultiNode || isSNOExpansionAllowed(cluster))
+  );
 };

--- a/src/ocm/components/AddHosts/utils.ts
+++ b/src/ocm/components/AddHosts/utils.ts
@@ -3,35 +3,29 @@ import Day2ClusterService from '../../services/Day2ClusterService';
 import { getFeatureSupported } from '../featureSupportLevels/FeatureSupportLevelProvider';
 import { OcmClusterType } from './types';
 
+const isSNOExpansionAllowed = (cluster: OcmClusterType) => {
+  return getFeatureSupported(
+    cluster.openshift_version,
+    cluster.aiSupportLevels || [],
+    'SINGLE_NODE_EXPANSION',
+  );
+};
+
 export const canAddHost = ({ cluster }: { cluster: OcmClusterType }) => {
-  if (Day2ClusterService.getOpenshiftClusterId(cluster)) {
-    if (cluster.aiCluster) {
-      if (isSNO(cluster.aiCluster)) {
-        return (
-          cluster.aiCluster.status === 'installed' &&
-          cluster.aiCluster.openshiftVersion &&
-          getFeatureSupported(
-            cluster.aiCluster.openshiftVersion || '',
-            cluster.aiSupportLevels || [],
-            'SINGLE_NODE_EXPANSION',
-          )
-        );
-      } else {
-        return cluster.aiCluster.status === 'installed';
-      }
-    } else {
-      return (
-        cluster.state === 'ready' &&
-        cluster.product?.id === 'OCP-AssistedInstall' &&
-        ((cluster.metrics?.nodes?.total && cluster.metrics?.nodes?.total > 1) ||
-          getFeatureSupported(
-            cluster.openshift_version,
-            cluster.aiSupportLevels || [],
-            'SINGLE_NODE_EXPANSION',
-          ))
-      );
-    }
+  if (!Day2ClusterService.getOpenshiftClusterId(cluster)) {
+    return false;
   }
 
-  return false;
+  const { aiCluster } = cluster;
+  if (aiCluster) {
+    const isMultiNode = !isSNO(aiCluster);
+    return aiCluster.status === 'installed' && (isMultiNode || isSNOExpansionAllowed(cluster));
+  } else {
+    const isMultiNode = (cluster.metrics?.nodes?.total || 0) > 1;
+    return (
+      cluster.state === 'ready' &&
+      cluster.product?.id === 'OCP-AssistedInstall' &&
+      (isMultiNode || isSNOExpansionAllowed(cluster))
+    );
+  }
 };


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-11009

For SNO clusters, we were using Day1's cluster version to determine if hosts could be added to it.
But if the cluster is upgraded, the version in Day1 remains unchanged. We must look at Day2's version instead.

Before: Add hosts tab missing
![upgraded-cluster-add-hosts-staging2](https://user-images.githubusercontent.com/829045/177281042-d206d776-76a2-4c4f-89ff-4799475a2b5d.png)


After: Same cluster - Add hosts tab displayed 
![upgraded-cluster-add-hosts-fixed](https://user-images.githubusercontent.com/829045/177280686-e0b94105-5374-4ae9-9d81-fdacc890c924.png)

