### PR TITLE
MGMT-11392: New cluster creation failed when OCP v4.11 is selected by default (#1551)

### DIFF
--- a/src/ocm/hooks/useOpenshiftVersions.tsx
+++ b/src/ocm/hooks/useOpenshiftVersions.tsx
@@ -90,7 +90,7 @@ export default function useOpenshiftVersions(): UseOpenshiftVersionsType {
 
   return {
     error,
-    loading: !error && !versions,
+    loading: !error && versions.length === 0,
     versions,
     normalizeClusterVersion,
     isSupportedOpenShiftVersion,


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-11392