### PR TITLE
MGMT-10110 Readonly cluster

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "prepare": "install-peers",
     "test": "run-s test:circular lint format:check",
     "test:circular": "dpdm --warning false --tree false --exit-code circular:1 ./src/index.ts",
-    "lint": "eslint . --max-warnings=303 --color",
+    "lint": "eslint . --max-warnings=293 --color",
     "lint:fix": "yarn run lint --fix",
     "format": "prettier --write '**/*.{json,md,scss,yaml,yml}'",
     "format:check": "prettier --check '**/*.{json,md,scss,yaml,yml}'",

--- a/src/common/components/clusterConfiguration/SecurityFields.tsx
+++ b/src/common/components/clusterConfiguration/SecurityFields.tsx
@@ -28,9 +28,14 @@ const label = 'Host SSH Public Key for troubleshooting after installation';
 interface SecurityFieldsFieldsProps {
   clusterSshKey: Cluster['sshPublicKey'];
   imageSshKey?: Cluster['imageInfo']['sshPublicKey'];
+  isDisabled?: boolean;
 }
 
-const SecurityFields: React.FC<SecurityFieldsFieldsProps> = ({ clusterSshKey, imageSshKey }) => {
+const SecurityFields = ({
+  clusterSshKey,
+  imageSshKey,
+  isDisabled = false,
+}: SecurityFieldsFieldsProps) => {
   //shareSshKey shouldn't response to changes. imageSshKey stays the same, there's a loading state while it's requested
   //clusterSshKey updating causes the textarea to disappear when the user clears it to edit it
   const defaultShareSshKey = !!imageSshKey && (clusterSshKey === imageSshKey || !clusterSshKey);
@@ -47,10 +52,10 @@ const SecurityFields: React.FC<SecurityFieldsFieldsProps> = ({ clusterSshKey, im
   };
 
   React.useEffect(() => {
-    if (shareSshKey) {
+    if (!isDisabled && shareSshKey) {
       setFieldValue('sshPublicKey', imageSshKey);
     }
-  }, [shareSshKey, imageSshKey, setFieldValue]);
+  }, [shareSshKey, imageSshKey, setFieldValue, isDisabled]);
 
   const fieldId = getFieldId('shareDiscoverySshKey', 'checkbox');
   const { t } = useTranslation();

--- a/src/common/components/clusterConfiguration/SecurityFields.tsx
+++ b/src/common/components/clusterConfiguration/SecurityFields.tsx
@@ -74,6 +74,7 @@ const SecurityFields = ({
             label={t('ai:Use the same host discovery SSH key')}
             aria-describedby={`${fieldId}-helper`}
             isChecked={shareSshKey}
+            isDisabled={isDisabled}
             onChange={setShareSshKey}
           />
         </RenderIf>
@@ -82,6 +83,7 @@ const SecurityFields = ({
             name="sshPublicKey"
             helperText={<SshPublicKeyHelperText />}
             onBlur={handleSshKeyBlur}
+            isDisabled={isDisabled}
           />
         </RenderIf>
       </FormGroup>

--- a/src/common/components/clusterDetail/ConsoleModal.tsx
+++ b/src/common/components/clusterDetail/ConsoleModal.tsx
@@ -8,8 +8,7 @@ import {
   ExpandableSection,
 } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
-import { Cluster } from '../../api/types';
-import { removeProtocolFromURL } from '../../api/utils';
+import { Cluster, removeProtocolFromURL } from '../../api';
 import { ToolbarButton } from '../ui/Toolbar';
 import PrismCode from '../ui/PrismCode';
 import { useTranslation } from '../../hooks/use-translation-wrapper';
@@ -55,7 +54,7 @@ const ModalExpandableSection: React.FC<ModalExpandableSectionProps> = (props) =>
 export const WebConsoleHint: React.FC<WebConsoleHintProps> = ({ cluster, consoleUrl }) => {
   const [isDNSExpanded, setIsDNSExpanded] = React.useState(true);
   const handleToggle = () => setIsDNSExpanded(!isDNSExpanded);
-  const [apiVip, ingressVip] = [cluster.apiVip, cluster.ingressVip];
+  const [apiVip = '', ingressVip = ''] = [cluster.apiVip, cluster.ingressVip];
   const clusterUrl = `${cluster.name}.${cluster.baseDnsDomain}`;
   const appsUrl = `apps.${clusterUrl}`;
   const etcHosts = [

--- a/src/common/components/clusterWizard/networkingSteps/NetworkTypeControlGroup.tsx
+++ b/src/common/components/clusterWizard/networkingSteps/NetworkTypeControlGroup.tsx
@@ -6,13 +6,16 @@ import { NETWORK_TYPE_OVN, NETWORK_TYPE_SDN } from '../../../config';
 import { useTranslation } from '../../../hooks/use-translation-wrapper';
 
 const GROUP_NAME = 'networkType';
+
 export interface NetworkTypeControlGroupProps {
+  isDisabled?: boolean;
   isSDNSelectable: boolean;
 }
 
-export const NetworkTypeControlGroup: React.FC<NetworkTypeControlGroupProps> = ({
+export const NetworkTypeControlGroup = ({
+  isDisabled = false,
   isSDNSelectable,
-}) => {
+}: NetworkTypeControlGroupProps) => {
   const { t } = useTranslation();
   return (
     <FormGroup fieldId={GROUP_NAME} label="Network type">
@@ -27,7 +30,7 @@ export const NetworkTypeControlGroup: React.FC<NetworkTypeControlGroupProps> = (
             <RadioField
               id={GROUP_NAME}
               name={GROUP_NAME}
-              isDisabled={!isSDNSelectable}
+              isDisabled={isDisabled || !isSDNSelectable}
               value={NETWORK_TYPE_SDN}
               label={
                 <>
@@ -46,6 +49,7 @@ export const NetworkTypeControlGroup: React.FC<NetworkTypeControlGroupProps> = (
           <RadioField
             id={GROUP_NAME}
             name={GROUP_NAME}
+            isDisabled={isDisabled}
             value={NETWORK_TYPE_OVN}
             label={
               <>

--- a/src/common/components/ui/formik/CodeField.tsx
+++ b/src/common/components/ui/formik/CodeField.tsx
@@ -8,7 +8,7 @@ import { CodeEditor } from '@patternfly/react-code-editor';
 import useFieldErrorMsg from '../../../hooks/useFieldErrorMsg';
 import { monaco } from 'react-monaco-editor';
 
-const CodeField: React.FC<CodeFieldProps> = ({
+const CodeField = ({
   label,
   labelIcon,
   helperText,
@@ -18,7 +18,8 @@ const CodeField: React.FC<CodeFieldProps> = ({
   language,
   name,
   description,
-}) => {
+  isDisabled,
+}: CodeFieldProps) => {
   const [field, , { setValue, setTouched }] = useField({ name, validate });
   const fieldId = getFieldId(name, 'input', idPostfix);
   const [monacoSubscription, setMonacoSubscription] = React.useState<monaco.IDisposable>();
@@ -74,7 +75,7 @@ const CodeField: React.FC<CodeFieldProps> = ({
         )}
         <CodeEditor
           code={field.value}
-          isUploadEnabled
+          isUploadEnabled={!isDisabled}
           isDownloadEnabled
           isCopyEnabled
           isLanguageLabelVisible

--- a/src/common/components/ui/formik/InputField.tsx
+++ b/src/common/components/ui/formik/InputField.tsx
@@ -69,8 +69,10 @@ const InputField: React.FC<
               isRequired={isRequired}
               aria-describedby={`${fieldId}-helper`}
               onChange={(value, event) => {
-                !noDefaultOnChange && field.onChange(event);
-                onChange && onChange(event);
+                if (!props.isDisabled) {
+                  !noDefaultOnChange && field.onChange(event);
+                  onChange && onChange(event);
+                }
               }}
             />
           </SplitItem>

--- a/src/common/components/ui/formik/RichInputField.tsx
+++ b/src/common/components/ui/formik/RichInputField.tsx
@@ -71,7 +71,7 @@ export const RichValidation: React.FC<RichValidationProps> = ({
   );
 };
 
-type RichInputFieldPropsProps = BaseInputProps & {
+export type RichInputFieldPropsProps = BaseInputProps & {
   richValidationMessages: RichValidationProps['richValidationMessages'];
   placeholder?: string;
 };

--- a/src/common/components/ui/formik/types.ts
+++ b/src/common/components/ui/formik/types.ts
@@ -27,8 +27,8 @@ export interface FieldProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ref?: React.Ref<any>;
   validate?: FieldValidator;
-  min?: number;
-  max?: number;
+  min?: number | string;
+  max?: number | string;
   idPostfix?: string;
   callFormikOnChange?: boolean;
 }

--- a/src/common/features/featureGate.tsx
+++ b/src/common/features/featureGate.tsx
@@ -12,6 +12,15 @@ export type FeatureListType = {
   [key in AssistedInstallerFeatureType]?: boolean;
 };
 
+export type AssistedInstallerOCMPermissionTypes = 'canEdit';
+export type AssistedInstallerOCMPermissionTypesListType = {
+  [key in AssistedInstallerOCMPermissionTypes]: boolean;
+};
+export type AssistedInstallerPermissionTypes = 'isViewerMode';
+export type AssistedInstallerPermissionTypesListType = {
+  [key in AssistedInstallerPermissionTypes]: boolean;
+};
+
 // Hardcoded for ACM
 export const ACM_ENABLED_FEATURES: FeatureListType = {
   ASSISTED_INSTALLER_SNO_FEATURE: true,

--- a/src/ocm/components/AddHosts/utils.ts
+++ b/src/ocm/components/AddHosts/utils.ts
@@ -11,7 +11,7 @@ const isSNOExpansionAllowed = (cluster: OcmClusterType) => {
 };
 
 export const canAddHost = ({ cluster }: { cluster: OcmClusterType }) => {
-  if (!Day2ClusterService.getOpenshiftClusterId(cluster)) {
+  if (!cluster.canEdit || !Day2ClusterService.getOpenshiftClusterId(cluster)) {
     return false;
   }
 

--- a/src/ocm/components/clusterConfiguration/ArmCheckbox.tsx
+++ b/src/ocm/components/clusterConfiguration/ArmCheckbox.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { Checkbox, FormGroup, Tooltip } from '@patternfly/react-core';
+import { FormGroup, Tooltip } from '@patternfly/react-core';
 import { useField, useFormikContext } from 'formik';
 import {
   getFieldId,
+  isArmArchitecture,
   ClusterCreateParams,
   HelperText,
   PopoverIcon,
@@ -13,7 +14,7 @@ import {
   FeatureSupportLevelBadge,
   useFeatureSupportLevel,
 } from '../../../common/components/featureSupportLevels';
-import { isArmArchitecture } from '../../../common/selectors/clusterSelectors';
+import { OcmCheckbox } from '../ui/OcmFormFields';
 
 const getLabel = (openshiftVersion: string) => {
   return (
@@ -74,7 +75,7 @@ const ArmCheckbox: React.FC<ArmCheckboxProps> = ({ versions }) => {
   return (
     <FormGroup isInline fieldId={fieldId}>
       <Tooltip hidden={!disabledReason} content={disabledReason}>
-        <Checkbox
+        <OcmCheckbox
           id={fieldId}
           name={name}
           isDisabled={featureSupportLevelContext.isFeatureDisabled(

--- a/src/ocm/components/clusterConfiguration/HostInventory.tsx
+++ b/src/ocm/components/clusterConfiguration/HostInventory.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import {
   Text,
   TextContent,
@@ -11,22 +12,23 @@ import {
   Split,
   SplitItem,
 } from '@patternfly/react-core';
+import { useFormikContext } from 'formik';
 import {
   Cluster,
+  HostDiscoveryValues,
   PopoverIcon,
   useFeature,
   ClusterWizardStepHeader,
-  SwitchField,
   selectMastersMustRunWorkloads,
   selectSchedulableMasters,
-  HostDiscoveryValues,
   isClusterPlatformTypeVM,
 } from '../../../common';
 import HostsDiscoveryTable from '../hosts/HostsDiscoveryTable';
 import { DiscoveryImageModalButton } from './discoveryImageModal';
 import InformationAndAlerts from './InformationAndAlerts';
 import { useClusterSupportedPlatforms } from '../../hooks';
-import { useFormikContext } from 'formik';
+import { OcmSwitchField } from '../ui/OcmFormFields';
+import { selectCurrentClusterPermissionsState } from '../../selectors';
 
 const PlatformIntegrationLabel: React.FC = () => (
   <>
@@ -77,6 +79,7 @@ const HostInventory = ({ cluster }: { cluster: Cluster }) => {
   );
   const mastersMustRunWorkloads = selectMastersMustRunWorkloads(cluster);
   const { setFieldValue } = useFormikContext<HostDiscoveryValues>();
+  const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
 
   React.useEffect(() => {
     setFieldValue('schedulableMasters', selectSchedulableMasters(cluster));
@@ -88,21 +91,23 @@ const HostInventory = ({ cluster }: { cluster: Cluster }) => {
         <ClusterWizardStepHeader>Host discovery</ClusterWizardStepHeader>
       </StackItem>
       <StackItem>
-        <TextContent>
-          <Text component="p">
-            <DiscoveryImageModalButton
-              ButtonComponent={Button}
-              cluster={cluster}
-              idPrefix="host-inventory"
-            />
-          </Text>
-        </TextContent>
+        {!isViewerMode && (
+          <TextContent>
+            <Text component="p">
+              <DiscoveryImageModalButton
+                ButtonComponent={Button}
+                cluster={cluster}
+                idPrefix="host-inventory"
+              />
+            </Text>
+          </TextContent>
+        )}
       </StackItem>
       {isPlatformIntegrationFeatureEnabled && (
         <StackItem>
           <Split hasGutter>
             <SplitItem>
-              <SwitchField
+              <OcmSwitchField
                 tooltipProps={{
                   hidden: isPlatformIntegrationSupported,
                   content: platformIntegrationTooltip,
@@ -117,7 +122,7 @@ const HostInventory = ({ cluster }: { cluster: Cluster }) => {
         </StackItem>
       )}
       <StackItem>
-        <SwitchField
+        <OcmSwitchField
           tooltipProps={{
             hidden: !mastersMustRunWorkloads,
             content: schedulableMastersTooltip,

--- a/src/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
+++ b/src/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
@@ -5,16 +5,12 @@ import { useFormikContext } from 'formik';
 import ArmCheckbox from './ArmCheckbox';
 import { HostsNetworkConfigurationControlGroup } from './HostsNetworkConfigurationControlGroup';
 import {
-  CheckboxField,
   ClusterDetailsValues,
-  InputField,
   isSNO,
   ManagedDomain,
   OpenshiftVersionOptionType,
   OpenShiftVersionSelect,
   PullSecret,
-  RichInputField,
-  SelectField,
   SNOControlGroup,
   StaticTextField,
   ocmClusterNameValidationMessages,
@@ -22,10 +18,14 @@ import {
 } from '../../../common';
 import DiskEncryptionControlGroup from '../../../common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionControlGroup';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
-import useClusterPermissions from '../../hooks/useClusterPermissions';
+import {
+  OcmCheckboxField,
+  OcmInputField,
+  OcmRichInputField,
+  OcmSelectField,
+} from '../ui/OcmFormFields';
 
 export type OcmClusterDetailsFormFieldsProps = {
-  canEditPullSecret: boolean;
   forceOpenshiftVersion?: string;
   isBaseDnsDomainDisabled?: boolean;
   defaultPullSecret?: string;
@@ -59,8 +59,6 @@ export const OcmClusterDetailsFormFields = ({
   clusterExists,
 }: OcmClusterDetailsFormFieldsProps) => {
   const { values } = useFormikContext<ClusterDetailsValues>();
-  const { isViewerMode: realViewerMode } = useClusterPermissions();
-  const isViewerMode = clusterExists && realViewerMode;
   const { name, baseDnsDomain, highAvailabilityMode, useRedHatDnsService } = values;
   const nameInputRef = React.useRef<HTMLInputElement>();
   React.useEffect(() => {
@@ -70,12 +68,11 @@ export const OcmClusterDetailsFormFields = ({
   const { t } = useTranslation();
   return (
     <Form id="wizard-cluster-details__form">
-      <RichInputField
+      <OcmRichInputField
         ref={nameInputRef}
         label="Cluster name"
         name="name"
         placeholder={isOcm ? '' : 'Enter cluster name'}
-        isDisabled={isViewerMode}
         isRequired
         richValidationMessages={
           useRedHatDnsService
@@ -84,20 +81,18 @@ export const OcmClusterDetailsFormFields = ({
         }
       />
       {!!managedDomains.length && toggleRedHatDnsService && (
-        <CheckboxField
+        <OcmCheckboxField
           name="useRedHatDnsService"
           label="Use a temporary 60-day domain"
           helperText="A base domain will be provided for temporary, non-production clusters."
-          isDisabled={isViewerMode}
           onChange={toggleRedHatDnsService}
         />
       )}
       {useRedHatDnsService ? (
-        <SelectField
+        <OcmSelectField
           label="Base domain"
           name="baseDnsDomain"
           helperText={<BaseDnsHelperText name={name} baseDnsDomain={baseDnsDomain} />}
-          isDisabled={isViewerMode}
           options={managedDomains.map((d) => ({
             label: `${d.domain || ''} (${d.provider || ''})`,
             value: d.domain,
@@ -105,10 +100,9 @@ export const OcmClusterDetailsFormFields = ({
           isRequired
         />
       ) : (
-        <InputField
+        <OcmInputField
           label="Base domain"
           name="baseDnsDomain"
-          isReadOnly={isViewerMode}
           helperText={<BaseDnsHelperText name={name} baseDnsDomain={baseDnsDomain} />}
           placeholder="example.com"
           isDisabled={isBaseDnsDomainDisabled || useRedHatDnsService}
@@ -129,7 +123,7 @@ export const OcmClusterDetailsFormFields = ({
       <HostsNetworkConfigurationControlGroup clusterExists={clusterExists} />
       <DiskEncryptionControlGroup
         values={values}
-        isDisabled={isViewerMode || isPullSecretSet}
+        isDisabled={isPullSecretSet}
         isSNO={isSNO({ highAvailabilityMode })}
       />
     </Form>

--- a/src/ocm/components/clusterConfiguration/ReviewStep.tsx
+++ b/src/ocm/components/clusterConfiguration/ReviewStep.tsx
@@ -10,10 +10,12 @@ import ClusterWizardNavigation from '../clusterWizard/ClusterWizardNavigation';
 import ReviewCluster from './ReviewCluster';
 import { ClustersService } from '../../services';
 import { useStateSafely } from '../../../common/hooks';
+import useClusterPermissions from '../../hooks/useClusterPermissions';
 
 const ReviewStep: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
   const { addAlert } = useAlerts();
   const clusterWizardContext = useClusterWizardContext();
+  const { isViewerMode } = useClusterPermissions();
   const [isStartingInstallation, setIsStartingInstallation] = useStateSafely(false);
   const dispatch = useDispatch();
 
@@ -48,7 +50,7 @@ const ReviewStep: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
             variant={ButtonVariant.primary}
             name="install"
             onClick={handleClusterInstall}
-            isDisabled={isStartingInstallation || cluster.status !== 'ready'}
+            isDisabled={isViewerMode || isStartingInstallation || cluster.status !== 'ready'}
           >
             Install cluster
           </Button>

--- a/src/ocm/components/clusterConfiguration/ReviewStep.tsx
+++ b/src/ocm/components/clusterConfiguration/ReviewStep.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { ActionListItem, Button, ButtonVariant, Grid, GridItem } from '@patternfly/react-core';
 import { Cluster, ClusterWizardStepHeader, useAlerts, ClusterWizardStep } from '../../../common';
 import { useClusterWizardContext } from '../clusterWizard/ClusterWizardContext';
@@ -10,12 +10,12 @@ import ClusterWizardNavigation from '../clusterWizard/ClusterWizardNavigation';
 import ReviewCluster from './ReviewCluster';
 import { ClustersService } from '../../services';
 import { useStateSafely } from '../../../common/hooks';
-import useClusterPermissions from '../../hooks/useClusterPermissions';
+import { selectCurrentClusterPermissionsState } from '../../selectors';
 
 const ReviewStep: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
   const { addAlert } = useAlerts();
   const clusterWizardContext = useClusterWizardContext();
-  const { isViewerMode } = useClusterPermissions();
+  const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
   const [isStartingInstallation, setIsStartingInstallation] = useStateSafely(false);
   const dispatch = useDispatch();
 

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/AdvancedNetworkFields.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/AdvancedNetworkFields.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import {
   Alert,
   AlertVariant,
@@ -8,17 +9,21 @@ import {
   Grid,
 } from '@patternfly/react-core';
 import { FieldArray, useFormikContext } from 'formik';
-import { NetworkConfigurationValues } from '../../../../common/types';
-import { useFeature } from '../../../../common/features';
-import { InputField } from '../../../../common/components/ui';
-import { DUAL_STACK, PREFIX_MAX_RESTRICTION } from '../../../../common/config/constants';
+import {
+  DUAL_STACK,
+  PREFIX_MAX_RESTRICTION,
+  useFeature,
+  NetworkConfigurationValues,
+} from '../../../../common';
 import { NetworkTypeControlGroup } from '../../../../common/components/clusterWizard/networkingSteps/NetworkTypeControlGroup';
+import { selectCurrentClusterPermissionsState } from '../../../selectors';
+import { OcmInputField } from '../../ui/OcmFormFields';
 
 type AdvancedNetworkFieldsProps = {
   isSDNSelectable: boolean;
 };
 
-const getNextworkLabelSuffix = (index: number, isDualStack: boolean) => {
+const getNetworkLabelSuffix = (index: number, isDualStack: boolean) => {
   return isDualStack ? ` (${index === 0 ? 'IPv4' : 'IPv6'})` : '';
 };
 
@@ -34,8 +39,9 @@ const clusterCidrHelperText =
 const serviceCidrHelperText =
   'The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.';
 
-const AdvancedNetworkFields: React.FC<AdvancedNetworkFieldsProps> = ({ isSDNSelectable }) => {
+const AdvancedNetworkFields = ({ isSDNSelectable }: AdvancedNetworkFieldsProps) => {
   const { setFieldValue, values, errors } = useFormikContext<NetworkConfigurationValues>();
+  const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
 
   const isNetworkTypeSelectionEnabled = useFeature(
     'ASSISTED_INSTALLER_NETWORK_TYPE_SELECTION_FEATURE',
@@ -68,17 +74,17 @@ const AdvancedNetworkFields: React.FC<AdvancedNetworkFieldsProps> = ({ isSDNSele
         {() => (
           <FormGroup fieldId="clusterNetworks" labelInfo={isDualStack && 'Primary'}>
             {values.clusterNetworks?.map((_, index) => {
-              const networkSuffix = getNextworkLabelSuffix(index, isDualStack);
+              const networkSuffix = getNetworkLabelSuffix(index, isDualStack);
               return (
                 <StackItem key={index} className={'network-field-group'}>
-                  <InputField
+                  <OcmInputField
                     name={`clusterNetworks.${index}.cidr`}
                     label={`Cluster network CIDR${networkSuffix}`}
                     helperText={clusterCidrHelperText}
                     isRequired
                     labelInfo={index === 0 && isDualStack ? 'Primary' : ''}
                   />
-                  <InputField
+                  <OcmInputField
                     name={`clusterNetworks.${index}.hostPrefix`}
                     label={`Cluster network host prefix${networkSuffix}`}
                     type={TextInputTypes.number}
@@ -88,11 +94,8 @@ const AdvancedNetworkFields: React.FC<AdvancedNetworkFieldsProps> = ({ isSDNSele
                         ? PREFIX_MAX_RESTRICTION.IPv6
                         : PREFIX_MAX_RESTRICTION.IPv4
                     }
-                    onBlur={(e) =>
-                      formatClusterNetworkHostPrefix(
-                        e as React.ChangeEvent<HTMLInputElement>,
-                        index,
-                      )
+                    onBlur={(e: React.ChangeEvent<HTMLInputElement>) =>
+                      formatClusterNetworkHostPrefix(e, index)
                     }
                     helperText={clusterNetworkHostPrefixHelperText(index)}
                     isRequired
@@ -113,9 +116,9 @@ const AdvancedNetworkFields: React.FC<AdvancedNetworkFieldsProps> = ({ isSDNSele
           <FormGroup fieldId="serviceNetworks" labelInfo={isDualStack && 'Primary'}>
             {values.serviceNetworks?.map((_, index) => (
               <StackItem key={index} className={'network-field-group'}>
-                <InputField
+                <OcmInputField
                   name={`serviceNetworks.${index}.cidr`}
-                  label={`Service network CIDR${getNextworkLabelSuffix(index, isDualStack)}`}
+                  label={`Service network CIDR${getNetworkLabelSuffix(index, isDualStack)}`}
                   helperText={serviceCidrHelperText}
                   isRequired
                   labelInfo={index === 0 && isDualStack ? 'Primary' : ''}
@@ -131,7 +134,7 @@ const AdvancedNetworkFields: React.FC<AdvancedNetworkFieldsProps> = ({ isSDNSele
       )}
 
       {isNetworkTypeSelectionEnabled && (
-        <NetworkTypeControlGroup isSDNSelectable={isSDNSelectable} />
+        <NetworkTypeControlGroup isDisabled={isViewerMode} isSDNSelectable={isSDNSelectable} />
       )}
     </Grid>
   );

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/AvailableSubnetsControl.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/AvailableSubnetsControl.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect } from 'react';
+import { useSelector } from 'react-redux';
 import { Alert, AlertVariant, FormGroup, Stack, StackItem } from '@patternfly/react-core';
 import { FieldArray, useFormikContext, FormikHelpers } from 'formik';
+import { Address4, Address6 } from 'ip-address';
+
 import {
   Cluster,
   MachineNetwork,
@@ -9,9 +12,8 @@ import {
   DUAL_STACK,
   NO_SUBNET_SET,
 } from '../../../../common';
-import { SelectField } from '../../../../common/components/ui';
-import { Address4, Address6 } from 'ip-address';
-import useClusterPermissions from '../../../hooks/useClusterPermissions';
+import { selectCurrentClusterPermissionsState } from '../../../selectors';
+import { OcmSelectField } from '../../ui/OcmFormFields';
 
 const subnetSort = (subA: HostSubnet, subB: HostSubnet) =>
   subA.humanized.localeCompare(subB.humanized);
@@ -64,7 +66,7 @@ export const AvailableSubnetsControl = ({
 }: AvailableSubnetsControlProps) => {
   const { values, errors, setFieldValue } = useFormikContext<NetworkConfigurationValues>();
   const isDualStack = values.stackType === DUAL_STACK;
-  const { isViewerMode } = useClusterPermissions();
+  const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
 
   const IPv4Subnets = hostSubnets
     .filter((subnet) => Address4.isValid(subnet.subnet))
@@ -104,7 +106,7 @@ export const AvailableSubnetsControl = ({
                 const machineSubnets = index === 1 ? IPv6Subnets : IPv4Subnets;
                 return (
                   <StackItem key={index}>
-                    <SelectField
+                    <OcmSelectField
                       name={`machineNetworks.${index}.cidr`}
                       options={buildOptions(machineSubnets)}
                       isRequired={isRequired}
@@ -114,7 +116,7 @@ export const AvailableSubnetsControl = ({
               })
             ) : (
               <StackItem>
-                <SelectField
+                <OcmSelectField
                   name={`machineNetworks.0.cidr`}
                   options={buildOptions(IPv4Subnets)}
                   isRequired={isRequired}

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/AvailableSubnetsControl.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/AvailableSubnetsControl.tsx
@@ -1,52 +1,59 @@
 import React, { useEffect } from 'react';
 import { Alert, AlertVariant, FormGroup, Stack, StackItem } from '@patternfly/react-core';
 import { FieldArray, useFormikContext, FormikHelpers } from 'formik';
-import { Cluster, MachineNetwork } from '../../../../common/api/types';
-import { HostSubnet, HostSubnets, NetworkConfigurationValues } from '../../../../common/types';
-import { DUAL_STACK, NO_SUBNET_SET } from '../../../../common/config/constants';
+import {
+  Cluster,
+  MachineNetwork,
+  HostSubnet,
+  NetworkConfigurationValues,
+  DUAL_STACK,
+  NO_SUBNET_SET,
+} from '../../../../common';
 import { SelectField } from '../../../../common/components/ui';
 import { Address4, Address6 } from 'ip-address';
+import useClusterPermissions from '../../../hooks/useClusterPermissions';
+
+const subnetSort = (subA: HostSubnet, subB: HostSubnet) =>
+  subA.humanized.localeCompare(subB.humanized);
 
 const toFormSelectOptions = (subnets: HostSubnet[]) => {
-  return subnets
-    .sort((subA, subB) => subA.humanized.localeCompare(subB.humanized))
-    .map((hn, index) => ({
-      label: hn.humanized,
-      value: hn.subnet,
-      isDisabled: false,
-      id: `form-input-hostSubnet-field-option-${index}`,
-    }));
+  return subnets.map((hn, index) => ({
+    label: hn.humanized,
+    value: hn.subnet,
+    isDisabled: false,
+    id: `form-input-hostSubnet-field-option-${index}`,
+  }));
 };
 
-const makeNoSubnetSelectedOption = (hostSubnets: HostSubnet[]) => ({
-  label: `Please select a subnet. (${hostSubnets.length} available)`,
+const makeNoSubnetSelectedOption = (availableSubnets: number) => ({
+  label: `Please select a subnet. (${availableSubnets} available)`,
   value: NO_SUBNET_SET,
   isDisabled: true,
   id: 'form-input-hostSubnet-field-option-no-subnet-selected',
 });
 
-const makeNoSubnetAvailableOption = () => ({
+const noSubnetAvailableOption = {
   label: 'No subnets are currently available',
   value: NO_SUBNET_SET,
   id: 'form-input-hostSubnet-field-option-no-subnet-available',
-});
+};
 
 const useAutoSelectSingleAvailableSubnet = (
-  hasNoMachineNetworks: boolean,
+  autoSelectNetwork: boolean,
   setFieldValue: FormikHelpers<NetworkConfigurationValues>['setFieldValue'],
   cidr: MachineNetwork['cidr'],
   clusterId: string,
 ) => {
   useEffect(() => {
-    if (hasNoMachineNetworks) {
+    if (autoSelectNetwork) {
       setFieldValue('machineNetworks', [{ cidr, clusterId }], true);
     }
-  }, [hasNoMachineNetworks, cidr, clusterId, setFieldValue]);
+  }, [autoSelectNetwork, cidr, clusterId, setFieldValue]);
 };
 
 export interface AvailableSubnetsControlProps {
   clusterId: Cluster['id'];
-  hostSubnets: HostSubnets;
+  hostSubnets: HostSubnet[];
   isRequired: boolean;
 }
 
@@ -57,13 +64,30 @@ export const AvailableSubnetsControl = ({
 }: AvailableSubnetsControlProps) => {
   const { values, errors, setFieldValue } = useFormikContext<NetworkConfigurationValues>();
   const isDualStack = values.stackType === DUAL_STACK;
+  const { isViewerMode } = useClusterPermissions();
 
-  const IPv4Subnets = hostSubnets.filter((subnet) => Address4.isValid(subnet.subnet));
-  const IPv6Subnets = hostSubnets.filter((subnet) => Address6.isValid(subnet.subnet));
+  const IPv4Subnets = hostSubnets
+    .filter((subnet) => Address4.isValid(subnet.subnet))
+    .sort(subnetSort);
+  const IPv6Subnets = hostSubnets
+    .filter((subnet) => Address6.isValid(subnet.subnet))
+    .sort(subnetSort);
 
-  const hasNoMachineNetworks = (values.machineNetworks ?? []).length === 0;
   const cidr = IPv4Subnets.length >= 1 ? IPv4Subnets[0].subnet : NO_SUBNET_SET;
-  useAutoSelectSingleAvailableSubnet(hasNoMachineNetworks, setFieldValue, cidr, clusterId);
+  const hasEmptySelection = (values.machineNetworks ?? []).length === 0;
+  const autoSelectNetwork = !isViewerMode && hasEmptySelection;
+  useAutoSelectSingleAvailableSubnet(autoSelectNetwork, setFieldValue, cidr, clusterId);
+
+  const buildOptions = React.useMemo(
+    () => (machineSubnets: HostSubnet[]) => {
+      return machineSubnets.length === 0
+        ? [noSubnetAvailableOption]
+        : [makeNoSubnetSelectedOption(machineSubnets.length)].concat(
+            toFormSelectOptions(machineSubnets),
+          );
+    },
+    [],
+  );
 
   return (
     <FormGroup
@@ -77,17 +101,12 @@ export const AvailableSubnetsControl = ({
           <Stack>
             {isDualStack ? (
               values.machineNetworks?.map((_machineNetwork, index) => {
+                const machineSubnets = index === 1 ? IPv6Subnets : IPv4Subnets;
                 return (
                   <StackItem key={index}>
                     <SelectField
                       name={`machineNetworks.${index}.cidr`}
-                      options={
-                        (index === 1 ? IPv6Subnets.length > 0 : IPv4Subnets.length > 0)
-                          ? [
-                              makeNoSubnetSelectedOption(index === 1 ? IPv6Subnets : IPv4Subnets),
-                            ].concat(toFormSelectOptions(index === 1 ? IPv6Subnets : IPv4Subnets))
-                          : [makeNoSubnetAvailableOption()]
-                      }
+                      options={buildOptions(machineSubnets)}
                       isRequired={isRequired}
                     />
                   </StackItem>
@@ -96,15 +115,9 @@ export const AvailableSubnetsControl = ({
             ) : (
               <StackItem>
                 <SelectField
-                  isRequired={isRequired}
                   name={`machineNetworks.0.cidr`}
-                  options={
-                    IPv4Subnets.length === 0
-                      ? [makeNoSubnetAvailableOption()]
-                      : [makeNoSubnetSelectedOption(IPv4Subnets)].concat(
-                          toFormSelectOptions(IPv4Subnets),
-                        )
-                  }
+                  options={buildOptions(IPv4Subnets)}
+                  isRequired={isRequired}
                 />
               </StackItem>
             )}

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
@@ -1,16 +1,17 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { useFormikContext } from 'formik';
-import { Alert, AlertVariant, Checkbox, Grid, Tooltip } from '@patternfly/react-core';
+import { useSelector } from 'react-redux';
+import { Alert, AlertVariant, Grid, Tooltip } from '@patternfly/react-core';
 import { VirtualIPControlGroup, VirtualIPControlGroupProps } from './VirtualIPControlGroup';
-import { Cluster, ClusterDefaultConfig } from '../../../../common/api/types';
 import {
+  CpuArchitecture,
+  HostSubnets,
+  NetworkConfigurationValues,
+  Cluster,
+  ClusterDefaultConfig,
   FeatureSupportLevelData,
   useFeatureSupportLevel,
-} from '../../../../common/components/featureSupportLevels';
-import { CpuArchitecture, HostSubnets, NetworkConfigurationValues } from '../../../../common/types';
-import { getLimitedFeatureSupportLevels } from '../../../../common/components/featureSupportLevels/utils';
-import { isSNO } from '../../../../common/selectors';
-import {
+  isSNO,
   canBeDualStack,
   canSelectNetworkTypeSDN,
   getDefaultNetworkType,
@@ -18,6 +19,7 @@ import {
   DUAL_STACK,
   serviceNetworksEqual,
 } from '../../../../common';
+import { getLimitedFeatureSupportLevels } from '../../../../common/components/featureSupportLevels/utils';
 import {
   ManagedNetworkingControlGroup,
   UserManagedNetworkingTextContent,
@@ -26,7 +28,8 @@ import { StackTypeControlGroup } from './StackTypeControl';
 import { AvailableSubnetsControl } from './AvailableSubnetsControl';
 import AdvancedNetworkFields from './AdvancedNetworkFields';
 import { useTranslation } from '../../../../common/hooks/use-translation-wrapper';
-import useClusterPermissions from '../../../hooks/useClusterPermissions';
+import { selectCurrentClusterPermissionsState } from '../../../selectors';
+import { OcmCheckbox } from '../../ui/OcmFormFields';
 
 export type NetworkConfigurationProps = VirtualIPControlGroupProps & {
   hostSubnets: HostSubnets;
@@ -113,14 +116,14 @@ const isManagedNetworkingDisabled = (
   }
 };
 
-const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
+const NetworkConfiguration = ({
   cluster,
   hostSubnets,
   isVipDhcpAllocationDisabled,
   defaultNetworkSettings,
   hideManagedNetworking,
   children,
-}) => {
+}: PropsWithChildren<NetworkConfigurationProps>) => {
   const { t } = useTranslation();
   const featureSupportLevelData = useFeatureSupportLevel();
   const { setFieldValue, values, validateField } = useFormikContext<NetworkConfigurationValues>();
@@ -132,7 +135,7 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
   const isMultiNodeCluster = !isSNOCluster;
   const isUserManagedNetworking = values.managedNetworkingType === 'userManaged';
   const isDualStack = values.stackType === DUAL_STACK;
-  const { isViewerMode } = useClusterPermissions();
+  const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
   const shouldUpdateAdvConf = !isViewerMode && isDualStack && !isUserManagedNetworking;
   const isDualStackSelectable = React.useMemo(() => canBeDualStack(hostSubnets), [hostSubnets]);
 
@@ -261,7 +264,7 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
       {!isUserManagedNetworking && (
         <VirtualIPControlGroup
           cluster={cluster}
-          isVipDhcpAllocationDisabled={isViewerMode || isVipDhcpAllocationDisabled}
+          isVipDhcpAllocationDisabled={isVipDhcpAllocationDisabled}
         />
       )}
 
@@ -270,13 +273,13 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
         hidden={!isDualStack}
         position={'top-start'}
       >
-        <Checkbox
+        <OcmCheckbox
           id="useAdvancedNetworking"
           label="Use advanced networking"
           description="Configure advanced networking properties (e.g. CIDR ranges)."
           isChecked={isAdvanced}
           onChange={toggleAdvConfiguration}
-          isDisabled={isViewerMode || isDualStack}
+          isDisabled={isDualStack}
         />
       </Tooltip>
 

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { Formik, FormikConfig, useFormikContext } from 'formik';
 import { Form, Grid, GridItem, Text, TextContent } from '@patternfly/react-core';
 import {
@@ -27,7 +27,7 @@ import { canNextNetwork } from '../../clusterWizard/wizardTransition';
 import ClusterWizardNavigation from '../../clusterWizard/ClusterWizardNavigation';
 import NetworkConfigurationTable from './NetworkConfigurationTable';
 import useInfraEnv from '../../../hooks/useInfraEnv';
-import useClusterPermissions from '../../../hooks/useClusterPermissions';
+import { selectCurrentClusterPermissionsState } from '../../../selectors';
 import {
   getNetworkConfigurationValidationSchema,
   getNetworkInitialValues,
@@ -52,24 +52,23 @@ const NetworkConfigurationForm: React.FC<{
 }> = ({ cluster, hostSubnets, defaultNetworkSettings, infraEnv }) => {
   const { alerts } = useAlerts();
   const clusterWizardContext = useClusterWizardContext();
-  const { isViewerMode } = useClusterPermissions();
+  const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
   const { errors, touched, isSubmitting, isValid } = useFormikContext<NetworkConfigurationValues>();
   const isAutoSaveRunning = useFormikAutoSave();
   const errorFields = getFormikErrorFields(errors, touched);
-
-  const isNextDisabled =
-    isSubmitting ||
-    isAutoSaveRunning ||
-    !!alerts.length ||
-    !isValid ||
-    !canNextNetwork({ cluster });
 
   const footer = (
     <ClusterWizardFooter
       cluster={cluster}
       errorFields={errorFields}
       isSubmitting={isSubmitting}
-      isNextDisabled={!isViewerMode && isNextDisabled}
+      isNextDisabled={
+        isSubmitting ||
+        isAutoSaveRunning ||
+        !!alerts.length ||
+        !isValid ||
+        !canNextNetwork({ cluster })
+      }
       onNext={() => clusterWizardContext.moveNext()}
       onBack={() => clusterWizardContext.moveBack()}
     />
@@ -119,7 +118,7 @@ const NetworkConfigurationPage = ({ cluster }: { cluster: Cluster }) => {
 
   const { addAlert, clearAlerts, alerts } = useAlerts();
   const dispatch = useDispatch();
-  const { isViewerMode } = useClusterPermissions();
+  const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
 
   const hostSubnets = React.useMemo(() => getHostSubnets(cluster), [cluster]);
   const initialValues = React.useMemo(

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationTable.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationTable.tsx
@@ -4,9 +4,14 @@ import { ClusterHostsTableProps, isSNO } from '../../../../common';
 import { AdditionalNTPSourcesDialogToggle } from '../../hosts/AdditionaNTPSourceDialogToggle';
 import { HostsTableModals, useHostsTable } from '../../hosts/use-hosts-table';
 import NetworkConfigurationTableBase from './NetworkConfigurationTableBase';
+import useClusterPermissions from '../../../hooks/useClusterPermissions';
 
 const NetworkConfigurationTable = ({ cluster }: ClusterHostsTableProps) => {
-  const { onEditHost, actionResolver, ...modalProps } = useHostsTable(cluster);
+  const { isViewerMode } = useClusterPermissions();
+  const { onEditHost, actionChecks, onEditRole, actionResolver, ...modalProps } = useHostsTable(
+    cluster,
+    isViewerMode,
+  );
 
   return (
     <>

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationTable.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationTable.tsx
@@ -4,14 +4,9 @@ import { ClusterHostsTableProps, isSNO } from '../../../../common';
 import { AdditionalNTPSourcesDialogToggle } from '../../hosts/AdditionaNTPSourceDialogToggle';
 import { HostsTableModals, useHostsTable } from '../../hosts/use-hosts-table';
 import NetworkConfigurationTableBase from './NetworkConfigurationTableBase';
-import useClusterPermissions from '../../../hooks/useClusterPermissions';
 
 const NetworkConfigurationTable = ({ cluster }: ClusterHostsTableProps) => {
-  const { isViewerMode } = useClusterPermissions();
-  const { onEditHost, actionChecks, onEditRole, actionResolver, ...modalProps } = useHostsTable(
-    cluster,
-    isViewerMode,
-  );
+  const { actionChecks, onEditHost, actionResolver, ...modalProps } = useHostsTable(cluster);
 
   return (
     <>
@@ -19,6 +14,7 @@ const NetworkConfigurationTable = ({ cluster }: ClusterHostsTableProps) => {
         cluster={cluster}
         AdditionalNTPSourcesDialogToggleComponent={AdditionalNTPSourcesDialogToggle}
         onEditHost={onEditHost}
+        canEditHostname={actionChecks.canEditHostname}
         actionResolver={actionResolver}
       >
         <HostsTableEmptyState isSNO={isSNO(cluster)} />

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationTableBase.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationTableBase.tsx
@@ -53,6 +53,7 @@ type NetworkConfigurationTableProps = {
   onEditHost?: HostsTableActions['onEditHost'];
   onEditRole?: HostsTableActions['onEditRole'];
   canEditRole?: HostsTableActions['canEditRole'];
+  canEditHostname?: HostsTableActions['canEditHostname'];
   onSelect?: (obj: Host, isSelected: boolean) => void;
   selectedIDs?: string[];
 };
@@ -63,6 +64,7 @@ const NetworkConfigurationTableBase = ({
   onEditHost,
   onEditRole,
   canEditRole,
+  canEditHostname,
   actionResolver,
   children,
   onSelect,
@@ -71,7 +73,7 @@ const NetworkConfigurationTableBase = ({
   const { t } = useTranslation();
   const content = React.useMemo(
     () => [
-      hostnameColumn(t, onEditHost),
+      hostnameColumn(t, onEditHost, undefined, canEditHostname),
       roleColumn(t, canEditRole, onEditRole, selectSchedulableMasters(cluster)),
       networkingStatusColumn(onEditHost),
       activeNICColumn(cluster),
@@ -80,7 +82,7 @@ const NetworkConfigurationTableBase = ({
       macAddressColumn(cluster),
       countColumn(cluster),
     ],
-    [onEditHost, onEditRole, canEditRole, cluster, t],
+    [t, onEditHost, onEditRole, canEditHostname, canEditRole, cluster],
   );
 
   const hosts = cluster.hosts || [];

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/StackTypeControl.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/StackTypeControl.tsx
@@ -1,20 +1,26 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { ButtonVariant, FormGroup, Tooltip } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
 import { Address6 } from 'ip-address';
+
 import {
+  HostSubnets,
+  NetworkConfigurationValues,
+  getFieldId,
+  getDefaultNetworkType,
+  DUAL_STACK,
+  IPV4_STACK,
+  NO_SUBNET_SET,
   Cluster,
   ClusterNetwork,
   MachineNetwork,
   ServiceNetwork,
-} from '../../../../common/api/types';
-import { HostSubnets, NetworkConfigurationValues } from '../../../../common/types';
-import { DUAL_STACK, IPV4_STACK, NO_SUBNET_SET } from '../../../../common/config/constants';
-import { getFieldId } from '../../../../common/components/ui/formik/utils';
-import { ConfirmationModal, PopoverIcon, RadioField } from '../../../../common/components/ui';
-import { getDefaultNetworkType } from '../../../../common';
-import useClusterPermissions from '../../../hooks/useClusterPermissions';
+} from '../../../../common';
+import { ConfirmationModal, PopoverIcon } from '../../../../common/components/ui';
 import { useDefaultConfiguration } from '../ClusterDefaultConfigurationContext';
+import { selectCurrentClusterPermissionsState } from '../../../selectors';
+import { OcmRadioField } from '../../ui/OcmFormFields';
 
 type StackTypeControlGroupProps = {
   clusterId: Cluster['id'];
@@ -54,7 +60,7 @@ export const StackTypeControlGroup = ({
 
   const IPv6Subnets = hostSubnets.filter((subnet) => Address6.isValid(subnet.subnet));
   const cidrIPv6 = IPv6Subnets.length >= 1 ? IPv6Subnets[0].subnet : NO_SUBNET_SET;
-  const { isViewerMode } = useClusterPermissions();
+  const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
   const shouldSetSingleStack =
     !isViewerMode && !isDualStackSelectable && values.stackType === DUAL_STACK;
 
@@ -156,7 +162,7 @@ export const StackTypeControlGroup = ({
           isInline
           onChange={setStackType}
         >
-          <RadioField
+          <OcmRadioField
             name={'stackType'}
             value={IPV4_STACK}
             isDisabled={!isDualStackSelectable}
@@ -170,7 +176,7 @@ export const StackTypeControlGroup = ({
               </>
             }
           />
-          <RadioField
+          <OcmRadioField
             name={'stackType'}
             value={DUAL_STACK}
             isDisabled={!isDualStackSelectable}

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/StackTypeControl.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/StackTypeControl.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ButtonVariant, FormGroup, Tooltip } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
+import { Address6 } from 'ip-address';
 import {
   Cluster,
   ClusterNetwork,
@@ -12,8 +13,8 @@ import { DUAL_STACK, IPV4_STACK, NO_SUBNET_SET } from '../../../../common/config
 import { getFieldId } from '../../../../common/components/ui/formik/utils';
 import { ConfirmationModal, PopoverIcon, RadioField } from '../../../../common/components/ui';
 import { getDefaultNetworkType } from '../../../../common';
+import useClusterPermissions from '../../../hooks/useClusterPermissions';
 import { useDefaultConfiguration } from '../ClusterDefaultConfigurationContext';
-import { Address6 } from 'ip-address';
 
 type StackTypeControlGroupProps = {
   clusterId: Cluster['id'];
@@ -53,6 +54,9 @@ export const StackTypeControlGroup = ({
 
   const IPv6Subnets = hostSubnets.filter((subnet) => Address6.isValid(subnet.subnet));
   const cidrIPv6 = IPv6Subnets.length >= 1 ? IPv6Subnets[0].subnet : NO_SUBNET_SET;
+  const { isViewerMode } = useClusterPermissions();
+  const shouldSetSingleStack =
+    !isViewerMode && !isDualStackSelectable && values.stackType === DUAL_STACK;
 
   const setSingleStack = React.useCallback(() => {
     setFieldValue('stackType', IPV4_STACK);
@@ -134,10 +138,10 @@ export const StackTypeControlGroup = ({
   };
 
   React.useEffect(() => {
-    if (!isDualStackSelectable && values.stackType === DUAL_STACK) {
+    if (shouldSetSingleStack) {
       setSingleStack();
     }
-  }, [isDualStackSelectable, setSingleStack, values.stackType]);
+  }, [shouldSetSingleStack, setSingleStack]);
 
   return (
     <Tooltip

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/VirtualIPControlGroup.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/VirtualIPControlGroup.tsx
@@ -1,16 +1,20 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { useFormikContext } from 'formik';
 import { Spinner, Alert, AlertVariant, Tooltip } from '@patternfly/react-core';
 import {
   Cluster,
   NetworkConfigurationValues,
   ValidationsInfo,
+  CheckboxField,
+  FormikStaticField,
+  InputField,
+  FeatureSupportLevelBadge,
   NETWORK_TYPE_SDN,
   selectMachineNetworkCIDR,
   stringToJSON,
 } from '../../../../common';
-import { FeatureSupportLevelBadge } from '../../../../common/components';
-import { CheckboxField, FormikStaticField, InputField } from '../../../../common/components/ui';
+import { selectCurrentClusterPermissionsState } from '../../../selectors';
 
 interface VipStaticValueProps {
   vipName: string;
@@ -90,7 +94,9 @@ export const VirtualIPControlGroup = ({
   cluster,
   isVipDhcpAllocationDisabled,
 }: VirtualIPControlGroupProps) => {
+  // TODO can I mock the "setFieldValue" so it doesn't update any field??
   const { values, setFieldValue } = useFormikContext<NetworkConfigurationValues>();
+  const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
 
   const apiVipHelperText = `Provide an endpoint for users, both human and machine, to interact with and configure the platform. If needed, contact your IT manager for more information. ${getVipHelperSuffix(
     cluster.apiVip,
@@ -114,10 +120,10 @@ export const VirtualIPControlGroup = ({
   const enableAllocation = values.networkType === NETWORK_TYPE_SDN;
 
   React.useEffect(() => {
-    if (!enableAllocation) {
+    if (!isViewerMode && !enableAllocation) {
       setFieldValue('vipDhcpAllocation', false);
     }
-  }, [enableAllocation, setFieldValue]);
+  }, [enableAllocation, isViewerMode, setFieldValue]);
 
   const onChangeDhcp = React.useCallback(
     (hasDhcp: boolean) => {

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/VirtualIPControlGroup.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/VirtualIPControlGroup.tsx
@@ -6,15 +6,14 @@ import {
   Cluster,
   NetworkConfigurationValues,
   ValidationsInfo,
-  CheckboxField,
   FormikStaticField,
-  InputField,
   FeatureSupportLevelBadge,
   NETWORK_TYPE_SDN,
-  selectMachineNetworkCIDR,
   stringToJSON,
+  selectMachineNetworkCIDR,
 } from '../../../../common';
 import { selectCurrentClusterPermissionsState } from '../../../selectors';
+import { OcmCheckboxField, OcmInputField } from '../../ui/OcmFormFields';
 
 interface VipStaticValueProps {
   vipName: string;
@@ -27,7 +26,7 @@ const VipStaticValue = ({ vipName, cluster, validationErrorMessage }: VipStaticV
   const machineNetworkCidr = selectMachineNetworkCIDR(cluster);
 
   if (vipDhcpAllocation && cluster[vipName]) {
-    return cluster[vipName];
+    return <>cluster[vipName]</>;
   }
   if (vipDhcpAllocation && validationErrorMessage) {
     return (
@@ -94,7 +93,6 @@ export const VirtualIPControlGroup = ({
   cluster,
   isVipDhcpAllocationDisabled,
 }: VirtualIPControlGroupProps) => {
-  // TODO can I mock the "setFieldValue" so it doesn't update any field??
   const { values, setFieldValue } = useFormikContext<NetworkConfigurationValues>();
   const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
 
@@ -137,7 +135,7 @@ export const VirtualIPControlGroup = ({
   return (
     <>
       {!isVipDhcpAllocationDisabled && (
-        <CheckboxField
+        <OcmCheckboxField
           onChange={onChangeDhcp}
           label={
             <>
@@ -192,8 +190,8 @@ export const VirtualIPControlGroup = ({
         </>
       ) : (
         <>
-          <InputField label="API IP" name="apiVip" helperText={apiVipHelperText} isRequired />
-          <InputField
+          <OcmInputField label="API IP" name="apiVip" helperText={apiVipHelperText} isRequired />
+          <OcmInputField
             name="ingressVip"
             label="Ingress IP"
             helperText={ingressVipHelperText}

--- a/src/ocm/components/clusterConfiguration/operators/CnvCheckbox.tsx
+++ b/src/ocm/components/clusterConfiguration/operators/CnvCheckbox.tsx
@@ -3,7 +3,6 @@ import { FormGroup, Tooltip } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { useFormikContext } from 'formik';
 import {
-  CheckboxField,
   ClusterOperatorProps,
   CNV_LINK,
   getFieldId,
@@ -14,6 +13,7 @@ import {
 } from '../../../../common';
 import CnvHostRequirements from './CnvHostRequirements';
 import { getCnvAndLvmIncompatibilityReason } from '../../featureSupportLevels/featureStateUtils';
+import { OcmCheckboxField } from '../../ui/OcmFormFields';
 
 const CNV_FIELD_NAME = 'useContainerNativeVirtualization';
 
@@ -62,7 +62,7 @@ const CnvCheckbox = ({ clusterId, openshiftVersion }: ClusterOperatorProps) => {
   return (
     <FormGroup isInline fieldId={fieldId}>
       <Tooltip hidden={!disabledReason} content={disabledReason}>
-        <CheckboxField
+        <OcmCheckboxField
           name={CNV_FIELD_NAME}
           label={<CnvLabel clusterId={clusterId} />}
           helperText={<CnvHelperText />}

--- a/src/ocm/components/clusterConfiguration/operators/LvmCheckbox.tsx
+++ b/src/ocm/components/clusterConfiguration/operators/LvmCheckbox.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { FormGroup, Tooltip } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
 import {
-  CheckboxField,
   ClusterOperatorProps,
   FeatureSupportLevelBadge,
   getFieldId,
@@ -13,6 +12,7 @@ import {
 } from '../../../../common';
 import LvmHostRequirements from './LvmHostRequirements';
 import { getCnvAndLvmIncompatibilityReason } from '../../featureSupportLevels/featureStateUtils';
+import { OcmCheckboxField } from '../../ui/OcmFormFields';
 
 const LVM_FIELD_NAME = 'useOdfLogicalVolumeManager';
 
@@ -49,7 +49,7 @@ const LvmCheckbox = ({ clusterId, openshiftVersion }: ClusterOperatorProps) => {
   return (
     <FormGroup isInline fieldId={fieldId}>
       <Tooltip hidden={!disabledReason} content={disabledReason}>
-        <CheckboxField
+        <OcmCheckboxField
           name={LVM_FIELD_NAME}
           label={<LvmLabel clusterId={clusterId} openshiftVersion={openshiftVersion} />}
           helperText={

--- a/src/ocm/components/clusterConfiguration/operators/OdfCheckbox.tsx
+++ b/src/ocm/components/clusterConfiguration/operators/OdfCheckbox.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { FormGroup, Tooltip } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import {
-  CheckboxField,
   getFieldId,
   useFeatureSupportLevel,
   PopoverIcon,
   ODF_REQUIREMENTS_LINK,
   ODF_LINK,
 } from '../../../../common';
+import { OcmCheckboxField } from '../../ui/OcmFormFields';
 
 const ODF_FIELD_NAME = 'useOpenShiftDataFoundation';
 
@@ -47,7 +47,7 @@ const OdfCheckbox = ({ openshiftVersion }: { openshiftVersion?: string }) => {
   return (
     <FormGroup isInline fieldId={fieldId}>
       <Tooltip hidden={!disabledReason} content={disabledReason}>
-        <CheckboxField
+        <OcmCheckboxField
           name={ODF_FIELD_NAME}
           label={<OdfLabel />}
           isDisabled={!!disabledReason}

--- a/src/ocm/components/clusterConfiguration/staticIp/components/FormViewHosts/FormViewHostsFields.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/components/FormViewHosts/FormViewHostsFields.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
 import { FormGroup, Grid } from '@patternfly/react-core';
-import StaticIpHostsArray, { HostComponentProps } from '../StaticIpHostsArray';
 import { useField } from 'formik';
-import { getFieldId, InputField } from '../../../../../../common';
+import StaticIpHostsArray, { HostComponentProps } from '../StaticIpHostsArray';
+import { getFieldId } from '../../../../../../common';
 import HostSummary from '../CollapsedHost';
 import { FormViewHost, StaticProtocolType } from '../../data/dataTypes';
 import { getProtocolVersionLabel, getShownProtocolVersions } from '../../data/protocolVersion';
 import { getEmptyFormViewHost } from '../../data/emptyData';
+import { OcmInputField } from '../../../../ui/OcmFormFields';
 
 const getExpandedHostComponent = (protocolType: StaticProtocolType) => {
   const Component: React.FC<HostComponentProps> = ({ fieldName, hostIdx }) => {
     return (
       <Grid hasGutter>
-        <InputField
+        <OcmInputField
           name={`${fieldName}.macAddress`}
           label="MAC Address"
           isRequired
@@ -24,9 +25,9 @@ const getExpandedHostComponent = (protocolType: StaticProtocolType) => {
             fieldId={getFieldId(`${fieldName}.ips.${protocolVersion}`, 'input')}
             key={protocolVersion}
           >
-            <InputField
+            <OcmInputField
               name={`${fieldName}.ips.${protocolVersion}`}
-              isRequired={true}
+              isRequired
               data-testid={`${protocolVersion}-address-${hostIdx}`}
             />{' '}
           </FormGroup>

--- a/src/ocm/components/clusterConfiguration/staticIp/components/FormViewNetworkWide/FormViewNetworkWideFields.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/components/FormViewNetworkWide/FormViewNetworkWideFields.tsx
@@ -12,15 +12,8 @@ import {
   Flex,
   FlexItem,
 } from '@patternfly/react-core';
-import {
-  CheckboxField,
-  getFieldId,
-  getHumanizedSubnetRange,
-  InputField,
-  PopoverIcon,
-  SelectField,
-} from '../../../../../../common';
 import { useField, useFormikContext } from 'formik';
+import { getFieldId, getHumanizedSubnetRange, PopoverIcon } from '../../../../../../common';
 import {
   getAddressObject,
   getProtocolVersionLabel,
@@ -37,7 +30,6 @@ import {
   StaticProtocolType,
 } from '../../data/dataTypes';
 import { getMachineNetworkCidr } from '../../data/machineNetwork';
-import '../staticIp.css';
 import useFieldErrorMsg from '../../../../../../common/hooks/useFieldErrorMsg';
 import {
   MIN_PREFIX_LENGTH,
@@ -45,6 +37,9 @@ import {
   MAX_VLAN_ID,
   MIN_VLAN_ID,
 } from './formViewNetworkWideValidationSchema';
+import { OcmCheckboxField, OcmInputField, OcmSelectField } from '../../../../ui/OcmFormFields';
+
+import '../staticIp.css';
 
 const hostsConfiguredAlert = (
   <Alert
@@ -87,7 +82,7 @@ const MachineNetwork: React.FC<{ fieldName: string; protocolVersion: ProtocolVer
     >
       <Flex>
         <FlexItem spacer={{ default: 'spacerSm' }}>
-          <InputField
+          <OcmInputField
             name={`${fieldName}.ip`}
             isRequired={true}
             data-testid={`${protocolVersion}-machine-network-ip`}
@@ -96,7 +91,7 @@ const MachineNetwork: React.FC<{ fieldName: string; protocolVersion: ProtocolVer
         </FlexItem>
         <FlexItem spacer={{ default: 'spacerSm' }}>{'/'}</FlexItem>
         <FlexItem>
-          <InputField
+          <OcmInputField
             name={`${fieldName}.prefixLength`}
             isRequired={true}
             data-testid={`${protocolVersion}-machine-network-prefix-length`}
@@ -118,7 +113,7 @@ const IpConfigFields: React.FC<{
   return (
     <Grid hasGutter>
       <MachineNetwork fieldName={`${fieldName}.machineNetwork`} protocolVersion={protocolVersion} />
-      <InputField
+      <OcmInputField
         isRequired
         label="Default gateway"
         labelIcon={
@@ -129,6 +124,12 @@ const IpConfigFields: React.FC<{
         }
         name={`${fieldName}.gateway`}
         data-testid={`${protocolVersion}-gateway`}
+      />
+      <OcmInputField
+        isRequired
+        label="DNS"
+        name={`${fieldName}.dns`}
+        data-testid={`${protocolVersion}-dns`}
       />
     </Grid>
   );
@@ -145,7 +146,7 @@ const protocolVersionOptions: FormSelectOptionProps[] = [
   },
 ];
 
-export const ProtocolTypeSelect: React.FC = () => {
+export const ProtocolTypeSelect = () => {
   const selectFieldName = 'protocolType';
   const [{ value: protocolType }, , { setValue: setProtocolType }] =
     useField<StaticProtocolType>(selectFieldName);
@@ -160,7 +161,7 @@ export const ProtocolTypeSelect: React.FC = () => {
     setProtocolType(newProtocolType);
   };
   return (
-    <SelectField
+    <OcmSelectField
       label="Internet protocol version"
       options={protocolVersionOptions}
       name={selectFieldName}
@@ -170,7 +171,7 @@ export const ProtocolTypeSelect: React.FC = () => {
     />
   );
 };
-export const FormViewNetworkWideFields: React.FC<{ hosts: FormViewHost[] }> = ({ hosts }) => {
+export const FormViewNetworkWideFields = ({ hosts }: { hosts: FormViewHost[] }) => {
   const { values, setFieldValue } = useFormikContext<FormViewNetworkWideValues>();
   return (
     <>
@@ -185,7 +186,7 @@ export const FormViewNetworkWideFields: React.FC<{ hosts: FormViewHost[] }> = ({
 
       <ProtocolTypeSelect />
 
-      <CheckboxField
+      <OcmCheckboxField
         label={
           <>
             {'Use VLAN '}
@@ -202,7 +203,7 @@ export const FormViewNetworkWideFields: React.FC<{ hosts: FormViewHost[] }> = ({
 
       {values.useVlan && (
         <div className="vlan-id">
-          <InputField
+          <OcmInputField
             label="VLAN ID"
             name="vlanId"
             isRequired
@@ -214,7 +215,7 @@ export const FormViewNetworkWideFields: React.FC<{ hosts: FormViewHost[] }> = ({
         </div>
       )}
 
-      <InputField isRequired label="DNS" name={`dns`} data-testid={`dns`} />
+      <OcmInputField isRequired label="DNS" name={`dns`} data-testid={`dns`} />
 
       {getShownProtocolVersions(values.protocolType).map((protocolVersion) => (
         <FormGroup

--- a/src/ocm/components/clusterConfiguration/staticIp/components/StaticIpForm.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/components/StaticIpForm.tsx
@@ -7,6 +7,7 @@ import { useFormikAutoSave } from '../../../../../common/components/ui/formik/Fo
 import { useErrorMonitor } from '../../../../../common/components/ErrorHandling/ErrorMonitorContext';
 import { getApiErrorMessage } from '../../../../api';
 import { StaticIpFormProps } from './propTypes';
+import useClusterPermissions from '../../../../hooks/useClusterPermissions';
 
 const AutosaveWithParentUpdate = <StaticIpFormValues extends object>({
   onFormStateChange,
@@ -42,6 +43,7 @@ export const StaticIpForm = <StaticIpFormValues extends object>({
 }: PropsWithChildren<StaticIpFormProps<StaticIpFormValues>>) => {
   const { clearAlerts, addAlert } = useAlerts();
   const { captureException } = useErrorMonitor();
+  const { isViewerMode } = useClusterPermissions();
   const [initialValues, setInitialValues] = React.useState<StaticIpFormValues | undefined>();
   React.useEffect(() => {
     if (showEmptyValues) {
@@ -52,6 +54,10 @@ export const StaticIpForm = <StaticIpFormValues extends object>({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  if (!initialValues) {
+    return null;
+  }
 
   const handleSubmit: FormikConfig<StaticIpFormValues>['onSubmit'] = async (values) => {
     clearAlerts();
@@ -65,21 +71,21 @@ export const StaticIpForm = <StaticIpFormValues extends object>({
       addAlert({ title: getApiErrorMessage(error) });
     }
   };
-  if (!initialValues) {
-    return null;
-  }
+
   const validate = (values: StaticIpFormValues) => {
     try {
-      validationSchema.validateSync(values, { abortEarly: false, context: { values: values } });
+      validationSchema.validateSync(values, { abortEarly: false, context: { values } });
       return {};
     } catch (error) {
       return yupToFormErrors(error);
     }
   };
+
+  const onSubmit = isViewerMode ? () => Promise.resolve() : handleSubmit;
   return (
     <Formik
       initialValues={initialValues}
-      onSubmit={handleSubmit}
+      onSubmit={onSubmit}
       validate={validate}
       validateOnMount
       enableReinitialize

--- a/src/ocm/components/clusterConfiguration/staticIp/components/StaticIpForm.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/components/StaticIpForm.tsx
@@ -1,13 +1,13 @@
+import React, { PropsWithChildren } from 'react';
+import { useSelector } from 'react-redux';
 import { Form } from '@patternfly/react-core';
 import { Formik, FormikConfig, useFormikContext, yupToFormErrors } from 'formik';
 import isEqual from 'lodash/isEqual';
-import React, { PropsWithChildren } from 'react';
-import { useAlerts } from '../../../../../common';
-import { useFormikAutoSave } from '../../../../../common/components/ui/formik/FormikAutoSave';
+import { useAlerts, useFormikAutoSave } from '../../../../../common';
 import { useErrorMonitor } from '../../../../../common/components/ErrorHandling/ErrorMonitorContext';
 import { getApiErrorMessage } from '../../../../api';
 import { StaticIpFormProps } from './propTypes';
-import useClusterPermissions from '../../../../hooks/useClusterPermissions';
+import { selectCurrentClusterPermissionsState } from '../../../../selectors';
 
 const AutosaveWithParentUpdate = <StaticIpFormValues extends object>({
   onFormStateChange,
@@ -43,7 +43,7 @@ export const StaticIpForm = <StaticIpFormValues extends object>({
 }: PropsWithChildren<StaticIpFormProps<StaticIpFormValues>>) => {
   const { clearAlerts, addAlert } = useAlerts();
   const { captureException } = useErrorMonitor();
-  const { isViewerMode } = useClusterPermissions();
+  const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
   const [initialValues, setInitialValues] = React.useState<StaticIpFormValues | undefined>();
   React.useEffect(() => {
     if (showEmptyValues) {

--- a/src/ocm/components/clusterConfiguration/staticIp/components/StaticIpHostsArray.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/components/StaticIpHostsArray.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
 import {
   Button,
   ButtonVariant,
@@ -12,12 +14,12 @@ import {
 import { MinusCircleIcon } from '@patternfly/react-icons';
 import { FieldArray, FieldArrayRenderProps, useField } from 'formik';
 import cloneDeep from 'lodash/cloneDeep';
-import React from 'react';
 import { getFormikArrayItemFieldName, LoadingState } from '../../../../../common';
 import ConfirmationModal from '../../../../../common/components/ui/ConfirmationModal';
-import { selectIsCurrentClusterSNO } from '../../../../selectors';
-import { useSelector } from 'react-redux';
-import useClusterPermissions from '../../../../hooks/useClusterPermissions';
+import {
+  selectIsCurrentClusterSNO,
+  selectCurrentClusterPermissionsState,
+} from '../../../../selectors';
 
 const fieldName = 'hosts';
 
@@ -118,7 +120,7 @@ const SingleHost = <HostFieldType,>({
         )}
       </Flex>
 
-      {isExpanded && (
+      {isExpanded ? (
         <ExpandableSection isDetached key={hostIdx} isExpanded>
           <ExpandedHostComponent
             fieldName={hostFieldName}
@@ -126,8 +128,7 @@ const SingleHost = <HostFieldType,>({
             isDisabled={isDisabled}
           />
         </ExpandableSection>
-      )}
-      {!isExpanded && (
+      ) : (
         <CollapsedHostComponent
           fieldName={hostFieldName}
           hostIdx={hostIdx}
@@ -163,11 +164,11 @@ const Hosts = <HostFieldType,>({
   emptyHostData,
   ...props
 }: HostsProps<HostFieldType>) => {
-  const canAddHosts = !useSelector(selectIsCurrentClusterSNO);
   const [field, { error }] = useField<HostFieldType[]>({
     name: fieldName,
   });
-  const { isViewerMode } = useClusterPermissions();
+  const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
+  const canAddHosts = !useSelector(selectIsCurrentClusterSNO) && !isViewerMode;
   const [expandedHosts, setExpandedHosts] = React.useState<ExpandedHosts>(
     getExpandedHostsDefaultValue(field.value.length),
   );
@@ -209,7 +210,7 @@ const Hosts = <HostFieldType,>({
               onRemove={() => setHostIdxToRemove(hostIdx)}
               fieldName={fieldName}
               emptyHostData={emptyHostData}
-              enableRemoveHost={!isViewerMode && field.value.length > 1}
+              enableRemoveHost={field.value.length > 1}
               {...props}
             />
 

--- a/src/ocm/components/clusterConfiguration/staticIp/components/StaticIpPage.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/components/StaticIpPage.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Text, TextContent, TextVariants, Alert, AlertVariant, Grid } from '@patternfly/react-core';
-
 import { StaticIpInfo, StaticIpView } from '../data/dataTypes';
 import StaticIpViewRadioGroup from './StaticIpViewRadioGroup';
 import { getStaticIpInfo } from '../data/fromInfraEnv';
@@ -10,6 +9,7 @@ import { useClusterWizardContext } from '../../../clusterWizard/ClusterWizardCon
 import { FormViewHosts } from './FormViewHosts/FormViewHosts';
 import { FormViewNetworkWide } from './FormViewNetworkWide/FormViewNetworkWide';
 import './staticIp.css';
+
 const isoRegenerationAlert = (
   <Alert
     variant={AlertVariant.warning}

--- a/src/ocm/components/clusterConfiguration/staticIp/components/StaticIpViewRadioGroup.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/components/StaticIpViewRadioGroup.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { ButtonVariant, Form, FormGroup, Radio } from '@patternfly/react-core';
-import { getFieldId } from '../../../../../common';
+import { ButtonVariant, Form, FormGroup } from '@patternfly/react-core';
 import { StaticIpView } from '../data/dataTypes';
+import { getFieldId } from '../../../../../common';
 import ConfirmationModal from '../../../../../common/components/ui/ConfirmationModal';
+import { OcmRadio } from '../../../ui/OcmFormFields';
 
 export type StaticIpViewRadioGroupProps = {
   initialView: StaticIpView;
@@ -10,11 +11,11 @@ export type StaticIpViewRadioGroupProps = {
   onChangeView(view: StaticIpView): void;
 };
 
-const StaticIpViewRadioGroup: React.FC<StaticIpViewRadioGroupProps> = ({
+const StaticIpViewRadioGroup = ({
   initialView,
   confirmOnChangeView,
   onChangeView,
-}) => {
+}: StaticIpViewRadioGroupProps) => {
   const GROUP_NAME = 'select-static-ip-view';
   const [confirmView, setConfirmView] = React.useState<StaticIpView>();
   const [view, setView] = React.useState<StaticIpView>(initialView);
@@ -51,7 +52,7 @@ const StaticIpViewRadioGroup: React.FC<StaticIpViewRadioGroupProps> = ({
           label="Configure via :"
           className="static-config-type-label"
         >
-          <Radio
+          <OcmRadio
             label="Form view"
             name={GROUP_NAME}
             data-testid="select-form-view"
@@ -60,14 +61,14 @@ const StaticIpViewRadioGroup: React.FC<StaticIpViewRadioGroupProps> = ({
             isChecked={view === StaticIpView.FORM}
             onChange={handleChange}
           />
-          <Radio
+          <OcmRadio
             label="YAML view"
             name={GROUP_NAME}
             data-testid="select-yaml-view"
             id="select-yaml-view"
             value={StaticIpView.YAML}
-            onChange={handleChange}
             isChecked={view === StaticIpView.YAML}
+            onChange={handleChange}
           />
         </FormGroup>
       </Form>

--- a/src/ocm/components/clusterConfiguration/staticIp/components/YamlView/MacIpMapping.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/components/YamlView/MacIpMapping.tsx
@@ -4,10 +4,12 @@ import { ArrayHelpers, FieldArray } from 'formik';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import {
   getFormikArrayItemFieldName,
-  InputField,
   MacInterfaceMap,
   RemovableField,
 } from '../../../../../../common';
+import { OcmInputField } from '../../../../ui/OcmFormFields';
+import { useSelector } from 'react-redux';
+import { selectCurrentClusterPermissionsState } from '../../../../../selectors';
 
 const AddMapping: React.FC<{
   onPush: ArrayHelpers['push'];
@@ -31,32 +33,28 @@ const MacMappingItem = ({
   mapIdx,
   enableRemove,
   hostIdx,
-  isDisabled,
 }: {
   fieldName: string;
   onRemove: () => void;
   mapIdx: number;
   hostIdx: number;
   enableRemove: boolean;
-  isDisabled: boolean;
 }) => {
   return (
     <RemovableField hideRemoveButton={!enableRemove} onRemove={onRemove}>
       <Grid hasGutter>
         <GridItem span={6}>
-          <InputField
+          <OcmInputField
             label="MAC address"
             isRequired
-            isDisabled={isDisabled}
             name={`${fieldName}.macAddress`}
             data-testid={`mac-address-${hostIdx}-${mapIdx}`}
           />
         </GridItem>
         <GridItem span={6}>
-          <InputField
+          <OcmInputField
             label="Interface name"
             isRequired
-            isDisabled={isDisabled}
             name={`${fieldName}.logicalNicName`}
             data-testid={`interface-name-${hostIdx}-${mapIdx}`}
           />
@@ -70,13 +68,13 @@ export const MacIpMapping = ({
   fieldName,
   macInterfaceMap,
   hostIdx,
-  isDisabled,
 }: {
   fieldName: string;
   macInterfaceMap: MacInterfaceMap;
   hostIdx: number;
-  isDisabled: boolean;
 }) => {
+  const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
+
   return (
     <Grid className="mac-ip-mapping">
       <GridItem span={6}>
@@ -89,15 +87,14 @@ export const MacIpMapping = ({
                 <MacMappingItem
                   key={getFormikArrayItemFieldName(fieldName, idx)}
                   fieldName={getFormikArrayItemFieldName(fieldName, idx)}
-                  isDisabled={isDisabled}
                   onRemove={() => remove(idx)}
                   mapIdx={idx}
-                  enableRemove={!isDisabled && idx > 0}
+                  enableRemove={!isViewerMode && idx > 0}
                   hostIdx={hostIdx}
                 />
               ))}
 
-              {!isDisabled && <AddMapping onPush={push} />}
+              {!isViewerMode && <AddMapping onPush={push} />}
             </Grid>
           )}
         />

--- a/src/ocm/components/clusterConfiguration/staticIp/components/YamlView/MacIpMapping.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/components/YamlView/MacIpMapping.tsx
@@ -25,13 +25,21 @@ const AddMapping: React.FC<{
   );
 };
 
-const MacMappingItem: React.FC<{
+const MacMappingItem = ({
+  fieldName,
+  onRemove,
+  mapIdx,
+  enableRemove,
+  hostIdx,
+  isDisabled,
+}: {
   fieldName: string;
   onRemove: () => void;
   mapIdx: number;
   hostIdx: number;
   enableRemove: boolean;
-}> = ({ fieldName, onRemove, mapIdx, enableRemove, hostIdx }) => {
+  isDisabled: boolean;
+}) => {
   return (
     <RemovableField hideRemoveButton={!enableRemove} onRemove={onRemove}>
       <Grid hasGutter>
@@ -39,6 +47,7 @@ const MacMappingItem: React.FC<{
           <InputField
             label="MAC address"
             isRequired
+            isDisabled={isDisabled}
             name={`${fieldName}.macAddress`}
             data-testid={`mac-address-${hostIdx}-${mapIdx}`}
           />
@@ -47,6 +56,7 @@ const MacMappingItem: React.FC<{
           <InputField
             label="Interface name"
             isRequired
+            isDisabled={isDisabled}
             name={`${fieldName}.logicalNicName`}
             data-testid={`interface-name-${hostIdx}-${mapIdx}`}
           />
@@ -56,11 +66,17 @@ const MacMappingItem: React.FC<{
   );
 };
 
-export const MacIpMapping: React.FC<{
+export const MacIpMapping = ({
+  fieldName,
+  macInterfaceMap,
+  hostIdx,
+  isDisabled,
+}: {
   fieldName: string;
   macInterfaceMap: MacInterfaceMap;
   hostIdx: number;
-}> = ({ fieldName, macInterfaceMap, hostIdx }) => {
+  isDisabled: boolean;
+}) => {
   return (
     <Grid className="mac-ip-mapping">
       <GridItem span={6}>
@@ -69,18 +85,19 @@ export const MacIpMapping: React.FC<{
           validateOnChange={false}
           render={({ push, remove }) => (
             <Grid hasGutter>
-              {macInterfaceMap.map((value, idx) => (
+              {macInterfaceMap.map((_, idx) => (
                 <MacMappingItem
                   key={getFormikArrayItemFieldName(fieldName, idx)}
                   fieldName={getFormikArrayItemFieldName(fieldName, idx)}
+                  isDisabled={isDisabled}
                   onRemove={() => remove(idx)}
                   mapIdx={idx}
-                  enableRemove={idx > 0}
+                  enableRemove={!isDisabled && idx > 0}
                   hostIdx={hostIdx}
                 />
               ))}
 
-              <AddMapping onPush={push} />
+              {!isDisabled && <AddMapping onPush={push} />}
             </Grid>
           )}
         />

--- a/src/ocm/components/clusterConfiguration/staticIp/components/YamlView/YamlViewFields.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/components/YamlView/YamlViewFields.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { TextVariants, TextContent, Text, FormGroup, Grid } from '@patternfly/react-core';
 import { useField } from 'formik';
-import { CodeField, getFieldId, HostStaticNetworkConfig } from '../../../../../../common';
 import { Language } from '@patternfly/react-code-editor';
+import { getFieldId, HostStaticNetworkConfig } from '../../../../../../common';
 import StaticIpHostsArray, { HostComponentProps } from '../StaticIpHostsArray';
 import HostSummary from '../CollapsedHost';
 import { MacIpMapping } from './MacIpMapping';
 import { getEmptyYamlHost } from '../../data/emptyData';
+import { OcmCodeField } from '../../../../ui/OcmFormFields';
 
 const CollapsedHost: React.FC<HostComponentProps> = ({ fieldName, hostIdx }) => {
   const mapFieldName = `${fieldName}.macInterfaceMap`;
@@ -41,10 +42,11 @@ const ExpandedHost: React.FC<HostComponentProps> = ({ fieldName, hostIdx }) => {
     name: mapFieldName,
   });
   const macInterfaceMap = mapField.value ? mapField.value : [];
+
   return (
     <>
       <FormGroup label="" fieldId={getFieldId('nmstateYaml', 'inputs')}>
-        <CodeField
+        <OcmCodeField
           language={Language.yaml}
           name={`${fieldName}.networkYaml`}
           data-testid={`yaml-${hostIdx}`}
@@ -64,7 +66,7 @@ const ExpandedHost: React.FC<HostComponentProps> = ({ fieldName, hostIdx }) => {
   );
 };
 
-export const YamlViewFields: React.FC = () => {
+export const YamlViewFields = () => {
   const emptyHostData = getEmptyYamlHost();
   return (
     <Grid hasGutter>

--- a/src/ocm/components/clusterDetail/AssistedInstallerDetailCard.tsx
+++ b/src/ocm/components/clusterDetail/AssistedInstallerDetailCard.tsx
@@ -11,6 +11,7 @@ import {
   ErrorState,
   LoadingState,
   FeatureListType,
+  AssistedInstallerOCMPermissionTypesListType,
 } from '../../../common';
 import { useClusterPolling, useFetchCluster } from '../clusters/clusterPolling';
 import ClusterWizard from '../clusterWizard/ClusterWizard';
@@ -28,6 +29,7 @@ import ClusterWizardContextProvider from '../clusterWizard/ClusterWizardContextP
 type AssistedInstallerDetailCardProps = {
   aiClusterId: string;
   allEnabledFeatures: FeatureListType;
+  permissions?: AssistedInstallerOCMPermissionTypesListType;
 };
 
 const errorStateActions: React.ReactNode[] = [];
@@ -92,6 +94,7 @@ const LoadingDefaultConfigFailedCard: React.FC = () => (
 const AssistedInstallerDetailCard: React.FC<AssistedInstallerDetailCardProps> = ({
   aiClusterId,
   allEnabledFeatures,
+  permissions,
 }) => {
   const fetchCluster = useFetchCluster(aiClusterId);
   const { cluster, uiState } = useClusterPolling(aiClusterId);
@@ -116,16 +119,17 @@ const AssistedInstallerDetailCard: React.FC<AssistedInstallerDetailCardProps> = 
     return null;
   }
 
-  let content;
-  if (['insufficient', 'ready', 'pending-for-input'].includes(cluster.status)) {
-    content = (
-      <ClusterWizardContextProvider cluster={cluster} infraEnv={infraEnv}>
+  const showWizard = ['insufficient', 'ready', 'pending-for-input'].includes(cluster.status);
+
+  const content = (
+    <ClusterWizardContextProvider cluster={cluster} infraEnv={infraEnv} permissions={permissions}>
+      {showWizard ? (
         <ClusterWizard cluster={cluster} infraEnv={infraEnv} updateInfraEnv={updateInfraEnv} />
-      </ClusterWizardContextProvider>
-    );
-  } else {
-    content = <ClusterInstallationProgressCard cluster={cluster} />;
-  }
+      ) : (
+        <ClusterInstallationProgressCard cluster={cluster} />
+      )}
+    </ClusterWizardContextProvider>
+  );
 
   return (
     <FeatureGateContextProvider features={allEnabledFeatures}>

--- a/src/ocm/components/clusterWizard/ClusterDetailsForm.tsx
+++ b/src/ocm/components/clusterWizard/ClusterDetailsForm.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { Grid, GridItem } from '@patternfly/react-core';
 import isUndefined from 'lodash/isUndefined';
+import { useLocation } from 'react-router-dom';
 import { Formik, FormikHelpers } from 'formik';
 import {
   Cluster,
@@ -11,18 +13,17 @@ import {
   getClusterDetailsValidationSchema,
   InfraEnv,
   getRichTextValidation,
+  useFeatureSupportLevel,
 } from '../../../common';
-import { Grid, GridItem } from '@patternfly/react-core';
 import { canNextClusterDetails } from './wizardTransition';
 import { OpenshiftVersionOptionType, getFormikErrorFields } from '../../../common';
 import ClusterWizardFooter from './ClusterWizardFooter';
 import { ocmClient } from '../../api';
-import { useFeatureSupportLevel } from '../../../common/components/featureSupportLevels';
 import { ClusterDetailsService } from '../../services';
 import { OcmClusterDetailsValues } from '../../services/types';
 import { OcmClusterDetailsFormFields } from '../clusterConfiguration/OcmClusterDetailsFormFields';
-import { useLocation } from 'react-router-dom';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
+import useClusterPermissions from '../../hooks/useClusterPermissions';
 
 type ClusterDetailsFormProps = {
   cluster?: Cluster;
@@ -31,15 +32,13 @@ type ClusterDetailsFormProps = {
   managedDomains: ManagedDomain[];
   ocpVersions: OpenshiftVersionOptionType[];
   usedClusterNames: string[];
-
   navigation: React.ReactNode;
-
   moveNext: () => void;
   handleClusterCreate: (params: ClusterCreateParams) => Promise<void>;
   handleClusterUpdate: (clusterId: Cluster['id'], params: V2ClusterUpdateParams) => Promise<void>;
 };
 
-const ClusterDetailsForm: React.FC<ClusterDetailsFormProps> = (props) => {
+const ClusterDetailsForm = (props: ClusterDetailsFormProps) => {
   const {
     cluster,
     infraEnv,
@@ -54,6 +53,9 @@ const ClusterDetailsForm: React.FC<ClusterDetailsFormProps> = (props) => {
   } = props;
 
   const { search } = useLocation();
+  // Allow creation of new clusters on Standalone UI configured with isViewerMode
+  const { isViewerMode: realViewerMode } = useClusterPermissions();
+  const isViewerMode = !!cluster && realViewerMode;
   const featureSupportLevels = useFeatureSupportLevel();
   const handleSubmit = React.useCallback(
     async (values: OcmClusterDetailsValues) => {
@@ -72,7 +74,7 @@ const ClusterDetailsForm: React.FC<ClusterDetailsFormProps> = (props) => {
     submitForm: FormikHelpers<unknown>['submitForm'],
     cluster?: Cluster,
   ): (() => Promise<void> | void) => {
-    if (!dirty && !isUndefined(cluster) && canNextClusterDetails({ cluster })) {
+    if (isViewerMode || (!dirty && !isUndefined(cluster) && canNextClusterDetails({ cluster }))) {
       return moveNext;
     }
     return submitForm;
@@ -121,30 +123,26 @@ const ClusterDetailsForm: React.FC<ClusterDetailsFormProps> = (props) => {
                 <OcmClusterDetailsFormFields
                   toggleRedHatDnsService={toggleRedHatDnsService}
                   versions={ocpVersions}
-                  canEditPullSecret={!cluster?.pullSecretSet}
                   forceOpenshiftVersion={cluster?.openshiftVersion}
+                  isPullSecretSet={!!cluster?.pullSecretSet}
                   defaultPullSecret={pullSecret}
                   isOcm={!!ocmClient}
                   managedDomains={managedDomains}
-                  isPullSecretSet={cluster?.pullSecretSet ? cluster.pullSecretSet : false}
                   clusterExists={!!cluster}
                 />
               </GridItem>
             </Grid>
           </>
         );
+
+        const canMoveToNext =
+          !isSubmitting && isValid && (dirty || (cluster && canNextClusterDetails({ cluster })));
         const footer = (
           <ClusterWizardFooter
             cluster={cluster}
             errorFields={errorFields}
             isSubmitting={isSubmitting}
-            isNextDisabled={
-              !(
-                !isSubmitting &&
-                isValid &&
-                (dirty || (cluster && canNextClusterDetails({ cluster })))
-              )
-            }
+            isNextDisabled={!(isViewerMode || canMoveToNext)}
             onNext={handleOnNext(dirty, submitForm, cluster)}
           />
         );

--- a/src/ocm/components/clusterWizard/ClusterDetailsForm.tsx
+++ b/src/ocm/components/clusterWizard/ClusterDetailsForm.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
+import { useLocation } from 'react-router-dom';
 import { Grid, GridItem } from '@patternfly/react-core';
 import isUndefined from 'lodash/isUndefined';
-import { useLocation } from 'react-router-dom';
 import { Formik, FormikHelpers } from 'formik';
 import {
   Cluster,
@@ -23,7 +24,7 @@ import { ClusterDetailsService } from '../../services';
 import { OcmClusterDetailsValues } from '../../services/types';
 import { OcmClusterDetailsFormFields } from '../clusterConfiguration/OcmClusterDetailsFormFields';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
-import useClusterPermissions from '../../hooks/useClusterPermissions';
+import { selectCurrentClusterPermissionsState } from '../../selectors';
 
 type ClusterDetailsFormProps = {
   cluster?: Cluster;
@@ -53,9 +54,7 @@ const ClusterDetailsForm = (props: ClusterDetailsFormProps) => {
   } = props;
 
   const { search } = useLocation();
-  // Allow creation of new clusters on Standalone UI configured with isViewerMode
-  const { isViewerMode: realViewerMode } = useClusterPermissions();
-  const isViewerMode = !!cluster && realViewerMode;
+  const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
   const featureSupportLevels = useFeatureSupportLevel();
   const handleSubmit = React.useCallback(
     async (values: OcmClusterDetailsValues) => {
@@ -135,14 +134,18 @@ const ClusterDetailsForm = (props: ClusterDetailsFormProps) => {
           </>
         );
 
-        const canMoveToNext =
-          !isSubmitting && isValid && (dirty || (cluster && canNextClusterDetails({ cluster })));
         const footer = (
           <ClusterWizardFooter
             cluster={cluster}
             errorFields={errorFields}
             isSubmitting={isSubmitting}
-            isNextDisabled={!(isViewerMode || canMoveToNext)}
+            isNextDisabled={
+              !(
+                !isSubmitting &&
+                isValid &&
+                (dirty || (cluster && canNextClusterDetails({ cluster })))
+              )
+            }
             onNext={handleOnNext(dirty, submitForm, cluster)}
           />
         );

--- a/src/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
+++ b/src/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
@@ -13,6 +13,8 @@ import { defaultWizardSteps, staticIpFormViewSubSteps } from './constants';
 import { Cluster, InfraEnv } from '../../../common';
 import { StaticIpView } from '../clusterConfiguration/staticIp/data/dataTypes';
 import { getStaticIpInfo } from '../clusterConfiguration/staticIp/data/fromInfraEnv';
+import { AssistedInstallerOCMPermissionTypesListType } from '../../../common';
+import useClusterPermissions from '../../hooks/useClusterPermissions';
 
 const getWizardStepIds = (staticIpView?: StaticIpView): ClusterWizardStepsType[] => {
   const stepIds: ClusterWizardStepsType[] = [...defaultWizardSteps];
@@ -28,17 +30,21 @@ const ClusterWizardContextProvider: React.FC<
   PropsWithChildren<{
     cluster?: Cluster;
     infraEnv?: InfraEnv;
+    permissions?: AssistedInstallerOCMPermissionTypesListType;
   }>
-> = ({ children, cluster, infraEnv }) => {
+> = ({ children, cluster, infraEnv, permissions }) => {
   const [currentStepId, setCurrentStepId] = React.useState<ClusterWizardStepsType>();
   const [wizardStepIds, setWizardStepIds] = React.useState<ClusterWizardStepsType[]>();
   const { state: locationState } = useLocation<ClusterWizardFlowStateType>();
+  const { setPermissions } = useClusterPermissions();
+
   React.useEffect(() => {
     const staticIpInfo = infraEnv ? getStaticIpInfo(infraEnv) : undefined;
     const firstStep = getClusterWizardFirstStep(locationState, staticIpInfo, cluster?.status);
     const firstStepIds = getWizardStepIds(staticIpInfo?.view);
     setCurrentStepId(firstStep);
     setWizardStepIds(firstStepIds);
+    setPermissions(permissions, cluster);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   const contextValue = React.useMemo<ClusterWizardContextType | null>(() => {

--- a/src/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
+++ b/src/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
@@ -10,11 +10,10 @@ import {
 } from './wizardTransition';
 import { HostsNetworkConfigurationType } from '../../services';
 import { defaultWizardSteps, staticIpFormViewSubSteps } from './constants';
-import { Cluster, InfraEnv } from '../../../common';
 import { StaticIpView } from '../clusterConfiguration/staticIp/data/dataTypes';
 import { getStaticIpInfo } from '../clusterConfiguration/staticIp/data/fromInfraEnv';
-import { AssistedInstallerOCMPermissionTypesListType } from '../../../common';
-import useClusterPermissions from '../../hooks/useClusterPermissions';
+import { Cluster, InfraEnv, AssistedInstallerOCMPermissionTypesListType } from '../../../common';
+import useSetClusterPermissions from '../../hooks/useSetClusterPermissions';
 
 const getWizardStepIds = (staticIpView?: StaticIpView): ClusterWizardStepsType[] => {
   const stepIds: ClusterWizardStepsType[] = [...defaultWizardSteps];
@@ -36,7 +35,7 @@ const ClusterWizardContextProvider: React.FC<
   const [currentStepId, setCurrentStepId] = React.useState<ClusterWizardStepsType>();
   const [wizardStepIds, setWizardStepIds] = React.useState<ClusterWizardStepsType[]>();
   const { state: locationState } = useLocation<ClusterWizardFlowStateType>();
-  const { setPermissions } = useClusterPermissions();
+  const setClusterPermissions = useSetClusterPermissions();
 
   React.useEffect(() => {
     const staticIpInfo = infraEnv ? getStaticIpInfo(infraEnv) : undefined;
@@ -44,7 +43,8 @@ const ClusterWizardContextProvider: React.FC<
     const firstStepIds = getWizardStepIds(staticIpInfo?.view);
     setCurrentStepId(firstStep);
     setWizardStepIds(firstStepIds);
-    setPermissions(permissions, cluster);
+    setClusterPermissions(cluster, permissions);
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   const contextValue = React.useMemo<ClusterWizardContextType | null>(() => {

--- a/src/ocm/components/clusterWizard/ClusterWizardFooter.tsx
+++ b/src/ocm/components/clusterWizard/ClusterWizardFooter.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { Alert, AlertGroup, AlertVariant } from '@patternfly/react-core';
 import {
@@ -10,13 +11,14 @@ import {
   clusterFieldLabels,
   selectClusterValidationsInfo,
 } from '../../../common';
-import { routeBasePath } from '../../config/routeBaseBath';
-import { wizardStepsValidationsMap } from '../clusterWizard/wizardTransition';
-import { useClusterWizardContext } from '../clusterWizard/ClusterWizardContext';
+import { routeBasePath } from '../../config';
+import { wizardStepsValidationsMap } from './wizardTransition';
+import { useClusterWizardContext } from './ClusterWizardContext';
 import ClusterWizardStepValidationsAlert from '../../../common/components/clusterWizard/ClusterWizardStepValidationsAlert';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
 import { ClusterPlatformIntegrationHint } from './ClusterPlatformIntegrationHint';
 import { onFetchEvents } from '../fetching/fetchEvents';
+import { selectCurrentClusterPermissionsState } from '../../selectors';
 
 type ClusterValidationSectionProps = {
   cluster?: Cluster;
@@ -83,10 +85,12 @@ const ClusterWizardFooter = ({
   alertTitle,
   alertContent,
   onCancel,
+  isNextDisabled,
   ...rest
 }: ClusterWizardFooterProps) => {
   const { alerts } = useAlerts();
   const history = useHistory();
+  const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
 
   const handleCancel = React.useCallback(
     () => history.push(`${routeBasePath}/clusters/`),
@@ -112,6 +116,7 @@ const ClusterWizardFooter = ({
       leftExtraActions={additionalActions}
       cluster={cluster}
       onFetchEvents={onFetchEvents}
+      isNextDisabled={isNextDisabled && !isViewerMode}
       {...rest}
     />
   );

--- a/src/ocm/components/clusterWizard/HostDiscovery.tsx
+++ b/src/ocm/components/clusterWizard/HostDiscovery.tsx
@@ -1,33 +1,32 @@
 import React from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { Formik, FormikConfig, useFormikContext } from 'formik';
 import {
   Cluster,
   V2ClusterUpdateParams,
   getFormikErrorFields,
   ClusterWizardStep,
+  HostDiscoveryValues,
   useAlerts,
   getHostDiscoveryInitialValues,
   useFormikAutoSave,
 } from '../../../common';
-import { HostDiscoveryValues } from '../../../common/types/clusters';
 import HostInventory from '../clusterConfiguration/HostInventory';
 import { useClusterWizardContext } from './ClusterWizardContext';
 import { canNextHostDiscovery } from './wizardTransition';
-import { getApiErrorMessage, handleApiError } from '../../api/utils';
-import { updateCluster } from '../../reducers/clusters/currentClusterSlice';
+import { getApiErrorMessage, handleApiError } from '../../api';
+import { updateCluster } from '../../reducers/clusters';
 import ClusterWizardFooter from './ClusterWizardFooter';
 import ClusterWizardNavigation from './ClusterWizardNavigation';
 import { ClustersService, HostDiscoveryService } from '../../services';
-import useClusterPermissions from '../../hooks/useClusterPermissions';
+import { selectCurrentClusterPermissionsState } from '../../selectors';
 
-const HostDiscoveryForm: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
+const HostDiscoveryForm = ({ cluster }: { cluster: Cluster }) => {
   const { alerts } = useAlerts();
   const { errors, touched, isSubmitting, isValid } = useFormikContext<HostDiscoveryValues>();
   const clusterWizardContext = useClusterWizardContext();
   const isAutoSaveRunning = useFormikAutoSave();
   const errorFields = getFormikErrorFields(errors, touched);
-  const { isViewerMode } = useClusterPermissions();
 
   const isNextDisabled =
     !isValid ||
@@ -41,7 +40,7 @@ const HostDiscoveryForm: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
       cluster={cluster}
       errorFields={errorFields}
       isSubmitting={isSubmitting}
-      isNextDisabled={!isViewerMode && isNextDisabled}
+      isNextDisabled={isNextDisabled}
       onNext={() => clusterWizardContext.moveNext()}
       onBack={() => clusterWizardContext.moveBack()}
     />
@@ -54,10 +53,10 @@ const HostDiscoveryForm: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
   );
 };
 
-const HostDiscovery: React.FC<{ cluster: Cluster }> = ({ cluster }) => {
+const HostDiscovery = ({ cluster }: { cluster: Cluster }) => {
   const dispatch = useDispatch();
   const { addAlert, clearAlerts } = useAlerts();
-  const { isViewerMode } = useClusterPermissions();
+  const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
   const initialValues = React.useMemo(
     () => getHostDiscoveryInitialValues(cluster),
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/ocm/components/clusterWizard/StaticIp.tsx
+++ b/src/ocm/components/clusterWizard/StaticIp.tsx
@@ -9,6 +9,7 @@ import {
 } from '../clusterConfiguration/staticIp/components/propTypes';
 import { StaticIpPage } from '../clusterConfiguration/staticIp/components/StaticIpPage';
 import { WithErrorBoundary } from '../../../common/components/ErrorHandling/WithErrorBoundary';
+import useClusterPermissions from '../../hooks/useClusterPermissions';
 
 const getInitialFormStateProps = () => {
   return {
@@ -26,13 +27,16 @@ const StaticIp: React.FC<StaticIpProps & { cluster: Cluster }> = ({
   updateInfraEnv,
 }) => {
   const clusterWizardContext = useClusterWizardContext();
+  const { isViewerMode } = useClusterPermissions();
   const { alerts } = useAlerts();
   const [formState, setFormStateProps] = React.useState<StaticIpFormState>(
     getInitialFormStateProps(),
   );
 
   const onFormStateChange = (formState: StaticIpFormState) => {
-    setFormStateProps(formState);
+    if (!isViewerMode) {
+      setFormStateProps(formState);
+    }
   };
 
   const isNextDisabled =
@@ -47,7 +51,7 @@ const StaticIp: React.FC<StaticIpProps & { cluster: Cluster }> = ({
       isSubmitting={formState.isSubmitting}
       onNext={() => clusterWizardContext.moveNext()}
       onBack={() => clusterWizardContext.moveBack()}
-      isNextDisabled={isNextDisabled}
+      isNextDisabled={!isViewerMode && isNextDisabled}
     />
   );
 

--- a/src/ocm/components/clusterWizard/StaticIp.tsx
+++ b/src/ocm/components/clusterWizard/StaticIp.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import { Cluster, ClusterWizardStep, getFormikErrorFields, useAlerts } from '../../../common';
 import { useClusterWizardContext } from './ClusterWizardContext';
 import ClusterWizardFooter from './ClusterWizardFooter';
@@ -9,7 +10,7 @@ import {
 } from '../clusterConfiguration/staticIp/components/propTypes';
 import { StaticIpPage } from '../clusterConfiguration/staticIp/components/StaticIpPage';
 import { WithErrorBoundary } from '../../../common/components/ErrorHandling/WithErrorBoundary';
-import useClusterPermissions from '../../hooks/useClusterPermissions';
+import { selectCurrentClusterPermissionsState } from '../../selectors';
 
 const getInitialFormStateProps = () => {
   return {
@@ -27,7 +28,7 @@ const StaticIp: React.FC<StaticIpProps & { cluster: Cluster }> = ({
   updateInfraEnv,
 }) => {
   const clusterWizardContext = useClusterWizardContext();
-  const { isViewerMode } = useClusterPermissions();
+  const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
   const { alerts } = useAlerts();
   const [formState, setFormStateProps] = React.useState<StaticIpFormState>(
     getInitialFormStateProps(),
@@ -51,7 +52,7 @@ const StaticIp: React.FC<StaticIpProps & { cluster: Cluster }> = ({
       isSubmitting={formState.isSubmitting}
       onNext={() => clusterWizardContext.moveNext()}
       onBack={() => clusterWizardContext.moveBack()}
-      isNextDisabled={!isViewerMode && isNextDisabled}
+      isNextDisabled={isNextDisabled}
     />
   );
 

--- a/src/ocm/components/hosts/ClusterHostsTable.tsx
+++ b/src/ocm/components/hosts/ClusterHostsTable.tsx
@@ -34,11 +34,8 @@ export interface ClusterHostsTableProps {
 }
 
 const ClusterHostsTable = ({ cluster, skipDisabled }: ClusterHostsTableProps) => {
-  // TODO Celia NOT OK
-  const { onEditHost, actionChecks, onEditRole, actionResolver, ...modalProps } = useHostsTable(
-    cluster,
-    true,
-  );
+  const { onEditHost, actionChecks, onEditRole, actionResolver, ...modalProps } =
+    useHostsTable(cluster);
   const { t } = useTranslation();
   const content = React.useMemo(
     () => [

--- a/src/ocm/components/hosts/ClusterHostsTable.tsx
+++ b/src/ocm/components/hosts/ClusterHostsTable.tsx
@@ -34,8 +34,11 @@ export interface ClusterHostsTableProps {
 }
 
 const ClusterHostsTable = ({ cluster, skipDisabled }: ClusterHostsTableProps) => {
-  const { onEditHost, actionChecks, onEditRole, actionResolver, ...modalProps } =
-    useHostsTable(cluster);
+  // TODO Celia NOT OK
+  const { onEditHost, actionChecks, onEditRole, actionResolver, ...modalProps } = useHostsTable(
+    cluster,
+    true,
+  );
   const { t } = useTranslation();
   const content = React.useMemo(
     () => [

--- a/src/ocm/components/hosts/HostsDiscoveryTable.tsx
+++ b/src/ocm/components/hosts/HostsDiscoveryTable.tsx
@@ -31,6 +31,8 @@ import { usePagination } from '../../../common/components/hosts/usePagination';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
 import HardwareStatus from './HardwareStatus';
 import HostsTableEmptyState from '../hosts/HostsTableEmptyState';
+import { useSelector } from 'react-redux';
+import { selectCurrentClusterPermissionsState } from '../../selectors';
 
 export const hardwareStatusColumn = (
   onEditHostname?: HostsTableActions['onEditHost'],
@@ -74,7 +76,6 @@ type HostsDiscoveryTableProps = {
 };
 
 const HostsDiscoveryTable = ({ cluster }: HostsDiscoveryTableProps) => {
-  const isDisabled = true; // TODO Celia NOT OK
   const {
     onEditHost,
     actionChecks,
@@ -86,8 +87,9 @@ const HostsDiscoveryTable = ({ cluster }: HostsDiscoveryTableProps) => {
     onMassChangeHostname,
     onMassDeleteHost,
     ...modalProps
-  } = useHostsTable(cluster, isDisabled);
+  } = useHostsTable(cluster);
 
+  const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
   const isSNOCluster = isSNO(cluster);
   const { t } = useTranslation();
   const content = React.useMemo(
@@ -107,7 +109,7 @@ const HostsDiscoveryTable = ({ cluster }: HostsDiscoveryTableProps) => {
   const hosts = cluster.hosts || [];
   const paginationProps = usePagination(hosts.length);
   const itemIDs = hosts.map((h) => h.id);
-  const showBulkActions = !isDisabled && !isSNOCluster;
+  const showBulkActions = !(isViewerMode || isSNOCluster);
 
   return (
     <>

--- a/src/ocm/components/hosts/HostsDiscoveryTable.tsx
+++ b/src/ocm/components/hosts/HostsDiscoveryTable.tsx
@@ -71,10 +71,10 @@ const HostRowDetailExpand = ({ obj: host }: ExpandComponentProps<Host>) => (
 
 type HostsDiscoveryTableProps = {
   cluster: Cluster;
-  skipDisabled?: boolean;
 };
 
 const HostsDiscoveryTable = ({ cluster }: HostsDiscoveryTableProps) => {
+  const isDisabled = true; // TODO Celia NOT OK
   const {
     onEditHost,
     actionChecks,
@@ -86,7 +86,7 @@ const HostsDiscoveryTable = ({ cluster }: HostsDiscoveryTableProps) => {
     onMassChangeHostname,
     onMassDeleteHost,
     ...modalProps
-  } = useHostsTable(cluster);
+  } = useHostsTable(cluster, isDisabled);
 
   const isSNOCluster = isSNO(cluster);
   const { t } = useTranslation();
@@ -107,11 +107,12 @@ const HostsDiscoveryTable = ({ cluster }: HostsDiscoveryTableProps) => {
   const hosts = cluster.hosts || [];
   const paginationProps = usePagination(hosts.length);
   const itemIDs = hosts.map((h) => h.id);
+  const showBulkActions = !isDisabled && !isSNOCluster;
 
   return (
     <>
       <Stack hasGutter>
-        {!isSNOCluster && (
+        {showBulkActions && (
           <StackItem>
             <TableToolbar
               selectedIDs={selectedHostIDs || []}
@@ -132,7 +133,7 @@ const HostsDiscoveryTable = ({ cluster }: HostsDiscoveryTableProps) => {
             content={content}
             actionResolver={actionResolver}
             ExpandComponent={HostRowDetailExpand}
-            onSelect={isSNOCluster ? undefined : onSelect}
+            onSelect={showBulkActions ? onSelect : undefined}
             selectedIDs={selectedHostIDs}
             setSelectedIDs={setSelectedHostIDs}
             {...paginationProps}

--- a/src/ocm/components/hosts/use-hosts-table.tsx
+++ b/src/ocm/components/hosts/use-hosts-table.tsx
@@ -52,7 +52,7 @@ import { usePagination } from '../../../common/components/hosts/usePagination';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
 import { getErrorMessage } from '../../../common/utils';
 
-export const useHostsTable = (cluster: Cluster) => {
+export const useHostsTable = (cluster: Cluster, isViewerMode: boolean) => {
   const { addAlert } = useAlerts();
   const {
     eventsDialog,
@@ -181,17 +181,18 @@ export const useHostsTable = (cluster: Cluster) => {
 
   const actionChecks = React.useMemo(
     () => ({
-      canEditRole: (host: Host) => canEditRoleUtil(cluster.status, host.status, isSNO(cluster)),
-      canInstallHost: (host: Host) => canInstallHostUtil(cluster, host.status),
-      canEditDisks: (host: Host) => canEditDisksUtil(cluster.status, host.status),
-      canEnable: (host: Host) => canEnableUtil(cluster.status, host.status),
-      canDisable: (host: Host) => canDisableUtil(cluster.status, host.status),
-      canDelete: (host: Host) => canDeleteUtil(cluster.status, host.status),
-      canEditHost: (host: Host) => canEditHostUtil(cluster.status, host.status),
-      canReset: (host: Host) => canResetUtil(cluster.status, host.status),
-      canEditHostname: () => canEditHostnameUtil(cluster.status),
+      canEditRole: (host: Host) =>
+        !isViewerMode && canEditRoleUtil(cluster.status, host.status, isSNO(cluster)),
+      canInstallHost: (host: Host) => !isViewerMode && canInstallHostUtil(cluster, host.status),
+      canEditDisks: (host: Host) => !isViewerMode && canEditDisksUtil(cluster.status, host.status),
+      canEnable: (host: Host) => !isViewerMode && canEnableUtil(cluster.status, host.status),
+      canDisable: (host: Host) => !isViewerMode && canDisableUtil(cluster.status, host.status),
+      canDelete: (host: Host) => !isViewerMode && canDeleteUtil(cluster.status, host.status),
+      canEditHost: (host: Host) => !isViewerMode && canEditHostUtil(cluster.status, host.status),
+      canReset: (host: Host) => !isViewerMode && canResetUtil(cluster.status, host.status),
+      canEditHostname: () => !isViewerMode && canEditHostnameUtil(cluster.status),
     }),
-    [cluster],
+    [cluster, isViewerMode],
   );
 
   const onReset = React.useCallback(() => {
@@ -317,7 +318,7 @@ export const useHostsTable = (cluster: Cluster) => {
     onDelete,
     onAdditionalNtpSource,
     onUpdateDay2ApiVip,
-    onSelect,
+    onSelect: isViewerMode ? undefined : onSelect,
     selectedHostIDs,
     setSelectedHostIDs,
     onMassChangeHostname,

--- a/src/ocm/components/hosts/use-hosts-table.tsx
+++ b/src/ocm/components/hosts/use-hosts-table.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import {
   useAlerts,
   Cluster,
@@ -51,8 +51,9 @@ import { UpdateDay2ApiVipFormProps } from './UpdateDay2ApiVipForm';
 import { usePagination } from '../../../common/components/hosts/usePagination';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
 import { getErrorMessage } from '../../../common/utils';
+import { selectCurrentClusterPermissionsState } from '../../selectors';
 
-export const useHostsTable = (cluster: Cluster, isViewerMode: boolean) => {
+export const useHostsTable = (cluster: Cluster) => {
   const { addAlert } = useAlerts();
   const {
     eventsDialog,
@@ -63,6 +64,7 @@ export const useHostsTable = (cluster: Cluster, isViewerMode: boolean) => {
     massDeleteHostDialog,
   } = useModalDialogsContext();
   const { resetCluster } = React.useContext(AddHostsContext);
+  const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
 
   const dispatch = useDispatch();
 

--- a/src/ocm/components/ui/OcmFormFields.tsx
+++ b/src/ocm/components/ui/OcmFormFields.tsx
@@ -1,0 +1,73 @@
+import * as React from 'react';
+import { useSelector } from 'react-redux';
+import { Checkbox, CheckboxProps, Radio, RadioProps } from '@patternfly/react-core';
+import { selectCurrentClusterPermissionsState } from '../../selectors';
+import {
+  CheckboxField,
+  CodeField,
+  InputField,
+  RadioField,
+  RichInputField,
+  SelectField,
+  SwitchField,
+} from '../../../common';
+import {
+  CheckboxFieldProps,
+  CodeFieldProps,
+  InputFieldProps,
+  RadioFieldProps,
+  SelectFieldProps,
+  SwitchFieldProps,
+} from '../../../common/components/ui/formik/types';
+import { RichInputFieldPropsProps } from '../../../common/components/ui/formik/RichInputField';
+
+type DisableableField = {
+  isDisabled?: boolean;
+};
+
+function FormFieldDisabler<T extends DisableableField>(FormComponent: React.ComponentType<T>) {
+  return function WrapperHoc(props: T) {
+    const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
+
+    const isDisabled = props.isDisabled || isViewerMode;
+    return <FormComponent {...props} isDisabled={isDisabled} />;
+  };
+}
+
+export function RefFormFieldDisabler<T extends DisableableField>(
+  FormComponent: React.ComponentType<T>,
+) {
+  return React.forwardRef(function useInputRef(props: T, ref) {
+    const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
+
+    const isDisabled: boolean = props.isDisabled || isViewerMode;
+    return <FormComponent ref={ref} {...props} isDisabled={isDisabled} />;
+  });
+}
+
+// Formik Fields
+const OcmInputField = FormFieldDisabler<InputFieldProps>(InputField);
+const OcmSelectField = FormFieldDisabler<SelectFieldProps>(SelectField);
+const OcmCheckboxField = FormFieldDisabler<CheckboxFieldProps>(CheckboxField);
+const OcmSwitchField = FormFieldDisabler<SwitchFieldProps>(SwitchField);
+const OcmRadioField = FormFieldDisabler<RadioFieldProps>(RadioField);
+const OcmCodeField = FormFieldDisabler<CodeFieldProps>(CodeField);
+
+// Patternfly components
+const OcmCheckbox = FormFieldDisabler<CheckboxProps>(Checkbox);
+const OcmRadio = FormFieldDisabler<RadioProps>(Radio);
+
+// With forwardRef
+const OcmRichInputField = RefFormFieldDisabler<RichInputFieldPropsProps>(RichInputField);
+
+export {
+  OcmInputField,
+  OcmRichInputField,
+  OcmSelectField,
+  OcmCheckbox,
+  OcmCheckboxField,
+  OcmCodeField,
+  OcmSwitchField,
+  OcmRadioField,
+  OcmRadio,
+};

--- a/src/ocm/config/constants.ts
+++ b/src/ocm/config/constants.ts
@@ -8,7 +8,7 @@ export const isSingleClusterMode = () => {
   return process.env.REACT_APP_BUILD_MODE === 'single-cluster';
 };
 
-/* Used from e2e tests so we can mock the permissions */
+/* Used from Integration tests so we can mock the permissions */
 export type ExtendedCluster = Cluster & {
   permissions: AssistedInstallerOCMPermissionTypesListType;
 };

--- a/src/ocm/config/constants.ts
+++ b/src/ocm/config/constants.ts
@@ -1,2 +1,45 @@
-export const isSingleClusterMode = () => process.env.REACT_APP_BUILD_MODE === 'single-cluster';
+import {
+  AssistedInstallerOCMPermissionTypesListType,
+  AssistedInstallerPermissionTypesListType,
+  Cluster,
+} from '../../common';
+
+export const isSingleClusterMode = () => {
+  return process.env.REACT_APP_BUILD_MODE === 'single-cluster';
+};
+
+/* Used from e2e tests so we can mock the permissions */
+export type ExtendedCluster = Cluster & {
+  permissions: AssistedInstallerOCMPermissionTypesListType;
+};
+
+export const getBasePermissions = (
+  cluster?: ExtendedCluster,
+): AssistedInstallerPermissionTypesListType => {
+  if (cluster?.permissions) {
+    return { isViewerMode: !cluster.permissions.canEdit };
+  }
+
+  const basePermissions = { isViewerMode: false };
+  if (!process.env.REACT_APP_CLUSTER_PERMISSIONS) {
+    return basePermissions;
+  }
+  const ocmPermissions = JSON.parse(process.env.REACT_APP_CLUSTER_PERMISSIONS);
+
+  return {
+    ...basePermissions,
+    ...ocmPermissionsToAIPermissions(ocmPermissions),
+  };
+};
+
+export const ocmPermissionsToAIPermissions = (
+  ocmPermissions: AssistedInstallerOCMPermissionTypesListType,
+): Partial<AssistedInstallerPermissionTypesListType> => {
+  const permissions: Partial<AssistedInstallerPermissionTypesListType> = {};
+  if (ocmPermissions.canEdit !== undefined) {
+    permissions.isViewerMode = !ocmPermissions.canEdit;
+  }
+  return permissions;
+};
+
 export const OCM_CLUSTER_LIST_LINK = '/openshift'; // TODO(mlibra): Tweak it!!!

--- a/src/ocm/config/constants.ts
+++ b/src/ocm/config/constants.ts
@@ -14,9 +14,9 @@ export type ExtendedCluster = Cluster & {
 };
 
 export const getBasePermissions = (
-  cluster?: ExtendedCluster,
+  cluster: ExtendedCluster,
 ): AssistedInstallerPermissionTypesListType => {
-  if (cluster?.permissions) {
+  if (cluster.permissions) {
     return { isViewerMode: !cluster.permissions.canEdit };
   }
 
@@ -24,7 +24,9 @@ export const getBasePermissions = (
   if (!process.env.REACT_APP_CLUSTER_PERMISSIONS) {
     return basePermissions;
   }
-  const ocmPermissions = JSON.parse(process.env.REACT_APP_CLUSTER_PERMISSIONS);
+  const ocmPermissions = JSON.parse(
+    process.env.REACT_APP_CLUSTER_PERMISSIONS,
+  ) as AssistedInstallerOCMPermissionTypesListType;
 
   return {
     ...basePermissions,

--- a/src/ocm/hooks/useClusterPermissions.ts
+++ b/src/ocm/hooks/useClusterPermissions.ts
@@ -1,0 +1,30 @@
+import { useDispatch, useSelector } from 'react-redux';
+import { AssistedInstallerOCMPermissionTypesListType, Cluster } from '../../common';
+import { ExtendedCluster, getBasePermissions, ocmPermissionsToAIPermissions } from '../config';
+import { updateClusterPermissions } from '../reducers/clusters';
+import { selectCurrentClusterPermissionsState } from '../selectors';
+
+export default function useClusterPermissions() {
+  const dispatch = useDispatch();
+
+  const permissions = useSelector(selectCurrentClusterPermissionsState);
+
+  const updatePermissions = (
+    ocmPermissions?: AssistedInstallerOCMPermissionTypesListType,
+    cluster?: Cluster,
+  ) => {
+    let newPermissions = getBasePermissions(cluster as ExtendedCluster);
+    if (ocmPermissions) {
+      newPermissions = {
+        ...newPermissions,
+        ...ocmPermissionsToAIPermissions(ocmPermissions || {}),
+      };
+    }
+    dispatch(updateClusterPermissions(newPermissions));
+  };
+
+  return {
+    ...permissions,
+    setPermissions: updatePermissions,
+  };
+}

--- a/src/ocm/hooks/useSetClusterPermissions.ts
+++ b/src/ocm/hooks/useSetClusterPermissions.ts
@@ -1,18 +1,16 @@
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { AssistedInstallerOCMPermissionTypesListType, Cluster } from '../../common';
 import { ExtendedCluster, getBasePermissions, ocmPermissionsToAIPermissions } from '../config';
 import { updateClusterPermissions } from '../reducers/clusters';
-import { selectCurrentClusterPermissionsState } from '../selectors';
 
-export default function useClusterPermissions() {
+export default function useSetClusterPermissions() {
   const dispatch = useDispatch();
 
-  const permissions = useSelector(selectCurrentClusterPermissionsState);
-
-  const updatePermissions = (
-    ocmPermissions?: AssistedInstallerOCMPermissionTypesListType,
-    cluster?: Cluster,
-  ) => {
+  return (cluster?: Cluster, ocmPermissions?: AssistedInstallerOCMPermissionTypesListType) => {
+    if (!cluster) {
+      // We must not update the permissions, the state is reset when the cluster is cleaned
+      return;
+    }
     let newPermissions = getBasePermissions(cluster as ExtendedCluster);
     if (ocmPermissions) {
       newPermissions = {
@@ -21,10 +19,5 @@ export default function useClusterPermissions() {
       };
     }
     dispatch(updateClusterPermissions(newPermissions));
-  };
-
-  return {
-    ...permissions,
-    setPermissions: updatePermissions,
   };
 }

--- a/src/ocm/reducers/clusters/currentClusterSlice.ts
+++ b/src/ocm/reducers/clusters/currentClusterSlice.ts
@@ -1,7 +1,7 @@
 import findIndex from 'lodash/findIndex';
 import set from 'lodash/set';
 import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
-import { Cluster, Host } from '../../../common';
+import { AssistedInstallerPermissionTypesListType, Cluster, Host } from '../../../common';
 import { handleApiError } from '../../api/utils';
 import { ResourceUIState } from '../../../common';
 import { ClustersService, HostsService } from '../../services';
@@ -15,6 +15,7 @@ type CurrentClusterStateSlice = {
   data?: Cluster;
   uiState: ResourceUIState;
   isReloadScheduled: number;
+  permissions: AssistedInstallerPermissionTypesListType;
   errorDetail?: RetrievalErrorType;
 };
 
@@ -40,6 +41,7 @@ export const fetchClusterAsync = createAsyncThunk<
 const initialState: CurrentClusterStateSlice = {
   data: undefined,
   uiState: ResourceUIState.LOADING,
+  permissions: { isViewerMode: false },
   errorDetail: undefined,
   isReloadScheduled: 0,
 };
@@ -72,6 +74,13 @@ export const currentClusterSlice = createSlice({
     cancelForceReload: (state) => ({
       ...state,
       isReloadScheduled: 0,
+    }),
+    updateClusterPermissions: (
+      state,
+      action: PayloadAction<AssistedInstallerPermissionTypesListType>,
+    ) => ({
+      ...state,
+      permissions: action.payload,
     }),
   },
   extraReducers: (builder) => {
@@ -110,5 +119,6 @@ export const {
   cleanCluster,
   forceReload,
   cancelForceReload,
+  updateClusterPermissions,
 } = currentClusterSlice.actions;
 export default currentClusterSlice.reducer;

--- a/src/ocm/selectors/currentCluster.ts
+++ b/src/ocm/selectors/currentCluster.ts
@@ -1,9 +1,17 @@
 import { RootState } from '../store/rootReducer';
+import { AssistedInstallerPermissionTypesListType } from '../../common';
 
 export const selectCurrentClusterState = (state: RootState) => state.currentCluster;
 export const selectCurrentCluster = (state: RootState) => state.currentCluster.data;
 export const selectCurrentClusterUIState = (state: RootState) => state.currentCluster.uiState;
 export const selectIsCurrentClusterSNO = (state: RootState) =>
   state.currentCluster.data?.highAvailabilityMode === 'None';
-export const selectCurrentClusterPermissionsState = (state: RootState) =>
-  state.currentCluster.permissions;
+export const selectCurrentClusterPermissionsState = (
+  state: RootState,
+): AssistedInstallerPermissionTypesListType => {
+  if (state.currentCluster) {
+    return state.currentCluster.permissions;
+  }
+  // This shouldn't happen, but to be on the safe side, return the default permissions
+  return { isViewerMode: false };
+};

--- a/src/ocm/selectors/currentCluster.ts
+++ b/src/ocm/selectors/currentCluster.ts
@@ -5,3 +5,5 @@ export const selectCurrentCluster = (state: RootState) => state.currentCluster.d
 export const selectCurrentClusterUIState = (state: RootState) => state.currentCluster.uiState;
 export const selectIsCurrentClusterSNO = (state: RootState) =>
   state.currentCluster.data?.highAvailabilityMode === 'None';
+export const selectCurrentClusterPermissionsState = (state: RootState) =>
+  state.currentCluster.permissions;


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-10110


### Description
The UI now has a mode for users that are not allowed to edit a cluster, to be able to see it and not update it.
They can go through the wizard, even when validations are failing on a previous step.


### Related PRs:

**Assisted UI**: Allows to set an environment variable to make the Assisted UI application be in read-only mode.
https://github.com/openshift-assisted/assisted-ui/pull/569

**Openshift Assisted UI**: Includes the adaptations to the existing Read-only Integration tests.
https://github.com/openshift-assisted/openshift-assisted-ui/pull/18

**UHC Portal**: OCM sends the cluster permissions so that the UI can determine if the cluster is in edition or viewer mode.
https://gitlab.cee.redhat.com/service/uhc-portal/-/merge_requests/3398