### PR TITLE
Solving problems with cluster name validation

### DIFF
--- a/src/ocm/components/clusterWizard/ClusterDetailsForm.tsx
+++ b/src/ocm/components/clusterWizard/ClusterDetailsForm.tsx
@@ -10,6 +10,7 @@ import {
   ClusterWizardStepHeader,
   getClusterDetailsValidationSchema,
   InfraEnv,
+  getRichTextValidation,
 } from '../../../common';
 import { Grid, GridItem } from '@patternfly/react-core';
 import { canNextClusterDetails } from './wizardTransition';
@@ -103,7 +104,7 @@ const ClusterDetailsForm: React.FC<ClusterDetailsFormProps> = (props) => {
   return (
     <Formik
       initialValues={initialValues}
-      validationSchema={validationSchema}
+      validate={getRichTextValidation(validationSchema)}
       onSubmit={handleSubmit}
     >
       {({ submitForm, isSubmitting, isValid, dirty, setFieldValue, errors, touched }) => {


### PR DESCRIPTION
Putting back the RichTextValidation removed on 77dc5cbd574717c31c13809a029e31c5d1b30730 so that all validations of the cluster name are displayed