### PR TITLE
MGMT-11858 Avoid separate requests when toggling DHCP

### DIFF
--- a/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
@@ -103,9 +103,7 @@ const NetworkConfigurationForm: React.FC<{
   );
 };
 
-const NetworkConfigurationPage: React.FC<{
-  cluster: Cluster;
-}> = ({ cluster }) => {
+const NetworkConfigurationPage = ({ cluster }: { cluster: Cluster }) => {
   const { infraEnv, error: infraEnvError, isLoading } = useInfraEnv(cluster.id);
   const defaultNetworkValues = useDefaultConfiguration([
     'clusterNetworksDualstack',

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/VirtualIPControlGroup.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/VirtualIPControlGroup.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import { useFormikContext } from 'formik';
 import { Spinner, Alert, AlertVariant, Tooltip } from '@patternfly/react-core';
-import { Cluster } from '../../../../common/api/types';
-import { stringToJSON } from '../../../../common/api/utils';
-import { NetworkConfigurationValues, ValidationsInfo } from '../../../../common/types';
-import { CheckboxField, FormikStaticField, InputField } from '../../../../common/components/ui';
+import {
+  Cluster,
+  NetworkConfigurationValues,
+  ValidationsInfo,
+  NETWORK_TYPE_SDN,
+  selectMachineNetworkCIDR,
+  stringToJSON,
+} from '../../../../common';
 import { FeatureSupportLevelBadge } from '../../../../common/components';
-import { NETWORK_TYPE_SDN } from '../../../../common/config/constants';
-import { selectMachineNetworkCIDR } from '../../../../common';
+import { CheckboxField, FormikStaticField, InputField } from '../../../../common/components/ui';
 
 interface VipStaticValueProps {
   vipName: string;
@@ -116,10 +119,20 @@ export const VirtualIPControlGroup = ({
     }
   }, [enableAllocation, setFieldValue]);
 
+  const onChangeDhcp = React.useCallback(
+    (hasDhcp: boolean) => {
+      // We need to sync the values back to the form
+      setFieldValue('apiVip', hasDhcp ? '' : cluster.apiVip);
+      setFieldValue('ingressVip', hasDhcp ? '' : cluster.ingressVip);
+    },
+    [cluster.apiVip, cluster.ingressVip, setFieldValue],
+  );
+
   return (
     <>
       {!isVipDhcpAllocationDisabled && (
         <CheckboxField
+          onChange={onChangeDhcp}
           label={
             <>
               <Tooltip
@@ -146,7 +159,7 @@ export const VirtualIPControlGroup = ({
             label="API IP"
             name="apiVip"
             helperText={apiVipHelperText}
-            value={cluster.apiVip || ''}
+            value={values.apiVip || ''}
             isValid={!apiVipFailedValidationMessage}
             isRequired
           >
@@ -160,7 +173,7 @@ export const VirtualIPControlGroup = ({
             label="Ingress IP"
             name="ingressVip"
             helperText={ingressVipHelperText}
-            value={cluster.ingressVip || ''}
+            value={values.ingressVip || ''}
             isValid={!ingressVipFailedValidationMessage}
             isRequired
           >


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-11858

When users switched DHCP on or off, the cluster and form were out of sync and this triggered unnecessary PATCH requests.

In particular, switching to DHCP `on` made three separate PATCH requests:
1. PATCH to set DHCP  `on`
2. PATCH to unset `apiVip` and `ingressVip`
3. PATCH to set `apiVip` and `ingressVip`. This request is completely unnecessary, because it was patching back the `cluster` with the values it received in the previous polling. But the form was out of sync with the cluster, and that's why the PATCH was being sent.

Now, when the user switches DHCP on / off we make sure to sync the form values at once, so only 1 PATCH request will be triggered. This avoids issues, since all requests send a few of the networking fields.