### PR TITLE
MGMT-11814 Display FieldArray errors with getRichTextValidation

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "prepare": "install-peers",
     "test": "run-s test:circular lint format:check",
     "test:circular": "dpdm --warning false --tree false --exit-code circular:1 ./src/index.ts",
-    "lint": "eslint . --max-warnings=310 --color",
+    "lint": "eslint . --max-warnings=304 --color",
     "lint:fix": "yarn run lint --fix",
     "format": "prettier --write '**/*.{json,md,scss,yaml,yml}'",
     "format:check": "prettier --check '**/*.{json,md,scss,yaml,yml}'",

--- a/src/common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionControlGroup.tsx
+++ b/src/common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionControlGroup.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import isEqual from 'lodash/isEqual';
-import { FormGroup, Stack, StackItem } from '@patternfly/react-core';
+import { Alert, AlertVariant, FlexItem, FormGroup, Stack, StackItem } from '@patternfly/react-core';
 import SwitchField from '../../ui/formik/SwitchField';
 import { DiskEncryptionMode } from './DiskEncryptionMode';
 import { RenderIf } from '../../ui';
@@ -31,11 +31,11 @@ export interface DiskEncryptionControlGroupProps {
   isDisabled?: boolean;
 }
 
-const DiskEncryptionControlGroup: React.FC<DiskEncryptionControlGroupProps> = ({
+const DiskEncryptionControlGroup = ({
   values,
   isSNO = false,
-  isDisabled,
-}) => {
+  isDisabled = false,
+}: DiskEncryptionControlGroupProps) => {
   const {
     enableDiskEncryptionOnMasters,
     enableDiskEncryptionOnWorkers,
@@ -43,6 +43,7 @@ const DiskEncryptionControlGroup: React.FC<DiskEncryptionControlGroupProps> = ({
     diskEncryptionTangServers,
   } = values;
 
+  const hasEnabledDiskEncryption = enableDiskEncryptionOnMasters || enableDiskEncryptionOnWorkers;
   const { setFieldValue, setFieldTouched } = useFormikContext<ClusterDetailsValues>();
 
   React.useEffect(() => {
@@ -105,6 +106,28 @@ const DiskEncryptionControlGroup: React.FC<DiskEncryptionControlGroupProps> = ({
           </StackItem>
         </RenderIf>
       </Stack>
+      {hasEnabledDiskEncryption && (
+        <Alert
+          variant={AlertVariant.warning}
+          isInline
+          title={
+            <FlexItem>
+              {diskEncryptionMode === 'tpmv2' && (
+                <>
+                  To use this encryption method, enable TPMv2 encryption in the BIOS of each
+                  selected host.
+                </>
+              )}
+              {diskEncryptionMode === 'tang' && (
+                <>
+                  The use of Tang encryption mode to encrypt your disks is only supported for bare
+                  metal or vSphere installations on user-provisioned infrastructure.
+                </>
+              )}
+            </FlexItem>
+          }
+        />
+      )}
     </FormGroup>
   );
 };

--- a/src/common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionMode.tsx
+++ b/src/common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionMode.tsx
@@ -1,7 +1,4 @@
 import React from 'react';
-import { ENCRYPTING_DISK_DURING_INSTALLATION } from '../../../config/constants';
-import PopoverIcon from '../../ui/PopoverIcon';
-import { RadioField } from '../../ui/formik';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import {
   Flex,
@@ -12,11 +9,14 @@ import {
   TextVariants,
   TextContent,
 } from '@patternfly/react-core';
+import { ENCRYPTING_DISK_DURING_INSTALLATION } from '../../../config';
+import PopoverIcon from '../../ui/PopoverIcon';
+import { RadioField } from '../../ui/formik';
 import { TangServers } from './TangServers';
-import { DiskEncryption } from '../../../api/types';
+import { DiskEncryption } from '../../../api';
 import { useTranslation } from '../../../hooks/use-translation-wrapper';
 
-const DiskEncryptionModeTPMv2: React.FC = () => {
+const DiskEncryptionModeTPMv2 = () => {
   const { t } = useTranslation();
   return (
     <>
@@ -40,7 +40,7 @@ const DiskEncryptionModeTPMv2: React.FC = () => {
   );
 };
 
-const DiskEncryptionModeTang: React.FC = () => {
+const DiskEncryptionModeTang = () => {
   const { t } = useTranslation();
   return (
     <>
@@ -62,14 +62,11 @@ const DiskEncryptionModeTang: React.FC = () => {
 };
 
 export interface DiskEncryptionModeProps {
-  isDisabled?: boolean;
+  isDisabled: boolean;
   diskEncryptionMode: DiskEncryption['mode'];
 }
 
-export const DiskEncryptionMode: React.FC<DiskEncryptionModeProps> = ({
-  diskEncryptionMode,
-  isDisabled,
-}) => {
+export const DiskEncryptionMode = ({ diskEncryptionMode, isDisabled }: DiskEncryptionModeProps) => {
   const { t } = useTranslation();
   return (
     <Stack>

--- a/src/common/components/clusterConfiguration/DiskEncryptionFields/TangServers.tsx
+++ b/src/common/components/clusterConfiguration/DiskEncryptionFields/TangServers.tsx
@@ -1,46 +1,45 @@
 import React from 'react';
 import { FieldArray, useFormikContext } from 'formik';
-import { ClusterDetailsValues } from '../../clusterWizard/types';
 import { Stack, StackItem, TextInputTypes } from '@patternfly/react-core';
+import { ClusterDetailsValues } from '../../clusterWizard';
 import { InputField } from '../../ui';
 import { AddButton, RemovableField } from '../../ui/formik';
 import { useTranslation } from '../../../hooks/use-translation-wrapper';
 
-export const TangServers: React.FC<{ isDisabled?: boolean }> = ({ isDisabled = false }) => {
+export const TangServers = ({ isDisabled = false }: { isDisabled: boolean }) => {
   const { values } = useFormikContext<ClusterDetailsValues>();
   const { t } = useTranslation();
   return (
     <FieldArray name="diskEncryptionTangServers">
       {({ remove, push }) => (
         <Stack hasGutter>
-          {values.diskEncryptionTangServers.length > 0 &&
-            values.diskEncryptionTangServers.map((tang, index) => (
-              <StackItem key={index}>
-                <RemovableField
-                  hideRemoveButton={index === 0 || isDisabled}
-                  onRemove={() => remove(index)}
-                >
-                  <div>
-                    <InputField
-                      type={TextInputTypes.url}
-                      name={`diskEncryptionTangServers.${index}.url`}
-                      helperText={`Must start with "http://" or "https://". Optionally, end with ":<port>"`}
-                      label="Server URL"
-                      isRequired
-                      isDisabled={isDisabled}
-                    />
-                    &thinsp;
-                    <InputField
-                      type={TextInputTypes.text}
-                      name={`diskEncryptionTangServers.${index}.thumbprint`}
-                      label="Server Thumbprint"
-                      isRequired
-                      isDisabled={isDisabled}
-                    />
-                  </div>
-                </RemovableField>{' '}
-              </StackItem>
-            ))}
+          {values.diskEncryptionTangServers.map((tang, index) => (
+            <StackItem key={index}>
+              <RemovableField
+                hideRemoveButton={index === 0 || isDisabled}
+                onRemove={() => remove(index)}
+              >
+                <div>
+                  <InputField
+                    type={TextInputTypes.url}
+                    name={`diskEncryptionTangServers.${index}.url`}
+                    helperText={`Must start with "http://" or "https://". Optionally, end with ":<port>"`}
+                    label="Server URL"
+                    isRequired
+                    isDisabled={isDisabled}
+                  />
+                  &thinsp;
+                  <InputField
+                    type={TextInputTypes.text}
+                    name={`diskEncryptionTangServers.${index}.thumbprint`}
+                    label="Server Thumbprint"
+                    isRequired
+                    isDisabled={isDisabled}
+                  />
+                </div>
+              </RemovableField>{' '}
+            </StackItem>
+          ))}
 
           {!isDisabled && (
             <StackItem>

--- a/src/common/components/ui/formik/utils.ts
+++ b/src/common/components/ui/formik/utils.ts
@@ -1,8 +1,9 @@
 import { FormikErrors, FormikTouched } from 'formik';
 import * as Yup from 'yup';
+import { Address4 } from 'ip-address';
+import set from 'lodash/set';
 import { OpenshiftVersionOptionType } from '../../../types';
 import { ClusterNetwork, MachineNetwork, ServiceNetwork } from '../../../api';
-import { Address4 } from 'ip-address';
 
 export const getFieldId = (fieldName: string, fieldType: string, unique?: string) => {
   unique = unique ? `${unique}-` : '';
@@ -31,14 +32,6 @@ export const getFormikErrorFields = <FormikValues>(
 export const getDefaultOpenShiftVersion = (versions: OpenshiftVersionOptionType[]) =>
   versions.find((v) => v.default)?.value || versions[0]?.value || '';
 
-export const labelsToArray = (labels: { [key in string]: string } = {}): string[] => {
-  const result: string[] = [];
-  for (const key in labels) {
-    result.push(`${key}=${labels[key]}`);
-  }
-  return result;
-};
-
 // strValues: array of 'key=value' items
 export const parseStringLabels = (
   strValues: string[],
@@ -53,32 +46,57 @@ export const parseStringLabels = (
   return labels;
 };
 
-// Input: ['foo=bar', 'key=value', 'foo=blee']
-// Result: ['key=value', 'foo=blee']
-export const uniqueLabels = (labelPairs: string[]): string[] =>
-  labelsToArray(parseStringLabels(labelPairs));
+type innerError = { path: string; message: string };
+type innerErrors = { inner: innerError[] };
+type fieldErrors = { [key: string]: string[] };
 
-// Input: (['foo=bar', 'key=value'], ['foo', 'bar'])
-// Result: ['foo=bar']
-export const selectedLabelsOnly = (labelPairs: string[], allowedKeys: string[]) =>
-  labelPairs.filter((pair) => allowedKeys.includes(pair.split('=')[0]));
+const fieldErrorReducer = (errors: innerError[]): fieldErrors => {
+  return errors.reduce(
+    (memo, { path, message }) => ({
+      ...memo,
+      [path]: (memo[path] || []).concat(message), // eslint-disable-line
+    }),
+    {},
+  );
+};
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const getRichTextValidation =
   <T extends object>(schema: Yup.ObjectSchema<T> | Yup.Lazy) =>
-  async (values: T): Promise<{ [key: string]: string[] } | undefined> => {
+  async (values: T): Promise<fieldErrors | undefined> => {
     try {
       await schema.validate(values, {
         abortEarly: false,
       });
-    } catch ({ inner }) {
-      return (inner as { path: string; message: string }[]).reduce(
-        (memo, { path, message }) => ({
-          ...memo,
-          [path]: (memo[path] || []).concat(message),
-        }),
-        {},
-      );
+    } catch (e) {
+      const { inner } = e as innerErrors;
+      if (!inner || inner.length === 0) {
+        return {};
+      }
+
+      const baseFields: innerError[] = [];
+      const arraySubfields: innerError[] = [];
+
+      inner.forEach((item) => {
+        const isArraySubfield = /\.|\[/.test(item.path);
+        if (isArraySubfield) {
+          arraySubfields.push(item);
+        } else {
+          baseFields.push(item);
+        }
+      });
+
+      const fieldErrors = fieldErrorReducer(baseFields);
+      if (arraySubfields.length === 0) {
+        return fieldErrors;
+      }
+
+      // Now we need to convert the fieldArray errors to the parent object
+      // eg. items[0].thumbprint --> { items: [{ thumbprint: ['subField error'] }]}
+      const arrayErrors = {};
+      arraySubfields.forEach((field) => {
+        set(arrayErrors, field.path, [field.message]);
+      });
+      return { ...fieldErrors, ...arrayErrors };
     }
   };
 

--- a/src/common/components/ui/formik/utils.ts
+++ b/src/common/components/ui/formik/utils.ts
@@ -46,15 +46,15 @@ export const parseStringLabels = (
   return labels;
 };
 
-type innerError = { path: string; message: string };
-type innerErrors = { inner: innerError[] };
-type fieldErrors = { [key: string]: string[] };
+type InnerError = { path: string; message: string };
+type InnerErrors = { inner: InnerError[] };
+type FieldErrors = { [key: string]: string[] };
 
-const fieldErrorReducer = (errors: innerError[]): fieldErrors => {
-  return errors.reduce(
+const fieldErrorReducer = (errors: InnerError[]): FieldErrors => {
+  return errors.reduce<FieldErrors>(
     (memo, { path, message }) => ({
       ...memo,
-      [path]: (memo[path] || []).concat(message), // eslint-disable-line
+      [path]: (memo[path] || []).concat(message),
     }),
     {},
   );
@@ -62,19 +62,19 @@ const fieldErrorReducer = (errors: innerError[]): fieldErrors => {
 
 export const getRichTextValidation =
   <T extends object>(schema: Yup.ObjectSchema<T> | Yup.Lazy) =>
-  async (values: T): Promise<fieldErrors | undefined> => {
+  async (values: T): Promise<FieldErrors | undefined> => {
     try {
       await schema.validate(values, {
         abortEarly: false,
       });
     } catch (e) {
-      const { inner } = e as innerErrors;
+      const { inner } = e as InnerErrors;
       if (!inner || inner.length === 0) {
         return {};
       }
 
-      const baseFields: innerError[] = [];
-      const arraySubfields: innerError[] = [];
+      const baseFields: InnerError[] = [];
+      const arraySubfields: InnerError[] = [];
 
       inner.forEach((item) => {
         const isArraySubfield = /\.|\[/.test(item.path);

--- a/src/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
+++ b/src/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
@@ -71,11 +71,6 @@ export const OcmClusterDetailsFormFields = ({
   const { t } = useTranslation();
   return (
     <Form id="wizard-cluster-details__form">
-      <DiskEncryptionControlGroup
-        values={values}
-        isDisabled={isPullSecretSet}
-        isSNO={isSNO({ highAvailabilityMode })}
-      />
       <RichInputField
         ref={nameInputRef}
         label="Cluster name"
@@ -129,6 +124,11 @@ export const OcmClusterDetailsFormFields = ({
       {canEditPullSecret && <PullSecret isOcm={isOcm} defaultPullSecret={defaultPullSecret} />}
       <ArmCheckbox versions={versions} />
       <HostsNetworkConfigurationControlGroup clusterExists={clusterExists} />
+      <DiskEncryptionControlGroup
+        values={values}
+        isDisabled={isPullSecretSet}
+        isSNO={isSNO({ highAvailabilityMode })}
+      />
     </Form>
   );
 };


### PR DESCRIPTION
When using `validate={getRichTextValidation}` in a form, messages from FielArray were not displaying correctly. 
The problem is that `getRichTextValidation` generates an object where the paths are the individual fields, whereas `validate` is looking for the format of the parent field.

For example, for `diskEncryptionTangServers`, it needs the structure:

```
{diskEncryptionTangServers: [
{ url: 'Url error for Tang Server', thumbprint: 'Thumbprint error for Tang Server' }
]}
```
but it is seeing

`{ 'diskEncryptionTangServers[0].thumbprint': 'Some error}`

Now we are detecting the subfields and generating the needed format from the `diskEncryptionTangServers[0].thumbPrint` etc errors.

The PR also includes some clean-up of the Disk Encryption and other components.