### PR TITLE
Fix label selector

### DIFF
--- a/src/cim/components/ClusterDeployment/LabelsSelector.tsx
+++ b/src/cim/components/ClusterDeployment/LabelsSelector.tsx
@@ -93,7 +93,7 @@ export const LabelSelectorGroup: React.FC<LabelsSelectorProps> = ({
           key={option.id}
           id={option.id}
           onClick={() => {
-            const values = (option.value as string).split('=', 1);
+            const values = (option.value as string).split('=', 2);
             setValue([...field.value, { key: values[0], value: values[1] }]);
           }}
         >


### PR DESCRIPTION
This PR fixes issue where parsed labels do not have value due to restricting `split` to just 1 element 