### PR TITLE
MGMT-11340 - Mass host rename - UI shows localhost4 as valid name

### DIFF
--- a/src/common/components/hosts/MassChangeHostnameModal.tsx
+++ b/src/common/components/hosts/MassChangeHostnameModal.tsx
@@ -31,11 +31,11 @@ import {
 import { Host } from '../../api';
 import { getHostname as getHostnameUtils, getInventory } from './utils';
 import { ActionCheck } from './types';
-import { getErrorMessage } from '../../utils';
 import { useTranslation } from '../../hooks/use-translation-wrapper';
 
 import './MassChangeHostnameModal.css';
 import { TFunction } from 'i18next';
+import { getApiErrorMessage } from '../../../ocm/api';
 
 const getHostname = (host: Host) => {
   const inventory = getInventory(host);
@@ -311,7 +311,7 @@ const MassChangeHostnameModal: React.FC<MassChangeHostnameModalProps> = ({
             formikActions.setStatus({
               error: {
                 title: t('ai:Failed to update host'),
-                message: getErrorMessage(e),
+                message: getApiErrorMessage(e),
               },
             });
           }

--- a/src/common/components/hosts/MassChangeHostnameModal.tsx
+++ b/src/common/components/hosts/MassChangeHostnameModal.tsx
@@ -81,6 +81,17 @@ const validationSchema = (
     hostname: richNameValidationSchema(t, usedHostnames, initialValues.hostname).required(),
   });
 
+const updateHostnameValidationResult = (
+  validationResult: { [key: string]: string[] } | undefined,
+  message: string,
+) => {
+  validationResult = {
+    ...(validationResult || {}),
+    hostname: (validationResult?.hostname || []).concat(message),
+  };
+  return validationResult;
+};
+
 const withTemplate =
   (
     selectedHosts: Host[],
@@ -110,21 +121,17 @@ const withTemplate =
       newHostnames.some((newHostname) => usedHostnames.includes(newHostname || '')) ||
       new Set(newHostnames).size !== newHostnames.length
     ) {
-      validationResult = {
-        ...(validationResult || {}),
-        hostname: (validationResult?.hostname || []).concat(
-          hostnameValidationMessages(t).NOT_UNIQUE,
-        ),
-      };
+      validationResult = updateHostnameValidationResult(
+        validationResult,
+        hostnameValidationMessages(t).NOT_UNIQUE,
+      );
     }
 
     if (newHostnames.some((hostname) => FORBIDDEN_HOSTNAMES.includes(hostname || ''))) {
-      validationResult = {
-        ...(validationResult || {}),
-        hostname: (validationResult?.hostname || []).concat(
-          hostnameValidationMessages(t).LOCALHOST_ERR,
-        ),
-      };
+      validationResult = updateHostnameValidationResult(
+        validationResult,
+        hostnameValidationMessages(t).LOCALHOST_ERR,
+      );
     }
 
     return validationResult;

--- a/src/common/components/hosts/MassChangeHostnameModal.tsx
+++ b/src/common/components/hosts/MassChangeHostnameModal.tsx
@@ -26,6 +26,7 @@ import {
   richNameValidationSchema,
   hostnameValidationMessages,
   ModalProgress,
+  FORBIDDEN_HOSTNAMES,
 } from '../ui';
 import { Host } from '../../api';
 import { getHostname as getHostnameUtils, getInventory } from './utils';
@@ -99,10 +100,12 @@ const withTemplate =
       }
       return acc;
     }, []);
+
     let validationResult = await getRichTextValidation(schema)({
       ...values,
       hostname: newHostnames[0] || '',
     });
+
     if (
       newHostnames.some((newHostname) => usedHostnames.includes(newHostname || '')) ||
       new Set(newHostnames).size !== newHostnames.length
@@ -114,6 +117,16 @@ const withTemplate =
         ),
       };
     }
+
+    if (newHostnames.some((hostname) => FORBIDDEN_HOSTNAMES.includes(hostname || ''))) {
+      validationResult = {
+        ...(validationResult || {}),
+        hostname: (validationResult?.hostname || []).concat(
+          hostnameValidationMessages(t).LOCALHOST_ERR,
+        ),
+      };
+    }
+
     return validationResult;
   };
 

--- a/src/common/components/ui/formik/constants.tsx
+++ b/src/common/components/ui/formik/constants.tsx
@@ -52,3 +52,12 @@ export const bmcAddressValidationMessages = (t: TFunction) => ({
     'ai:The Value is not valid BMC address, supported protocols are redfish-virtualmedia or idrac-virtualmedia.',
   ),
 });
+
+export const FORBIDDEN_HOSTNAMES = [
+  'localhost',
+  'localhost.localdomain',
+  'localhost4',
+  'localhost4.localdomain4',
+  'localhost6',
+  'localhost6.localdomain6',
+];

--- a/src/common/components/ui/formik/validationSchemas.ts
+++ b/src/common/components/ui/formik/validationSchemas.ts
@@ -12,6 +12,7 @@ import { getErrorMessage } from '../../../utils';
 import {
   bmcAddressValidationMessages,
   clusterNameValidationMessages,
+  FORBIDDEN_HOSTNAMES,
   hostnameValidationMessages,
   locationValidationMessages,
   nameValidationMessages,
@@ -372,17 +373,7 @@ export const richNameValidationSchema = (t: TFunction, usedNames: string[], orig
       }
       return !usedNames.find((n) => n === value);
     })
-    .notOneOf(
-      [
-        'localhost',
-        'localhost.localdomain',
-        'localhost4',
-        'localhost4.localdomain4',
-        'localhost6',
-        'localhost6.localdomain6',
-      ],
-      hostnameValidationMessages(t).LOCALHOST_ERR,
-    );
+    .notOneOf(FORBIDDEN_HOSTNAMES, hostnameValidationMessages(t).LOCALHOST_ERR);
 };
 
 const httpProxyValidationMessage = 'Provide a valid HTTP URL.';


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-11340

`localhost4` and `localhost6` are forbidden host names. The UI will show an error and prevent such name change.

**Before:**
![image](https://user-images.githubusercontent.com/87187179/187444192-e9f0f5c6-5186-430e-8655-085d01e61605.png)

**After:**
![image](https://user-images.githubusercontent.com/87187179/187443734-648576aa-378b-40f9-a098-4d125a7f07e8.png)
