### PR TITLE
MGMT-11722: In the validation message looks like there is a missing space in between the words

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -646,7 +646,7 @@
   "ai:View documentation": "View documentation",
   "ai:VIP IP allocation from DHCP server has been timed out": "VIP IP allocation from DHCP server has been timed out",
   "ai:Virtual machine": "Virtual machine",
-  "ai:Vsphere disk uuidenabled": "Vsphere disk uuidenabled",
+  "ai:Vsphere disk uuid enabled": "Vsphere disk uuid enabled",
   "ai:Waiting for host...": "Waiting for host...",
   "ai:Waiting for host..._plural": "Waiting for hosts...",
   "ai:Waiting for hosts...": "Waiting for hosts...",

--- a/src/common/config/constants.ts
+++ b/src/common/config/constants.ts
@@ -137,7 +137,7 @@ export const hostValidationLabels = (t: TFunction): { [key in HostValidationId]:
   'apps-domain-name-resolved-correctly': t('ai:Application ingress domain name resolution'),
   'dns-wildcard-not-configured': t('ai:DNS wildcard not configured'),
   'non-overlapping-subnets': t('ai:Non overlapping subnets'),
-  'vsphere-disk-uuid-enabled': t('ai:Vsphere disk uuidenabled'),
+  'vsphere-disk-uuid-enabled': t('ai:Vsphere disk uuid enabled'),
   'compatible-agent': t('ai:Agent compatibility'),
 });
 


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-11722
![validation_message](https://user-images.githubusercontent.com/11390125/185886743-f2b30cd9-5d8d-4778-b4aa-74aa658c5b7d.png)

