### PR TITLE
Do not display bullet if conditions dont apply

### DIFF
--- a/src/common/components/clusterConfiguration/SNODisclaimer.tsx
+++ b/src/common/components/clusterConfiguration/SNODisclaimer.tsx
@@ -25,10 +25,11 @@ const SNODisclaimer = ({
       <ListItem>
         {t('ai:Installing SNO will result in a non-highly available OpenShift deployment.')}
       </ListItem>
-      <ListItem>
-        {!snoExpansionSupported &&
-          t('ai:Adding additional machines to your cluster is currently out of scope.')}
-      </ListItem>
+      {!snoExpansionSupported && (
+        <ListItem>
+          {t('ai:Adding additional machines to your cluster is currently out of scope.')}
+        </ListItem>
+      )}
     </>
   );
   const unsupportedWarnings = (


### PR DESCRIPTION
Removing extra bullet if the conditions do not apply to the selected OpenShift version

![extra-bullet](https://user-images.githubusercontent.com/829045/180384880-015ef918-0063-467b-b04a-613993f7acfa.png)
