### PR TITLE
MGMT-11559: Not allow role editing in the Networking step

### DIFF
--- a/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationTable.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationTable.tsx
@@ -6,17 +6,14 @@ import { HostsTableModals, useHostsTable } from '../../hosts/use-hosts-table';
 import NetworkConfigurationTableBase from './NetworkConfigurationTableBase';
 
 const NetworkConfigurationTable = ({ cluster }: ClusterHostsTableProps) => {
-  const { onEditHost, actionChecks, onEditRole, actionResolver, ...modalProps } =
-    useHostsTable(cluster);
+  const { onEditHost, actionResolver, ...modalProps } = useHostsTable(cluster);
 
   return (
     <>
       <NetworkConfigurationTableBase
         cluster={cluster}
         AdditionalNTPSourcesDialogToggleComponent={AdditionalNTPSourcesDialogToggle}
-        canEditRole={actionChecks.canEditRole}
         onEditHost={onEditHost}
-        onEditRole={onEditRole}
         actionResolver={actionResolver}
       >
         <HostsTableEmptyState isSNO={isSNO(cluster)} />


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-11559

Not allow role editing in the "Storage" or "Networking" step (need to remove this capability from there) to prevent misclicks and wrong configurations dead ends.

![image](https://user-images.githubusercontent.com/11390125/186403284-951d444b-dd1d-452d-9612-23e65ac27ac3.png)
