### PR TITLE
MGMT-11577: Take OCP version from OCM when creating day-2 infraenv/cluster [BACKPORT]

### DIFF
--- a/src/ocm/components/AddHosts/HostsClusterDetailTab.tsx
+++ b/src/ocm/components/AddHosts/HostsClusterDetailTab.tsx
@@ -11,6 +11,7 @@ import {
 import { usePullSecret } from '../../hooks';
 import { AssistedUILibVersion } from '../ui';
 import { handleApiError } from '../../api';
+import { useOpenshiftVersions } from '../../hooks';
 import AddHosts from './AddHosts';
 import { OcmClusterType } from './types';
 import Day2ClusterService from '../../services/Day2ClusterService';
@@ -33,6 +34,7 @@ const HostsClusterDetailTabContent: React.FC<HostsClusterDetailTabProps> = ({
   const [error, setError] = React.useState<ReactNode>();
   const [day2Cluster, setDay2Cluster] = useStateSafely<Cluster | null | undefined>(undefined);
   const pullSecret = usePullSecret();
+  const { normalizeClusterVersion } = useOpenshiftVersions();
 
   const TryAgain = React.useCallback(
     () => (
@@ -84,6 +86,19 @@ const HostsClusterDetailTabContent: React.FC<HostsClusterDetailTabProps> = ({
     if (isVisible && day2Cluster === undefined && cluster && openshiftClusterId && pullSecret) {
       // ensure exclusive run
       setDay2Cluster(null);
+
+      const openshiftVersion = normalizeClusterVersion(cluster.openshift_version);
+      if (!openshiftVersion) {
+        setError(
+          <>
+            Unsupported OpenShift cluster version: ${cluster.openshift_version}.
+            <br />
+            Check your connection and <TryAgain />.
+          </>,
+        );
+        return;
+      }
+
       let apiVipDnsname = '';
       // Format of cluster.api.url: protocol://domain:port
       if (cluster.api?.url) {
@@ -124,7 +139,11 @@ const HostsClusterDetailTabContent: React.FC<HostsClusterDetailTabProps> = ({
 
       const doItAsync = async () => {
         try {
-          const day2Cluster = await Day2ClusterService.fetchCluster(cluster, pullSecret);
+          const day2Cluster = await Day2ClusterService.fetchCluster(
+            cluster,
+            pullSecret,
+            openshiftVersion,
+          );
           setDay2Cluster(day2Cluster);
         } catch (e) {
           handleApiError(e);
@@ -147,7 +166,15 @@ const HostsClusterDetailTabContent: React.FC<HostsClusterDetailTabProps> = ({
       void doItAsync();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cluster, openModal, pullSecret, day2Cluster, setDay2Cluster, isVisible]);
+  }, [
+    cluster,
+    openModal,
+    pullSecret,
+    day2Cluster,
+    setDay2Cluster,
+    isVisible,
+    normalizeClusterVersion,
+  ]);
 
   const resetCluster = React.useCallback(async () => {
     if (day2Cluster) {

--- a/src/ocm/services/Day2ClusterService.ts
+++ b/src/ocm/services/Day2ClusterService.ts
@@ -44,6 +44,7 @@ const Day2ClusterService = {
         ocmCluster.display_name || ocmCluster.name || openshiftClusterId,
         apiVipDnsname,
         pullSecret,
+        ocmCluster.openshift_version,
       );
     }
   },
@@ -59,17 +60,20 @@ const Day2ClusterService = {
     clusterName: string,
     apiVipDnsname: string,
     pullSecret: string,
+    openshiftVersion: string,
   ) {
     const { data } = await ClustersAPI.registerAddHosts({
       openshiftClusterId, // used to both match OpenShift Cluster and as an assisted-installer ID
       name: `scale-up-${clusterName}`, // both cluster.name and cluster.display-name contain just UUID which fails AI validation (k8s naming conventions)
       apiVipDnsname,
+      openshiftVersion: openshiftVersion,
     });
 
     await InfraEnvsService.create({
       name: `${data.name || ''}_infra-env`,
       pullSecret,
       clusterId: data.id,
+      openshiftVersion: openshiftVersion,
     });
 
     data.hosts = await Day2ClusterService.fetchHosts(data.id);

--- a/src/ocm/services/Day2ClusterService.ts
+++ b/src/ocm/services/Day2ClusterService.ts
@@ -8,7 +8,7 @@ const Day2ClusterService = {
     return ocmCluster && ocmCluster.external_id;
   },
 
-  async fetchCluster(ocmCluster: OcmClusterType, pullSecret: string) {
+  async fetchCluster(ocmCluster: OcmClusterType, pullSecret: string, openshiftVersion: string) {
     const openshiftClusterId = Day2ClusterService.getOpenshiftClusterId(ocmCluster);
 
     if (!openshiftClusterId) {
@@ -44,7 +44,7 @@ const Day2ClusterService = {
         ocmCluster.display_name || ocmCluster.name || openshiftClusterId,
         apiVipDnsname,
         pullSecret,
-        ocmCluster.openshift_version,
+        openshiftVersion,
       );
     }
   },
@@ -66,14 +66,14 @@ const Day2ClusterService = {
       openshiftClusterId, // used to both match OpenShift Cluster and as an assisted-installer ID
       name: `scale-up-${clusterName}`, // both cluster.name and cluster.display-name contain just UUID which fails AI validation (k8s naming conventions)
       apiVipDnsname,
-      openshiftVersion: openshiftVersion,
+      openshiftVersion,
     });
 
     await InfraEnvsService.create({
       name: `${data.name || ''}_infra-env`,
       pullSecret,
       clusterId: data.id,
-      openshiftVersion: openshiftVersion,
+      openshiftVersion,
     });
 
     data.hosts = await Day2ClusterService.fetchHosts(data.id);


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-11577

Follow up on #1583, backport of #1606 