### PR TITLE
MGMT-11522: Host role is editable after install

### DIFF
--- a/src/common/components/hosts/utils.ts
+++ b/src/common/components/hosts/utils.ts
@@ -52,7 +52,8 @@ export const canReset = (clusterStatus: Cluster['status'], status: Host['status'
   ['adding-hosts'].includes(clusterStatus) &&
   ['error', 'installing-pending-user-action'].includes(status);
 
-export const canEditRole = (cluster: Cluster): boolean => !isSNO(cluster);
+export const canEditRole = (cluster: Cluster): boolean =>
+  !isSNO(cluster) && cluster.status !== 'installed';
 
 export const canEditHost = (clusterStatus: Cluster['status'], status: Host['status']) =>
   ['pending-for-input', 'insufficient', 'ready'].includes(clusterStatus) &&


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-11522

If cluster is installed host role selection should be blocked once it's not possible to change it anymore.

