### PR TITLE
Use a unique test-id for the number of disks

### DIFF
--- a/src/common/components/storage/StorageUtils.tsx
+++ b/src/common/components/storage/StorageUtils.tsx
@@ -37,7 +37,7 @@ export const numberOfDisksColumn: TableRow<Host> = {
     const disks = inventory.disks || [];
     return {
       title: <> {disks.length} </>,
-      props: { 'data-testid': 'host-role' },
+      props: { 'data-testid': 'disk-number' },
       sortableValue: disks.length,
     };
   },


### PR DESCRIPTION
The column had the same data-testid as the host-role column.