### PR TITLE
MGMT-1344 iso download timing

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "prepare": "install-peers",
     "test": "run-s test:circular lint format:check",
     "test:circular": "dpdm --warning false --tree false --exit-code circular:1 ./src/index.ts",
-    "lint": "eslint . --max-warnings=333 --color",
+    "lint": "eslint . --max-warnings=328 --color",
     "lint:fix": "yarn run lint --fix",
     "format": "prettier --write '**/*.{json,md,scss,yaml,yml}'",
     "format:check": "prettier --check '**/*.{json,md,scss,yaml,yml}'",

--- a/src/ocm/components/clusterConfiguration/DiscoveryImageForm.tsx
+++ b/src/ocm/components/clusterConfiguration/DiscoveryImageForm.tsx
@@ -17,7 +17,7 @@ import { DiscoveryImageFormService } from '../../services';
 type DiscoveryImageFormProps = {
   cluster: Cluster;
   onCancel: () => void;
-  onSuccess: () => void;
+  onSuccess: () => Promise<void>;
 };
 
 const DiscoveryImageForm: React.FC<DiscoveryImageFormProps> = ({
@@ -53,7 +53,7 @@ const DiscoveryImageForm: React.FC<DiscoveryImageFormProps> = ({
           formValues,
           ocmPullSecret,
         );
-        onSuccess();
+        await onSuccess();
         dispatch(updateCluster(updatedCluster));
       } catch (error) {
         handleApiError(error, () => {

--- a/src/ocm/components/clusterConfiguration/DiscoveryImageSummary.tsx
+++ b/src/ocm/components/clusterConfiguration/DiscoveryImageSummary.tsx
@@ -1,24 +1,25 @@
 import React from 'react';
-import { Cluster, isSNO } from '../../../common';
 import DownloadIso from '../../../common/components/clusterConfiguration/DownloadIso';
 
 type DiscoveryImageSummaryProps = {
-  cluster: Cluster;
+  clusterName: string;
+  isSNO: boolean;
   isoDownloadUrl: string;
   onClose: () => void;
   onReset: () => void;
 };
 
 const DiscoveryImageSummary = ({
-  cluster,
+  clusterName,
+  isSNO,
   isoDownloadUrl,
   ...restProps
 }: DiscoveryImageSummaryProps) => {
   return (
     <DownloadIso
-      fileName={`discovery_image_${cluster.name || ''}.iso`}
+      fileName={`discovery_image_${clusterName}.iso`}
       downloadUrl={isoDownloadUrl}
-      isSNO={isSNO(cluster)}
+      isSNO={isSNO}
       {...restProps}
     />
   );

--- a/src/ocm/components/clusterConfiguration/DiscoveryImageSummary.tsx
+++ b/src/ocm/components/clusterConfiguration/DiscoveryImageSummary.tsx
@@ -1,24 +1,23 @@
 import React from 'react';
-import { Cluster, ErrorState, isSNO } from '../../../common';
+import { Cluster, isSNO } from '../../../common';
 import DownloadIso from '../../../common/components/clusterConfiguration/DownloadIso';
-import useInfraEnvImageUrl from '../../hooks/useInfraEnvImageUrl';
 
 type DiscoveryImageSummaryProps = {
   cluster: Cluster;
+  isoDownloadUrl: string;
   onClose: () => void;
-  onReset?: () => void;
+  onReset: () => void;
 };
 
-const DiscoveryImageSummary: React.FC<DiscoveryImageSummaryProps> = ({ cluster, ...restProps }) => {
-  const { imageUrl, error } = useInfraEnvImageUrl(cluster.id);
-  if (error) {
-    return <ErrorState />;
-  }
-
+const DiscoveryImageSummary = ({
+  cluster,
+  isoDownloadUrl,
+  ...restProps
+}: DiscoveryImageSummaryProps) => {
   return (
     <DownloadIso
-      fileName={`discovery_image_${cluster.name}.iso`}
-      downloadUrl={imageUrl}
+      fileName={`discovery_image_${cluster.name || ''}.iso`}
+      downloadUrl={isoDownloadUrl}
       isSNO={isSNO(cluster)}
       {...restProps}
     />

--- a/src/ocm/components/clusterConfiguration/discoveryImageModal.tsx
+++ b/src/ocm/components/clusterConfiguration/discoveryImageModal.tsx
@@ -71,7 +71,8 @@ export const DiscoveryImageModal: React.FC = () => {
       {isoDownloadError && <ErrorState />}
       {isoDownloadUrl ? (
         <DiscoveryImageSummary
-          cluster={cluster}
+          clusterName={cluster.name || ''}
+          isSNO={isSNOCluster}
           onClose={close}
           onReset={onReset}
           isoDownloadUrl={isoDownloadUrl}

--- a/src/ocm/components/clusterConfiguration/discoveryImageModal.tsx
+++ b/src/ocm/components/clusterConfiguration/discoveryImageModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Modal, Button, ButtonVariant, ModalVariant } from '@patternfly/react-core';
-import { Cluster, isSNO, ToolbarButton } from '../../../common';
+import { Cluster, ErrorState, isSNO, ToolbarButton } from '../../../common';
 import DiscoveryImageForm from './DiscoveryImageForm';
 import DiscoveryImageSummary from './DiscoveryImageSummary';
 import { useModalDialogsContext } from '../hosts/ModalDialogsContext';
@@ -35,6 +35,7 @@ export const DiscoveryImageModalButton: React.FC<DiscoveryImageModalButtonProps>
 
 export const DiscoveryImageModal: React.FC = () => {
   const [isoDownloadUrl, setIsoDownloadUrl] = React.useState<string>('');
+  const [isoDownloadError, setIsoDownloadError] = React.useState<string>('');
 
   const { discoveryImageDialog } = useModalDialogsContext();
   const { data, isOpen, close } = discoveryImageDialog;
@@ -42,8 +43,9 @@ export const DiscoveryImageModal: React.FC = () => {
   const { getImageUrl } = useInfraEnvImageUrl(cluster?.id);
 
   const onImageReady = React.useCallback(async () => {
-    const url = await getImageUrl();
+    const { url, error } = await getImageUrl();
     setIsoDownloadUrl(url);
+    setIsoDownloadError(error);
   }, [getImageUrl]);
 
   const onReset = React.useCallback(() => {
@@ -66,6 +68,7 @@ export const DiscoveryImageModal: React.FC = () => {
       hasNoBodyWrapper
       id="generate-discovery-iso-modal"
     >
+      {isoDownloadError && <ErrorState />}
       {isoDownloadUrl ? (
         <DiscoveryImageSummary
           cluster={cluster}

--- a/src/ocm/hooks/useInfraEnvImageUrl.ts
+++ b/src/ocm/hooks/useInfraEnvImageUrl.ts
@@ -1,18 +1,15 @@
 import React from 'react';
 import useInfraEnvId from './useInfraEnvId';
-import { Cluster, PresignedUrl } from '../../common';
+import { Cluster } from '../../common';
 import { InfraEnvsAPI } from '../services/apis';
-import { getErrorMessage } from '../../common/utils';
 
 export default function useInfraEnvImageUrl(clusterId: Cluster['id']) {
-  const { infraEnvId, error: infraEnvIdError } = useInfraEnvId(clusterId);
-  const [imageUrl, setImageUrl] = React.useState<PresignedUrl['url']>();
-  const [error, setError] = React.useState('');
+  const { infraEnvId } = useInfraEnvId(clusterId);
 
-  const getImageUrl = React.useCallback(async () => {
+  const getImageUrl = React.useCallback(async (): Promise<string> => {
     try {
       if (!infraEnvId) {
-        return;
+        return '';
       }
       const {
         data: { url },
@@ -20,19 +17,11 @@ export default function useInfraEnvImageUrl(clusterId: Cluster['id']) {
       if (!url) {
         throw 'Failed to retrieve the image URL, the API returned an invalid URL';
       }
-      setImageUrl(url);
+      return url;
     } catch (e) {
-      setError(getErrorMessage(e));
+      return '';
     }
   }, [infraEnvId]);
 
-  React.useEffect(() => {
-    if (infraEnvIdError) {
-      setError(infraEnvIdError);
-    } else if (!imageUrl) {
-      void getImageUrl();
-    }
-  }, [imageUrl, getImageUrl, infraEnvId, infraEnvIdError]);
-
-  return { imageUrl, error, isLoading: (!imageUrl || !infraEnvId) && !error };
+  return { getImageUrl };
 }

--- a/src/ocm/hooks/useInfraEnvImageUrl.ts
+++ b/src/ocm/hooks/useInfraEnvImageUrl.ts
@@ -1,15 +1,21 @@
 import React from 'react';
 import useInfraEnvId from './useInfraEnvId';
-import { Cluster } from '../../common';
+import { Cluster, PresignedUrl } from '../../common';
 import { InfraEnvsAPI } from '../services/apis';
+import { getErrorMessage } from '../../common/utils';
+
+type ImgUrl = {
+  url: PresignedUrl['url'];
+  error: string;
+};
 
 export default function useInfraEnvImageUrl(clusterId: Cluster['id']) {
-  const { infraEnvId } = useInfraEnvId(clusterId);
+  const { infraEnvId, error: infraEnvError } = useInfraEnvId(clusterId);
 
-  const getImageUrl = React.useCallback(async (): Promise<string> => {
+  const getImageUrl = React.useCallback(async (): Promise<ImgUrl> => {
     try {
       if (!infraEnvId) {
-        return '';
+        return { url: '', error: infraEnvError || 'Missing infraEnv' };
       }
       const {
         data: { url },
@@ -17,11 +23,11 @@ export default function useInfraEnvImageUrl(clusterId: Cluster['id']) {
       if (!url) {
         throw 'Failed to retrieve the image URL, the API returned an invalid URL';
       }
-      return url;
+      return { url, error: '' };
     } catch (e) {
-      return '';
+      return { url: '', error: getErrorMessage(e) };
     }
-  }, [infraEnvId]);
+  }, [infraEnvError, infraEnvId]);
 
   return { getImageUrl };
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-11344

After we update the cluster to generate the new ISO download URL, we retrieve the URL from the infraEnv.
Until we receive the infraEnv URL, we must stay in the initial page showing the "generating" button, and not move to the "download ISO is ready" page.

This PR fixes that by making sure the action for "Generating" waits until the infraenv image is received.