### PR TITLE
MGMT-11345 Wait until infraEnv is received to display Image config

### DIFF
--- a/src/ocm/components/clusterConfiguration/DiscoveryImageForm.tsx
+++ b/src/ocm/components/clusterConfiguration/DiscoveryImageForm.tsx
@@ -8,6 +8,7 @@ import {
   DiscoveryImageConfigForm,
   DiscoveryImageFormValues,
   ErrorState,
+  LoadingState,
 } from '../../../common';
 import { updateCluster, forceReload } from '../../reducers/clusters';
 import { usePullSecret } from '../../hooks';
@@ -71,16 +72,19 @@ const DiscoveryImageForm: React.FC<DiscoveryImageFormProps> = ({
   if (infraEnvError) {
     return <ErrorState />;
   }
+  if (!infraEnv) {
+    return <LoadingState />;
+  }
 
   return (
     <DiscoveryImageConfigForm
       onCancel={handleCancel}
       handleSubmit={handleSubmit}
-      sshPublicKey={infraEnv?.sshAuthorizedKey}
-      httpProxy={infraEnv?.proxy?.httpProxy}
-      httpsProxy={infraEnv?.proxy?.httpsProxy}
-      noProxy={infraEnv?.proxy?.noProxy}
-      imageType={infraEnv?.type}
+      sshPublicKey={infraEnv.sshAuthorizedKey}
+      httpProxy={infraEnv.proxy?.httpProxy}
+      httpsProxy={infraEnv.proxy?.httpsProxy}
+      noProxy={infraEnv.proxy?.noProxy}
+      imageType={infraEnv.type}
     />
   );
 };


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-11345

The SSH key was not displayed as the configuration was generated before the infraEnv was received.
After the infraEnv is loaded, we will show the "generating" button while the image is being generated

https://user-images.githubusercontent.com/829045/181450050-80b1c0f0-b818-49f2-8316-79da68d79758.mp4
