### PR TITLE
MGMT-11681 - Static IP flow - yaml form - "Add another mapping" should be renamed to "Add another MAC to interface name mapping"

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -361,7 +361,7 @@
   "ai:Location is a required field.": "Location is a required field.",
   "ai:LSO requirements": "LSO requirements",
   "ai:MAC has to be specified": "MAC has to be specified",
-  "ai:Mac to interface name mapping": "Mac to interface name mapping",
+  "ai:MAC to interface name mapping": "MAC to interface name mapping",
   "ai:Machine CIDR": "Machine CIDR",
   "ai:Machine CIDR conforms expected": "Machine CIDR conforms expected",
   "ai:Machine networks": "Machine networks",

--- a/src/cim/components/Agent/BMCForm.tsx
+++ b/src/cim/components/Agent/BMCForm.tsx
@@ -56,7 +56,7 @@ const MacMapping = () => {
   return (
     <FormGroup
       fieldId={fieldId}
-      label={t('ai:Mac to interface name mapping')}
+      label={t('ai:MAC to interface name mapping')}
       validated={isValid ? 'default' : 'error'}
     >
       <FieldArray

--- a/src/ocm/components/clusterConfiguration/staticIp/components/YamlView/MacIpMapping.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/components/YamlView/MacIpMapping.tsx
@@ -20,7 +20,7 @@ const AddMapping: React.FC<{
       data-testid="add-mapping"
       variant="link"
     >
-      Add another mapping
+      Add another MAC to interface name mapping
     </Button>
   );
 };

--- a/src/ocm/components/clusterConfiguration/staticIp/components/YamlView/YamlViewFields.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/components/YamlView/YamlViewFields.tsx
@@ -51,7 +51,7 @@ const ExpandedHost: React.FC<HostComponentProps> = ({ fieldName, hostIdx }) => {
         />
       </FormGroup>
       <FormGroup
-        label="Mac to interface name mapping"
+        label="MAC to interface name mapping"
         fieldId={getFieldId('macNicMaping', 'inputs')}
       >
         <MacIpMapping


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-11681

- "Add another mapping" → "Add another MAC to interface name mapping"
- "Mac to interface name mapping" → "MAC to interface name mapping"

**Before:**
![image](https://user-images.githubusercontent.com/87187179/187416796-ec6e3270-22bb-4175-9859-265eb13d417e.png)


**After:**
![image](https://user-images.githubusercontent.com/87187179/187416669-2d97e021-188b-47fe-b3bc-c211aebf9431.png)
