### PR TITLE
Revert "Version v2.7.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openshift-assisted-ui-lib",
-  "version": "2.7.1",
+  "version": "0.0.0",
   "description": "React component library for the Bare Metal Installer",
   "license": "Apache-2.0",
   "repository": "openshift-assisted/assisted-ui-lib",


### PR DESCRIPTION
This reverts commit 60397cb071f7810a3c1333c9415a9a1fe8a77257.

v2.7.1  was created by mistake on top of `master` instead of `releases/v2.7` branch