### PR TITLE
MGMT-11545 show correct disk storage

### DIFF
--- a/src/common/components/storage/StorageUtils.tsx
+++ b/src/common/components/storage/StorageUtils.tsx
@@ -1,10 +1,7 @@
 import * as React from 'react';
 import { sortable } from '@patternfly/react-table';
 import { TFunction } from 'i18next';
-import { getHostRole, getInventory, Host, RoleCell, stringToJSON } from '../../index';
-import { getHostRowHardwareInfo } from '../hosts/hardwareInfo';
-import { ValidationsInfo } from '../../types/hosts';
-import HostPropertyValidationPopover from '../hosts/HostPropertyValidationPopover';
+import { getHostRole, getInventory, Host, RoleCell } from '../../index';
 import { TableRow } from '../hosts/AITable';
 
 export const roleColumn = (t: TFunction, schedulableMasters: boolean): TableRow<Host> => {
@@ -71,29 +68,4 @@ export const odfUsageColumn = (excludeMasters: boolean): TableRow<Host> => {
       };
     },
   };
-};
-
-export const totalStorageColumn: TableRow<Host> = {
-  header: {
-    title: 'Total Storage',
-    props: {
-      id: 'col-header-total-storage',
-    },
-    transforms: [sortable],
-  },
-  cell: (host) => {
-    const inventory = getInventory(host);
-    const { memory } = getHostRowHardwareInfo(inventory);
-    const validationsInfo = stringToJSON<ValidationsInfo>(host.validationsInfo) || {};
-    const memoryValidation = validationsInfo?.hardware?.find((v) => v.id === 'has-memory-for-role');
-    return {
-      title: (
-        <HostPropertyValidationPopover validation={memoryValidation}>
-          {memory.title}
-        </HostPropertyValidationPopover>
-      ),
-      props: { 'data-testid': 'host-memory' },
-      sortableValue: memory.sortableValue,
-    };
-  },
 };

--- a/src/common/components/storage/StorageUtils.tsx
+++ b/src/common/components/storage/StorageUtils.tsx
@@ -53,8 +53,6 @@ export const odfUsageColumn = (excludeMasters: boolean): TableRow<Host> => {
       transforms: [sortable],
     },
     cell: (host) => {
-      const inventory = getInventory(host);
-      const disks = inventory.disks || [];
       const isMaster = host.role === 'master' || host.suggestedRole === 'master';
       const isExcluded = excludeMasters && isMaster;
       return {
@@ -64,7 +62,7 @@ export const odfUsageColumn = (excludeMasters: boolean): TableRow<Host> => {
           'Use ODF'
         ),
         props: { 'data-testid': 'use-odf' },
-        sortableValue: disks.length,
+        sortableValue: Number(isExcluded),
       };
     },
   };

--- a/src/ocm/components/hosts/HostsStorageTable.tsx
+++ b/src/ocm/components/hosts/HostsStorageTable.tsx
@@ -4,9 +4,9 @@ import {
   hostnameColumn,
   roleColumn,
   countColumn,
+  disksColumn,
 } from '../../../common/components/hosts/tableUtils';
 import {
-  totalStorageColumn,
   odfUsageColumn,
   numberOfDisksColumn,
 } from '../../../common/components/storage/StorageUtils';
@@ -48,7 +48,7 @@ const HostsStorageTable = ({ cluster }: { cluster: Cluster }) => {
       hostnameColumn(t, onEditHost, undefined, actionChecks.canEditHostname),
       roleColumn(t, undefined, undefined, selectSchedulableMasters(cluster)),
       hardwareStatusColumn(),
-      totalStorageColumn,
+      disksColumn,
       numberOfDisksColumn,
     ];
     if (hasODFOperators(cluster)) {


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-11545

- The column for memory was shown instead of disk size. It was likely a rebase conflict.
- The ODF column was being sorted based on the number of disks, now it's sorted by the ODF status instead.

Result:
![disk-size](https://user-images.githubusercontent.com/829045/183595428-54a971c5-d384-4f96-aabe-af1374c1d4cd.png)

