### PR TITLE
MGMT-11537 - Mass host-name change helper text is not correct

### DIFF
--- a/src/common/components/hosts/MassChangeHostnameModal.tsx
+++ b/src/common/components/hosts/MassChangeHostnameModal.tsx
@@ -171,7 +171,9 @@ const MassChangeHostnameForm: React.FC<MassChangeHostnameFormProps> = ({
             />
             <HelperText>
               <HelperTextItem variant="indeterminate">
-                {t('ai:For example: host-{{n}}')}
+                {t('ai:For example: host-{{n}}', {
+                  interpolation: { suffix: '###', prefix: '###' },
+                })}
               </HelperTextItem>
             </HelperText>
           </StackItem>


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-11537

**Before:**
![image](https://user-images.githubusercontent.com/87187179/187452660-80a35ba3-fd61-4851-92b5-051b534f6084.png)

**After:**
![image](https://user-images.githubusercontent.com/87187179/187452745-6753e725-cd3b-43be-ac51-329011b3070b.png)
