### PR TITLE
Enable seting host installation disk

### DIFF
--- a/src/cim/components/Agent/AgentsSelectionTable.tsx
+++ b/src/cim/components/Agent/AgentsSelectionTable.tsx
@@ -22,14 +22,30 @@ import DefaultEmptyState from '../../../common/components/ui/uiState/EmptyState'
 import { usePagination } from '../../../common/components/hosts/usePagination';
 import { useFormikHelpers } from '../../../common/hooks/useFormikHelpers';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
+import { HostDetail } from '../../../common/components/hosts/HostRowDetail';
+import { ExpandComponentProps } from '../../../common/components/hosts/AITable';
+import { Host } from '../../../common/api/types';
+import { onDiskRoleType } from '../../../common/components/hosts/DiskRole';
+import { HostsTableActions } from '../../../common/components/hosts/types';
 
 type AgentsSelectionTableProps = {
   matchingAgents: AgentK8sResource[];
   width?: number;
   onEditRole?: AgentTableActions['onEditRole'];
+  onSetInstallationDiskId?: AgentTableActions['onSetInstallationDiskId'];
   onEditHost?: AgentTableActions['onEditHost'];
   onHostSelect?: VoidFunction;
 };
+
+export const getExpandComponent = (
+  onDiskRole: onDiskRoleType,
+  canEditDisks: HostsTableActions['canEditDisks'],
+) =>
+  function ExpandComponent({ obj: host }: ExpandComponentProps<Host>) {
+    return (
+      <HostDetail key={host.id} host={host} onDiskRole={onDiskRole} canEditDisks={canEditDisks} />
+    );
+  };
 
 const AgentsSelectionTable: React.FC<AgentsSelectionTableProps> = ({
   matchingAgents,
@@ -37,6 +53,7 @@ const AgentsSelectionTable: React.FC<AgentsSelectionTableProps> = ({
   width,
   onEditHost,
   onHostSelect,
+  onSetInstallationDiskId,
 }) => {
   const { t } = useTranslation();
   const [{ value: selectedIDs }] =
@@ -77,7 +94,7 @@ const AgentsSelectionTable: React.FC<AgentsSelectionTableProps> = ({
 
   const [hosts, actions, actionResolver] = useAgentsTable(
     { agents: matchingAgents },
-    { onSelect, onEditRole, onEditHost },
+    { onSelect, onEditRole, onEditHost, onSetInstallationDiskId },
   );
 
   const addAll = width && width > 700;
@@ -112,7 +129,11 @@ const AgentsSelectionTable: React.FC<AgentsSelectionTableProps> = ({
       content={content}
       selectedIDs={selectedIDs}
       actionResolver={actionResolver}
-      ExpandComponent={DefaultExpandComponent}
+      ExpandComponent={
+        actions.onDiskRole
+          ? getExpandComponent(actions.onDiskRole, actions.canEditDisks)
+          : DefaultExpandComponent
+      }
       {...actions}
       {...paginationProps}
     >

--- a/src/cim/components/Agent/tableUtils.tsx
+++ b/src/cim/components/Agent/tableUtils.tsx
@@ -351,8 +351,15 @@ export const useAgentsTable = (
   { agents, bmhs, infraEnv, agentClusterInstalls }: AgentsTableResources,
   tableActions?: Partial<AgentTableActions>,
 ): [Host[], HostsTableActions, ActionsResolver<Host>] => {
-  const { onEditHost, onDeleteHost, onEditRole, onSelect, onEditBMH, onUnbindHost } =
-    tableActions || {};
+  const {
+    onEditHost,
+    onDeleteHost,
+    onEditRole,
+    onSelect,
+    onEditBMH,
+    onUnbindHost,
+    onSetInstallationDiskId,
+  } = tableActions || {};
   const { t } = useTranslation();
   const [hosts, actions] = React.useMemo(
     (): [Host[], HostsTableActions] => [
@@ -404,6 +411,16 @@ export const useAgentsTable = (
             }
           : undefined,
         canEditRole: () => !!onEditRole,
+        onDiskRole: onSetInstallationDiskId
+          ? (hostId, diskId) => {
+              const agent = agents.find((a) => a.metadata?.uid === hostId);
+              if (agent && diskId) {
+                return onSetInstallationDiskId(agent, diskId);
+              }
+              return Promise.resolve(agent);
+            }
+          : undefined,
+        canEditDisks: () => !!onSetInstallationDiskId,
         onSelect: onSelect
           ? (host: Host, selected: boolean) => {
               const agent = agents.find((a) => a.metadata?.uid === host.id);
@@ -445,17 +462,18 @@ export const useAgentsTable = (
       },
     ],
     [
+      agents,
+      bmhs,
+      infraEnv,
       onEditHost,
       onDeleteHost,
       onEditRole,
-      agents,
+      onSetInstallationDiskId,
       onSelect,
       onEditBMH,
       onUnbindHost,
-      bmhs,
-      infraEnv,
-      agentClusterInstalls,
       t,
+      agentClusterInstalls,
     ],
   );
   const actionResolver = React.useMemo(() => hostActionResolver(actions), [actions]);

--- a/src/cim/components/ClusterDeployment/ClusterDeploymentHostDiscoveryTable.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentHostDiscoveryTable.tsx
@@ -32,7 +32,8 @@ import { MassChangeHostnameModalProps } from '../../../common/components/hosts/M
 import MassApproveAction from '../modals/MassApproveAction';
 import { usePagination } from '../../../common/components/hosts/usePagination';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
-import { getExpandComponent } from '../Agent/AgentsSelectionTable';
+import { ExpandComponent } from '../Agent/AgentsSelectionTable';
+import { HostsTableDetailContextProvider } from '../../../common/components/hosts/HostsTableDetailContext';
 
 const ClusterDeploymentHostDiscoveryTable: React.FC<ClusterDeploymentHostDiscoveryTableProps> = ({
   agents,
@@ -133,22 +134,23 @@ const ClusterDeploymentHostDiscoveryTable: React.FC<ClusterDeploymentHostDiscove
           />
         </StackItem>
         <StackItem>
-          <HostsTable
-            hosts={hosts}
-            content={content}
-            actionResolver={actionResolver}
-            selectedIDs={selectedHostIDs}
-            setSelectedIDs={setSelectedHostIDs}
-            onSelect={onSelect}
-            ExpandComponent={
-              hostActions.onDiskRole
-                ? getExpandComponent(hostActions.onDiskRole, hostActions.canEditDisks)
-                : DefaultExpandComponent
-            }
-            {...paginationProps}
+          <HostsTableDetailContextProvider
+            canEditDisks={hostActions.canEditDisks}
+            onDiskRole={hostActions.onDiskRole}
           >
-            <HostsTableEmptyState setDiscoveryHintModalOpen={setDiscoveryHintModalOpen} />
-          </HostsTable>
+            <HostsTable
+              hosts={hosts}
+              content={content}
+              actionResolver={actionResolver}
+              selectedIDs={selectedHostIDs}
+              setSelectedIDs={setSelectedHostIDs}
+              onSelect={onSelect}
+              ExpandComponent={hostActions.onDiskRole ? ExpandComponent : DefaultExpandComponent}
+              {...paginationProps}
+            >
+              <HostsTableEmptyState setDiscoveryHintModalOpen={setDiscoveryHintModalOpen} />
+            </HostsTable>
+          </HostsTableDetailContextProvider>
         </StackItem>
       </Stack>
       {isDiscoveryHintModalOpen && (

--- a/src/cim/components/ClusterDeployment/ClusterDeploymentHostDiscoveryTable.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentHostDiscoveryTable.tsx
@@ -32,6 +32,7 @@ import { MassChangeHostnameModalProps } from '../../../common/components/hosts/M
 import MassApproveAction from '../modals/MassApproveAction';
 import { usePagination } from '../../../common/components/hosts/usePagination';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
+import { getExpandComponent } from '../Agent/AgentsSelectionTable';
 
 const ClusterDeploymentHostDiscoveryTable: React.FC<ClusterDeploymentHostDiscoveryTableProps> = ({
   agents,
@@ -41,6 +42,7 @@ const ClusterDeploymentHostDiscoveryTable: React.FC<ClusterDeploymentHostDiscove
   onChangeHostname,
   onChangeBMHHostname,
   onEditRole,
+  onSetInstallationDiskId,
   onEditHost,
   onEditBMH,
   onDeleteHost,
@@ -65,7 +67,7 @@ const ClusterDeploymentHostDiscoveryTable: React.FC<ClusterDeploymentHostDiscove
       bmhs: bareMetalHosts,
       infraEnv,
     },
-    { onEditHost, onEditRole, onEditBMH, onDeleteHost },
+    { onEditHost, onEditRole, onEditBMH, onDeleteHost, onSetInstallationDiskId },
   );
 
   const addAll = width && width > 700;
@@ -138,7 +140,11 @@ const ClusterDeploymentHostDiscoveryTable: React.FC<ClusterDeploymentHostDiscove
             selectedIDs={selectedHostIDs}
             setSelectedIDs={setSelectedHostIDs}
             onSelect={onSelect}
-            ExpandComponent={DefaultExpandComponent}
+            ExpandComponent={
+              hostActions.onDiskRole
+                ? getExpandComponent(hostActions.onDiskRole, hostActions.canEditDisks)
+                : DefaultExpandComponent
+            }
             {...paginationProps}
           >
             <HostsTableEmptyState setDiscoveryHintModalOpen={setDiscoveryHintModalOpen} />

--- a/src/cim/components/ClusterDeployment/ClusterDeploymentHostSelectionStep.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentHostSelectionStep.tsx
@@ -16,7 +16,6 @@ import ClusterDeploymentHostsSelection from './ClusterDeploymentHostsSelection';
 import {
   ClusterDeploymentHostSelectionStepProps,
   ClusterDeploymentHostsSelectionValues,
-  AgentTableActions,
 } from './types';
 import { hostCountValidationSchema } from './validationSchemas';
 import {
@@ -142,14 +141,7 @@ const getSelectedAgents = (
   return agents.filter((agent) => selectedHostIds.includes(agent.metadata?.uid || ''));
 };
 
-type HostSelectionFormProps = {
-  agents: ClusterDeploymentHostSelectionStepProps['agents'];
-  agentClusterInstall: ClusterDeploymentHostSelectionStepProps['agentClusterInstall'];
-  onClose: ClusterDeploymentHostSelectionStepProps['onClose'];
-  clusterDeployment: ClusterDeploymentHostSelectionStepProps['clusterDeployment'];
-  aiConfigMap?: ClusterDeploymentHostSelectionStepProps['aiConfigMap'];
-  onEditRole: AgentTableActions['onEditRole'];
-};
+type HostSelectionFormProps = Omit<ClusterDeploymentHostSelectionStepProps, 'onSaveHostsSelection'>;
 
 const HostSelectionForm: React.FC<HostSelectionFormProps> = ({
   agents,
@@ -158,6 +150,7 @@ const HostSelectionForm: React.FC<HostSelectionFormProps> = ({
   clusterDeployment,
   aiConfigMap,
   onEditRole: onEditRoleInit,
+  onSetInstallationDiskId,
 }) => {
   const { setCurrentStepId } = React.useContext(ClusterDeploymentWizardContext);
   const [showClusterErrors, setShowClusterErrors] = React.useState(false);
@@ -293,6 +286,7 @@ const HostSelectionForm: React.FC<HostSelectionFormProps> = ({
             clusterDeployment={clusterDeployment}
             aiConfigMap={aiConfigMap}
             onEditRole={onEditRole}
+            onSetInstallationDiskId={onSetInstallationDiskId}
             onAutoSelectChange={onAutoSelectChange}
             onHostSelect={onHostSelect}
           />

--- a/src/cim/components/ClusterDeployment/ClusterDeploymentHostsDiscovery.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentHostsDiscovery.tsx
@@ -27,6 +27,7 @@ const ClusterDeploymentHostsDiscovery: React.FC<ClusterDeploymentHostsDiscoveryP
   onCreateBMH,
   onSaveAgent,
   onEditRole,
+  onSetInstallationDiskId,
   onSaveBMH,
   onSaveISOParams,
   onFormSaveError,
@@ -85,6 +86,7 @@ const ClusterDeploymentHostsDiscovery: React.FC<ClusterDeploymentHostsDiscoveryP
                 infraEnv={infraEnv}
                 onEditHost={setEditAgent}
                 onEditRole={onEditRole}
+                onSetInstallationDiskId={onSetInstallationDiskId}
                 onEditBMH={setEditBMH}
                 onChangeHostname={onSaveAgent}
                 onChangeBMHHostname={onChangeBMHHostname}

--- a/src/cim/components/ClusterDeployment/ClusterDeploymentHostsDiscoveryStep.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentHostsDiscoveryStep.tsx
@@ -23,6 +23,7 @@ const ClusterDeploymentHostsDiscoveryStep: React.FC<ClusterDeploymentHostsDiscov
   onCreateBMH,
   onSaveAgent,
   onEditRole,
+  onSetInstallationDiskId,
   onSaveBMH,
   onSaveISOParams,
   onFormSaveError,
@@ -158,6 +159,7 @@ const ClusterDeploymentHostsDiscoveryStep: React.FC<ClusterDeploymentHostsDiscov
             onCreateBMH={onCreateBMH}
             onSaveAgent={onSaveAgent}
             onEditRole={onEditRole}
+            onSetInstallationDiskId={onSetInstallationDiskId}
             onSaveBMH={onSaveBMH}
             onSaveISOParams={onSaveISOParams}
             onFormSaveError={onFormSaveError}

--- a/src/cim/components/ClusterDeployment/ClusterDeploymentHostsSelection.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentHostsSelection.tsx
@@ -21,6 +21,7 @@ const ClusterDeploymentHostsSelection: React.FC<ClusterDeploymentHostsSelectionP
   onEditRole,
   onAutoSelectChange,
   onHostSelect,
+  onSetInstallationDiskId,
 }) => {
   const { values } = useFormikContext<ClusterDeploymentHostsSelectionValues>();
   const { autoSelectHosts } = values;
@@ -78,6 +79,7 @@ const ClusterDeploymentHostsSelection: React.FC<ClusterDeploymentHostsSelectionP
                 availableAgents={availableAgents}
                 onEditRole={onEditRole}
                 onHostSelect={onHostSelect}
+                onSetInstallationDiskId={onSetInstallationDiskId}
               />
             )}
           </Form>

--- a/src/cim/components/ClusterDeployment/ClusterDeploymentHostsSelectionAdvanced.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentHostsSelectionAdvanced.tsx
@@ -16,6 +16,7 @@ type ClusterDeploymentHostsSelectionAdvancedProps = {
   availableAgents: AgentK8sResource[];
   onEditRole?: AgentTableActions['onEditRole'];
   onEditHost?: AgentTableActions['onEditHost'];
+  onSetInstallationDiskId?: AgentTableActions['onSetInstallationDiskId'];
   onHostSelect?: VoidFunction;
 };
 
@@ -24,6 +25,7 @@ type FormValues = ClusterDeploymentHostsSelectionValues | ScaleUpFormValues;
 const ClusterDeploymentHostsSelectionAdvanced = <T extends FormValues>({
   availableAgents,
   onEditRole,
+  onSetInstallationDiskId,
   onEditHost,
   onHostSelect,
 }: ClusterDeploymentHostsSelectionAdvancedProps) => {
@@ -68,6 +70,7 @@ const ClusterDeploymentHostsSelectionAdvanced = <T extends FormValues>({
                 <AgentsSelectionTable
                   matchingAgents={matchingAgents}
                   onEditRole={onEditRole}
+                  onSetInstallationDiskId={onSetInstallationDiskId}
                   width={contentRect.bounds?.width}
                   onEditHost={onEditHost}
                   onHostSelect={onHostSelect}

--- a/src/cim/components/ClusterDeployment/ClusterDeploymentWizard.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentWizard.tsx
@@ -79,6 +79,7 @@ const ClusterDeploymentWizard: React.FC<ClusterDeploymentWizardProps> = ({
               agents={agents}
               aiConfigMap={aiConfigMap}
               onEditRole={hostActions.onEditRole}
+              onSetInstallationDiskId={hostActions.onSetInstallationDiskId}
             />
           );
         }
@@ -109,6 +110,7 @@ const ClusterDeploymentWizard: React.FC<ClusterDeploymentWizardProps> = ({
                 return Promise.resolve(bmh);
               }}
               onEditRole={hostActions.onEditRole}
+              onSetInstallationDiskId={hostActions.onSetInstallationDiskId}
               onApproveAgent={onApproveAgent}
               isBMPlatform={isBMPlatform}
               onDeleteHost={hostActions.onDeleteHost}

--- a/src/cim/components/ClusterDeployment/types.ts
+++ b/src/cim/components/ClusterDeployment/types.ts
@@ -29,6 +29,7 @@ export type AgentTableActions = {
   onEditHost: (agent: AgentK8sResource) => void;
   onEditRole: (agent: AgentK8sResource, role: string | undefined) => Promise<AgentK8sResource>;
   onDeleteHost: (agent?: AgentK8sResource, bmh?: BareMetalHostK8sResource) => void;
+  onSetInstallationDiskId: (agent: AgentK8sResource, diskId: string) => Promise<AgentK8sResource>;
   // eslint-disable-next-line
   onMassDeleteHost: (agent?: AgentK8sResource, bmh?: BareMetalHostK8sResource) => Promise<any>;
   onApprove: (agent: AgentK8sResource) => Promise<AgentK8sResource>;
@@ -125,7 +126,10 @@ export type ClusterDeploymentWizardProps = {
   onApproveAgent: InfraEnvAgentTableProps['onApprove'];
   onFinish: () => Promise<AgentClusterInstallK8sResource>;
 
-  hostActions: Pick<AgentTableActions, 'onEditHost' | 'onEditRole' | 'onDeleteHost'>;
+  hostActions: Pick<
+    AgentTableActions,
+    'onEditHost' | 'onEditRole' | 'onDeleteHost' | 'onSetInstallationDiskId'
+  >;
   clusterImages: ClusterImageSetK8sResource[];
   usedClusterNames: string[];
 
@@ -159,6 +163,7 @@ export type ClusterDeploymentHostsSelectionProps = {
   agents: AgentK8sResource[];
   aiConfigMap?: ConfigMapK8sResource;
   onEditRole: AgentTableActions['onEditRole'];
+  onSetInstallationDiskId: AgentTableActions['onSetInstallationDiskId'];
   onAutoSelectChange: VoidFunction;
   onHostSelect: VoidFunction;
 };
@@ -185,7 +190,7 @@ export type InfraEnvAgentTableProps = Pick<
 
 export type ClusterDeploymentHostDiscoveryTableProps = Pick<
   AgentTableActions,
-  'onEditRole' | 'onEditHost' | 'onEditBMH' | 'onDeleteHost'
+  'onEditRole' | 'onEditHost' | 'onEditBMH' | 'onDeleteHost' | 'onSetInstallationDiskId'
 > & {
   agents: AgentK8sResource[];
   bareMetalHosts: BareMetalHostK8sResource[];
@@ -213,6 +218,7 @@ export type ClusterDeploymentHostsDiscoveryProps = {
   onCreateBMH?: AddHostModalProps['onCreateBMH'];
   onSaveAgent: EditAgentModalProps['onSave'];
   onEditRole: ClusterDeploymentHostDiscoveryTableProps['onEditRole'];
+  onSetInstallationDiskId: AgentTableActions['onSetInstallationDiskId'];
   onSaveBMH: EditBMHModalProps['onEdit'];
   onSaveISOParams: AddHostModalProps['onSaveISOParams'];
   onFormSaveError?: EditAgentModalProps['onFormSaveError'];

--- a/src/cim/components/helpers/toAssisted.ts
+++ b/src/cim/components/helpers/toAssisted.ts
@@ -61,6 +61,7 @@ export const getAIHosts = (
       },
       progressStages: agentProgress?.progressStages,
       bootstrap: agent.status?.bootstrap,
+      installationDiskId: agent.spec.installation_disk_id,
     };
   });
 

--- a/src/cim/types/k8s/agent.ts
+++ b/src/cim/types/k8s/agent.ts
@@ -21,6 +21,7 @@ export type AgentK8sResource = K8sResourceCommon & {
     };
     role: HostRole;
     hostname: string;
+    installation_disk_id?: string;
   };
   status?: {
     conditions?: AgentStatusCondition[];

--- a/src/common/components/hosts/DiskRole.tsx
+++ b/src/common/components/hosts/DiskRole.tsx
@@ -17,7 +17,7 @@ export type onDiskRoleType = (
   hostId: Host['id'],
   diskId: Disk['id'],
   role: DiskRoleValue,
-) => Promise<void>;
+) => Promise<unknown>;
 
 export type DiskRoleProps = {
   host: Host;
@@ -86,7 +86,6 @@ const DiskRoleDropdown: React.FC<DiskRoleDropdownProps> = ({
           await onDiskRole(host.id, disk.id, event.currentTarget.id as DiskRoleValue);
           setDisabled(false);
         }
-        // TODO(mlibra): Improve for the case onDiskRole === undefined
         setOpen(false);
       };
       void asyncFunc();

--- a/src/common/components/hosts/HostsTableDetailContext.tsx
+++ b/src/common/components/hosts/HostsTableDetailContext.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { onDiskRoleType } from './DiskRole';
+import { HostsTableActions } from './types';
+
+type HostsTableDetailContextValue = {
+  onDiskRole: onDiskRoleType | undefined;
+  canEditDisks: HostsTableActions['canEditDisks'];
+};
+
+const HostsTableDetailContext = React.createContext<HostsTableDetailContextValue | undefined>(
+  undefined,
+);
+
+const HostsTableDetailContextProvider: React.FC<HostsTableDetailContextValue> = ({
+  canEditDisks,
+  onDiskRole,
+  children,
+}) => {
+  const context = {
+    canEditDisks,
+    onDiskRole,
+  };
+
+  return (
+    <HostsTableDetailContext.Provider value={context as HostsTableDetailContextValue}>
+      {children}
+    </HostsTableDetailContext.Provider>
+  );
+};
+
+const useHostsTableDetailContext = () => {
+  const context = React.useContext(HostsTableDetailContext);
+  if (context === undefined) {
+    throw new Error(
+      'useHostTableDetailContext must be used within a HostsTableDetailContextProvider',
+    );
+  }
+  return context;
+};
+
+export { HostsTableDetailContextProvider, useHostsTableDetailContext };


### PR DESCRIPTION
Host discovery and host selection wizard steps now allow user to set
installation disk in the disks list on expanded host detail

Fixes BZ2081597