### PR TITLE
MGMT-11962 Fix problems with polling

### DIFF
--- a/src/ocm/hooks/useInfraEnv.ts
+++ b/src/ocm/hooks/useInfraEnv.ts
@@ -25,6 +25,7 @@ export default function useInfraEnv(clusterId: Cluster['id']) {
       if (!infraEnvId) {
         throw 'updateInfraEnv should not be called before infra env was loaded';
       }
+      InfraEnvsAPI.abortLastGetRequest();
       const { data } = await InfraEnvsAPI.update(infraEnvId, infraEnvUpdateParams);
       setInfraEnv(data);
       return data;

--- a/src/ocm/services/ClustersService.ts
+++ b/src/ocm/services/ClustersService.ts
@@ -29,6 +29,7 @@ const ClustersService = {
     clusterTags: Cluster['tags'],
     params: V2ClusterUpdateParams,
   ) {
+    ClustersAPI.abortLastGetRequest();
     if (ocmClient) {
       params = ClustersService.updateClusterTags(clusterTags, params);
     }
@@ -58,6 +59,11 @@ const ClustersService = {
       params.tags = tags?.join(',');
     }
     return params;
+  },
+
+  async get(clusterId: Cluster['id']) {
+    const { data: cluster } = await ClustersAPI.get(clusterId);
+    return cluster;
   },
 };
 

--- a/src/ocm/services/DiscoveryImageFormService.ts
+++ b/src/ocm/services/DiscoveryImageFormService.ts
@@ -42,6 +42,7 @@ const DiscoveryImageFormService = {
       clusterTags,
       proxyParams,
     );
+    InfraEnvsAPI.abortLastGetRequest();
     const { data: updatedInfraEnv } = await InfraEnvsAPI.update(infraEnvId, infraEnvParams);
 
     return { updatedCluster, updatedInfraEnv };

--- a/src/ocm/services/HostsService.ts
+++ b/src/ocm/services/HostsService.ts
@@ -40,6 +40,7 @@ const HostsService = {
 
   async update(clusterId: Cluster['id'], hostId: Host['id'], params: HostUpdateParams) {
     const infraEnvId = await InfraEnvsService.getInfraEnvId(clusterId);
+    HostsAPI.abortLastGetRequest();
     return HostsAPI.update(infraEnvId, hostId, params);
   },
 


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-11962

We need to make sure our applications ( assisted-ui and uhc-portal) use a compatible axios version.
**PR for assisted-ui: https://github.com/openshift-assisted/assisted-ui/pull/605**
**PR for uhc-portal: https://gitlab.cee.redhat.com/service/uhc-portal/-/merge_requests/3586**

**Description of the problem**
-A continuous polling of the cluster is running: getting the cluster and the hosts. This polling does a cluster and hosts fetch which that can take a while
-If while this fetch is running, we do a PATCH in the middle with some hosts changes, this ends earlier than the previous GET request
-After that. if the previous polling ends, the page is updated with the old values
-And then the other polling of the cluster is executed again and everything is fine


https://user-images.githubusercontent.com/11390125/189119185-e28e0610-5ac4-4b70-866e-8f301d6f9e4c.mp4


**Solution**
When creating a cluster/hosts poll request pass the abortcontroller to the service, store the abortcontroller in the service and add the signal to the polling get request. When a service calls any update function which internally calls PATCH/PUT, do PollingAbortController.abort().