### PR TITLE
MGMT-10951 Improve Sentry logging for AI errors

### DIFF
--- a/src/ocm/sentry.ts
+++ b/src/ocm/sentry.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/browser';
+import { getAssistedUiLibVersion } from '../common/config/constants';
 import { ocmClient } from './api/axiosClient';
 
 export const captureException = (
@@ -8,8 +9,15 @@ export const captureException = (
   severity: Sentry.Severity = Sentry.Severity.Error,
 ) => {
   if (ocmClient) {
-    message && Sentry.captureMessage(message, severity);
-    Sentry.captureException(error);
+    const body = {
+      level: severity,
+      tags: {
+        app_section: 'assisted-ui-lib',
+        section_version: getAssistedUiLibVersion(),
+      },
+    };
+    message && Sentry.captureMessage(message, body);
+    Sentry.captureException(error, body);
   } else {
     severity === Sentry.Severity.Error
       ? console.error(message, error)


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-10951

We want to be able to filter clearly the Sentry errors originating from Assisted Installer UI lib.
For that, I added two new tags called `app_section` and `section_version` that should be displayed with the existing ones.
I chose this names based on the existing tags, and in theory they shuld be created when the first event using it happens.
![ocm-tags](https://user-images.githubusercontent.com/829045/177294545-414bd4be-839d-4fe7-8812-c4637eb5797e.png)


It looks like we won't be able to test this before Staging, given that the allowed origins blocks us from sending these requests from our local environments.

