### PR TITLE
Bug 2118545: Hosts in added-to-existing-cluster are considered installed

### DIFF
--- a/src/common/components/clusterDetail/ProgressBarTexts.tsx
+++ b/src/common/components/clusterDetail/ProgressBarTexts.tsx
@@ -36,7 +36,7 @@ export const ProgressBarTexts = ({ hosts, hostRole }: HostProgressProps) => {
     );
   }
 
-  if (hosts.every((host) => host.status === 'installed')) {
+  if (hosts.every((host) => ['installed', 'added-to-existing-cluster'].includes(host.status))) {
     return (
       <ClusterProgressItem icon={<CheckCircleIcon color={okColor.value} />}>
         <>


### PR DESCRIPTION
WHen a host is added to a cluster after the cluster is installed, it's final state is not installed but 'added-to-existing-cluster'. This change ensures that such hosts are not considered 'in progress' in ClusterProgressItems

Fixes BZ2118545