### PR TITLE
MGMT-11107 Keep the NTP tooltip open even after polling

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "prepare": "install-peers",
     "test": "run-s test:circular lint format:check",
     "test:circular": "dpdm --warning false --tree false --exit-code circular:1 ./src/index.ts",
-    "lint": "eslint . --max-warnings=333 --color",
+    "lint": "eslint . --max-warnings=328 --color",
     "lint:fix": "yarn run lint --fix",
     "format": "prettier --write '**/*.{json,md,scss,yaml,yml}'",
     "format:check": "prettier --check '**/*.{json,md,scss,yaml,yml}'",

--- a/src/common/components/hosts/HostStatus.tsx
+++ b/src/common/components/hosts/HostStatus.tsx
@@ -28,7 +28,6 @@ import { HostStatusProps } from './types';
 import { UpdateDay2ApiVipPropsType } from './HostValidationGroups';
 import { UnknownIcon } from '@patternfly/react-icons';
 import { useTranslation } from '../../hooks/use-translation-wrapper';
-import { TFunction } from 'i18next';
 
 const getTitleWithProgress = (host: Host, status: HostStatusProps['status']) => {
   const stages = getHostProgressStages(host);
@@ -42,11 +41,11 @@ type HostStatusPopoverContentProps = ValidationInfoActionProps & {
   autoCSR?: boolean;
 };
 
-const HostStatusPopoverContent: React.FC<HostStatusPopoverContentProps> = ({
+const HostStatusPopoverContent = ({
   details,
   autoCSR,
   ...props
-}) => {
+}: HostStatusPopoverContentProps) => {
   const { host } = props;
   const { status, statusInfo } = host;
   const { t } = useTranslation();
@@ -170,7 +169,6 @@ type WithHostStatusPopoverProps = AdditionNtpSourcePropsType &
     isSmall?: ButtonProps['isSmall'];
     details?: string;
     zIndex?: number;
-    t: TFunction;
     autoCSR?: boolean;
   };
 
@@ -210,7 +208,6 @@ const HostStatus: React.FC<HostStatusProps> = ({
 
   const { title, icon, sublabel, details, noPopover } = status;
   const titleWithProgress = getTitleWithProgress(host, status);
-  const { t } = useTranslation();
   const popoverProps: WithHostStatusPopoverProps = {
     hideOnOutsideClick: !keepOnOutsideClick,
     host,
@@ -221,7 +218,6 @@ const HostStatus: React.FC<HostStatusProps> = ({
     details,
     UpdateDay2ApiVipDialogToggleComponent,
     zIndex,
-    t,
     autoCSR,
   };
 

--- a/src/common/components/hosts/utils.ts
+++ b/src/common/components/hosts/utils.ts
@@ -52,7 +52,8 @@ export const canReset = (clusterStatus: Cluster['status'], status: Host['status'
   ['adding-hosts'].includes(clusterStatus) &&
   ['error', 'installing-pending-user-action'].includes(status);
 
-export const canEditRole = (cluster: Cluster): boolean => !isSNO(cluster);
+export const canEditRole = (cluster: Pick<Cluster, 'highAvailabilityMode'>): boolean =>
+  !isSNO(cluster);
 
 export const canEditHost = (clusterStatus: Cluster['status'], status: Host['status']) =>
   ['pending-for-input', 'insufficient', 'ready'].includes(clusterStatus) &&
@@ -80,8 +81,11 @@ export const canDownloadKubeconfig = (clusterStatus: Cluster['status']) =>
     clusterStatus,
   );
 
-export const canInstallHost = (cluster: Cluster, hostStatus: Host['status']) =>
-  cluster.kind === 'AddHostsCluster' && cluster.status === 'adding-hosts' && hostStatus === 'known';
+export const canInstallHost = (
+  status: Cluster['status'],
+  kind: Cluster['kind'],
+  hostStatus: Host['status'],
+) => kind === 'AddHostsCluster' && status === 'adding-hosts' && hostStatus === 'known';
 
 export const getHostProgressStages = (host: Host) => host.progressStages || [];
 

--- a/src/common/selectors/clusterSelectors.ts
+++ b/src/common/selectors/clusterSelectors.ts
@@ -36,7 +36,7 @@ export const selectOlmOperators = (cluster?: Pick<Cluster, 'monitoredOperators'>
   return selectMonitoredOperators(cluster).filter((operator) => operator.operatorType === 'olm');
 };
 
-export const isSNO = ({ highAvailabilityMode }: Partial<Cluster>) =>
+export const isSNO = ({ highAvailabilityMode }: Pick<Cluster, 'highAvailabilityMode'>) =>
   highAvailabilityMode === 'None';
 
 export const selectClusterValidationsInfo = ({

--- a/src/ocm/components/hosts/HostsDiscoveryTable.tsx
+++ b/src/ocm/components/hosts/HostsDiscoveryTable.tsx
@@ -24,13 +24,14 @@ import {
 } from '../../../common/components/hosts/tableUtils';
 import HostsTable from '../../../common/components/hosts/HostsTable';
 import { HostDetail } from '../../../common/components/hosts/HostRowDetail';
-import { TableRow } from '../../../common/components/hosts/AITable';
+import { ExpandComponentProps, TableRow } from '../../../common/components/hosts/AITable';
 import { ValidationsInfo } from '../../../common/types/hosts';
 import { usePagination } from '../../../common/components/hosts/usePagination';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
 import HostsTableEmptyState from '../hosts/HostsTableEmptyState';
 import HardwareStatus from './HardwareStatus';
 import { AdditionalNTPSourcesDialogToggle } from './AdditionaNTPSourceDialogToggle';
+import { onDiskRoleType } from '../../../common/components/hosts/DiskRole';
 
 export const hardwareStatusColumn = (
   onEditHostname?: HostsTableActions['onEditHost'],
@@ -60,6 +61,19 @@ export const hardwareStatusColumn = (
     },
   };
 };
+
+const getExpandComponent = (onDiskRole: onDiskRoleType, canEditDisks: (host: Host) => boolean) =>
+  function HostDetailExpander({ obj: host }: ExpandComponentProps<Host>) {
+    return (
+      <HostDetail
+        key={host.id}
+        host={host}
+        onDiskRole={onDiskRole}
+        canEditDisks={canEditDisks}
+        AdditionalNTPSourcesDialogToggleComponent={AdditionalNTPSourcesDialogToggle}
+      />
+    );
+  };
 
 const HostsDiscoveryTable = ({ cluster }: { cluster: Cluster; skipDisabled?: boolean }) => {
   const {
@@ -92,18 +106,8 @@ const HostsDiscoveryTable = ({ cluster }: { cluster: Cluster; skipDisabled?: boo
     [onEditHost, actionChecks.canEditHostname, actionChecks.canEditRole, onEditRole, cluster, t],
   );
 
-  const expandMemo = React.useMemo(() => {
-    return function ExpandedHostDetail({ obj: host }: { obj: Host }) {
-      return (
-        <HostDetail
-          key={host.id}
-          host={host}
-          onDiskRole={onDiskRole}
-          canEditDisks={actionChecks.canEditDisks}
-          AdditionalNTPSourcesDialogToggleComponent={AdditionalNTPSourcesDialogToggle}
-        />
-      );
-    };
+  const detailExpander = React.useMemo(() => {
+    return getExpandComponent(onDiskRole, actionChecks.canEditDisks);
   }, [onDiskRole, actionChecks.canEditDisks]);
 
   const hosts = cluster.hosts || [];
@@ -133,7 +137,7 @@ const HostsDiscoveryTable = ({ cluster }: { cluster: Cluster; skipDisabled?: boo
             hosts={hosts}
             content={content}
             actionResolver={actionResolver}
-            ExpandComponent={expandMemo}
+            ExpandComponent={detailExpander}
             onSelect={isSNOCluster ? undefined : onSelect}
             selectedIDs={selectedHostIDs}
             setSelectedIDs={setSelectedHostIDs}

--- a/src/ocm/components/hosts/HostsTableDetailContext.tsx
+++ b/src/ocm/components/hosts/HostsTableDetailContext.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { onDiskRoleType } from '../../../common/components/hosts/DiskRole';
+import { Host } from '../../../common';
+
+type HostTableDetailContext = {
+  canEditDisks: (host: Host) => boolean;
+  onDiskRole: onDiskRoleType;
+};
+
+const HostsTableDetailContext = React.createContext<HostTableDetailContext | undefined>(undefined);
+
+const HostsTableDetailContextProvider: React.FC<HostTableDetailContext> = ({
+  canEditDisks,
+  onDiskRole,
+  children,
+}) => {
+  const context = {
+    canEditDisks,
+    onDiskRole,
+  };
+
+  return (
+    <HostsTableDetailContext.Provider value={context as HostTableDetailContext}>
+      {children}
+    </HostsTableDetailContext.Provider>
+  );
+};
+
+const useHostTableDetailContext = () => {
+  const context = React.useContext(HostsTableDetailContext);
+  if (context === undefined) {
+    throw new Error(
+      'useHostTableDetailContext must be used within a HostsTableDetailContextProvider',
+    );
+  }
+  return context;
+};
+
+export { HostsTableDetailContextProvider, useHostTableDetailContext };

--- a/src/ocm/components/hosts/use-hosts-table.tsx
+++ b/src/ocm/components/hosts/use-hosts-table.tsx
@@ -164,8 +164,8 @@ export const useHostsTable = (cluster: Cluster) => {
 
   const actionChecks = React.useMemo(
     () => ({
-      canEditRole: () => canEditRoleUtil(cluster),
-      canInstallHost: (host: Host) => canInstallHostUtil(cluster, host.status),
+      canEditRole: () => canEditRoleUtil({ highAvailabilityMode: cluster.highAvailabilityMode }),
+      canInstallHost: (host: Host) => canInstallHostUtil(cluster.status, cluster.kind, host.status),
       canEditDisks: (host: Host) => canEditDisksUtil(cluster.status, host.status),
       canEnable: (host: Host) => canEnableUtil(cluster.status, host.status),
       canDisable: (host: Host) => canDisableUtil(cluster.status, host.status),
@@ -174,7 +174,7 @@ export const useHostsTable = (cluster: Cluster) => {
       canReset: (host: Host) => canResetUtil(cluster.status, host.status),
       canEditHostname: () => canEditHostnameUtil(cluster.status),
     }),
-    [cluster],
+    [cluster.status, cluster.kind, cluster.highAvailabilityMode],
   );
 
   const onReset = React.useCallback(() => {

--- a/src/ocm/services/HostsService.ts
+++ b/src/ocm/services/HostsService.ts
@@ -92,7 +92,7 @@ const HostsService = {
       const hosts = await HostsService.listHostsBoundToCluster(cluster.id);
 
       for (const host of hosts) {
-        if (canInstallHost(cluster, host.status)) {
+        if (canInstallHost(cluster.status, cluster.kind, host.status)) {
           promises.push(HostsAPI.installHost(infraEnvId, host.id));
         }
       }


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-11107

When the tooltip for NTP was open, as soon as a new polling happened, the tooltip would close.
This was due to the re-rendering of `canEditDisks` which itself changed every time the `cluster` updated.

I changed it so that the actions only change when the required data change.