### PR TITLE
MGMT-11571 storage table in host discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "prepare": "install-peers",
     "test": "run-s test:circular lint format:check",
     "test:circular": "dpdm --warning false --tree false --exit-code circular:1 ./src/index.ts",
-    "lint": "eslint . --max-warnings=313 --color",
+    "lint": "eslint . --max-warnings=310 --color",
     "lint:fix": "yarn run lint --fix",
     "format": "prettier --write '**/*.{json,md,scss,yaml,yml}'",
     "format:check": "prettier --check '**/*.{json,md,scss,yaml,yml}'",

--- a/src/common/components/hosts/HostRowDetail.tsx
+++ b/src/common/components/hosts/HostRowDetail.tsx
@@ -29,7 +29,6 @@ type HostDetailProps = {
   onDiskRole?: onDiskRoleType;
   AdditionalNTPSourcesDialogToggleComponent?: ValidationInfoActionProps['AdditionalNTPSourcesDialogToggleComponent'];
   hideNTPStatus?: boolean;
-  showStorage?: boolean;
 };
 
 type SectionTitleProps = {
@@ -121,7 +120,6 @@ export const HostDetail = ({
   onDiskRole,
   AdditionalNTPSourcesDialogToggleComponent,
   hideNTPStatus = false,
-  showStorage = true,
 }: HostDetailProps) => {
   const { t } = useTranslation();
   const { id, validationsInfo: hostValidationsInfo } = host;
@@ -212,9 +210,7 @@ export const HostDetail = ({
           value={ntpValidationStatus}
         />
       </SectionColumn>
-      {showStorage && (
-        <StorageDetail host={host} onDiskRole={onDiskRole} canEditDisks={canEditDisks} />
-      )}
+      <StorageDetail host={host} onDiskRole={onDiskRole} canEditDisks={canEditDisks} />
       <SectionTitle
         testId={'nics-section'}
         title={`${nics.length} NIC${nics.length === 1 ? '' : 's'}`}

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationTableBase.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationTableBase.tsx
@@ -92,7 +92,6 @@ const NetworkConfigurationTableBase = ({
       return (
         <HostDetail
           host={obj}
-          showStorage={false}
           AdditionalNTPSourcesDialogToggleComponent={AdditionalNTPSourcesDialogToggleComponent}
         />
       );

--- a/src/ocm/components/hosts/HostsDiscoveryTable.tsx
+++ b/src/ocm/components/hosts/HostsDiscoveryTable.tsx
@@ -65,7 +65,6 @@ const HostRowDetailExpand = ({ obj: host }: ExpandComponentProps<Host>) => (
   <HostDetail
     key={host.id}
     host={host}
-    showStorage={false}
     AdditionalNTPSourcesDialogToggleComponent={AdditionalNTPSourcesDialogToggle}
   />
 );

--- a/src/ocm/reducers/clusters/clustersSlice.ts
+++ b/src/ocm/reducers/clusters/clustersSlice.ts
@@ -1,9 +1,7 @@
 import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
-import { Cluster } from '../../../common';
-import { handleApiError } from '../../api/utils';
-import { ResourceUIState } from '../../../common';
+import { Cluster, ResourceUIState } from '../../../common';
 import { ClustersAPI } from '../../services/apis';
-import { ocmClient } from '../../api';
+import { handleApiError, ocmClient } from '../../api';
 
 export const fetchClustersAsync = createAsyncThunk<Cluster[] | void>(
   'clusters/fetchClustersAsync',
@@ -13,7 +11,9 @@ export const fetchClustersAsync = createAsyncThunk<Cluster[] | void>(
       const isOcm = !!ocmClient;
       return data.filter((cluster) => (isOcm ? cluster.kind === 'Cluster' : true));
     } catch (e) {
-      handleApiError(e, () => Promise.reject('Failed to fetch clusters.'));
+      handleApiError(e, () => {
+        void Promise.reject('Failed to fetch clusters.');
+      });
     }
   },
 );


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-11571

Added back the Storage disk section in Host Discovery and Networking steps (so they are all the same).
Actions are NOT included (eg. selecting installation disks, etc is not part of this block).