### PR TITLE
Do not allow warnings in updated files

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -32,6 +32,20 @@ jobs:
         # --frozen-lockfile: doesn't generate a yarn.lock file, fails if an update is needed.
         run: yarn install --frozen-lockfile
 
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v23.2
+        with:
+          files: |
+            src/**/*.ts
+            src/**/*.tsx
+
+      - name: Lint all changed files
+        run: |
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            yarn lint-touched-file $file
+          done
+
       - name: Validate that i18n locale files are updated and contains 'ai' prefix in keys
         run: |
           chmod +x ./scripts/validatei18n_files.sh

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "test": "run-s test:circular lint format:check",
     "test:circular": "dpdm --warning false --tree false --exit-code circular:1 ./src/index.ts",
     "lint": "eslint . --color",
+    "lint-touched-file": "eslint --color --max-warnings=0",
     "lint:fix": "yarn run lint --fix",
     "format": "prettier --write '**/*.{json,md,scss,yaml,yml}'",
     "format:check": "prettier --check '**/*.{json,md,scss,yaml,yml}'",


### PR DESCRIPTION
Added a new step in the On-pull-request flow that would throw an error if any of the updated files in the PR has linting warnings.
This should help bring down the number of warnings.