### PR TITLE
MGMT-11710 - "We lost that page" displays when BE is unavailable

### DIFF
--- a/src/ocm/components/clusters/ClusterPage.tsx
+++ b/src/ocm/components/clusters/ClusterPage.tsx
@@ -180,7 +180,11 @@ const ClusterPage: React.FC<RouteComponentProps<MatchParams>> = ({ match }) => {
     );
   }
 
-  return <Redirect to="/clusters" />;
+  return (
+    <PageSection variant={PageSectionVariants.light} isFilled>
+      <ErrorState fetchData={fetchCluster} actions={errorStateActions} />
+    </PageSection>
+  );
 };
 
 export default ClusterPage;


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-11710

No redirect will happen and a generic error will be shown.

https://user-images.githubusercontent.com/87187179/189924125-07c643b7-4043-48a7-9a88-3aadb9c7d8f3.mp4
