### PR TITLE
MGMT-11626: can't accept broadcast IP and network address for defaul gateway

### DIFF
--- a/src/ocm/components/clusterConfiguration/staticIp/commonValidationSchemas.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/commonValidationSchemas.tsx
@@ -1,6 +1,7 @@
 import { Address4, Address6 } from 'ip-address';
 import { isInSubnet } from 'is-in-subnet';
 import * as Yup from 'yup';
+import { getAddressObject } from './data/protocolVersion';
 
 const LOCAL_HOST_IP = {
   ipv4: '127.0.0.0',
@@ -141,6 +142,25 @@ export const getIpAddressInSubnetValidationSchema = (
         //if isInSubnet fails it means the machine network cidr isn't valid and this validation is irrelevant
         return true;
       }
+    },
+  );
+};
+
+export const getIpIsNotNetworkOrBroadcastAddressSchema = (
+  protocolVersion: 'ipv4' | 'ipv6',
+  subnet: string,
+) => {
+  return Yup.string().test(
+    'is-not-network-or-broadcast',
+    `The IP address must not match the network or broadcast address`,
+    (value) => {
+      const subnetAddr = getAddressObject(subnet, protocolVersion);
+      if (subnetAddr) {
+        const subnetStart = subnetAddr?.startAddress().correctForm();
+        const subnetEnd = subnetAddr?.endAddress().correctForm();
+        return !(value === subnetStart || value === subnetEnd);
+      }
+      return true;
     },
   );
 };

--- a/src/ocm/components/clusterConfiguration/staticIp/components/FormViewNetworkWide/formViewNetworkWideValidationSchema.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/components/FormViewNetworkWide/formViewNetworkWideValidationSchema.tsx
@@ -9,6 +9,7 @@ import {
   getIpAddressValidationSchema,
   isNotLocalHostIPAddress,
   isNotCatchAllIPAddress,
+  getIpIsNotNetworkOrBroadcastAddressSchema,
 } from '../../commonValidationSchemas';
 const REQUIRED_MESSAGE = 'A value is required';
 
@@ -28,6 +29,16 @@ export const getInMachineNetworkValidationSchema = (
   machineNetwork: Cidr,
 ) => {
   return getIpAddressInSubnetValidationSchema(
+    protocolVersion,
+    getMachineNetworkCidr(machineNetwork),
+  );
+};
+
+export const getIsNotNetworkOrBroadcastAddressSchema = (
+  protocolVersion: 'ipv4' | 'ipv6',
+  machineNetwork: Cidr,
+) => {
+  return getIpIsNotNetworkOrBroadcastAddressSchema(
     protocolVersion,
     getMachineNetworkCidr(machineNetwork),
   );
@@ -58,9 +69,9 @@ const getAddressDataValidationSchema = (protocolVersion: ProtocolVersion, ipConf
   return Yup.object().shape<IpConfig>({
     dns: getIPValidationSchema(protocolVersion),
     machineNetwork: getMachineNetworkValidationSchema(protocolVersion),
-    gateway: getIPValidationSchema(protocolVersion).concat(
-      getInMachineNetworkValidationSchema(protocolVersion, ipConfig.machineNetwork),
-    ),
+    gateway: getIPValidationSchema(protocolVersion)
+      .concat(getInMachineNetworkValidationSchema(protocolVersion, ipConfig.machineNetwork))
+      .concat(getIsNotNetworkOrBroadcastAddressSchema(protocolVersion, ipConfig.machineNetwork)),
   });
 };
 


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-11626

Add new validation in default gateway to validate that address is not broadcast or network address

New validation:
![image](https://user-images.githubusercontent.com/11390125/186165047-7261a661-0fda-46d3-a7c7-0267201d2291.png)

