### PR TITLE
MGMT-11643: Problems with validations in Vlan ID field in a cluster with static IP and vlan configuration

### DIFF
--- a/src/ocm/components/clusterConfiguration/staticIp/components/FormViewNetworkWide/FormViewNetworkWideFields.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/components/FormViewNetworkWide/FormViewNetworkWideFields.tsx
@@ -207,7 +207,6 @@ export const FormViewNetworkWideFields: React.FC<{ hosts: FormViewHost[] }> = ({
             name="vlanId"
             isRequired
             data-testid="vlan-id"
-            type={TextInputTypes.number}
             min={MIN_VLAN_ID}
             max={MAX_VLAN_ID}
           />

--- a/src/ocm/components/clusterConfiguration/staticIp/components/FormViewNetworkWide/formViewNetworkWideValidationSchema.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/components/FormViewNetworkWide/formViewNetworkWideValidationSchema.tsx
@@ -12,7 +12,7 @@ import {
   getIpIsNotNetworkOrBroadcastAddressSchema,
 } from '../../commonValidationSchemas';
 const REQUIRED_MESSAGE = 'A value is required';
-const REQUIRED_MESSAGE_AND_MUST_BE_A_NUMBER = 'A value is required and must be a number';
+const REQUIRED_MESSAGE_AND_MUST_BE_A_NUMBER = 'Must be a number';
 
 export const MIN_PREFIX_LENGTH = 1;
 export const MAX_PREFIX_LENGTH = {

--- a/src/ocm/components/clusterConfiguration/staticIp/components/FormViewNetworkWide/formViewNetworkWideValidationSchema.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/components/FormViewNetworkWide/formViewNetworkWideValidationSchema.tsx
@@ -14,8 +14,7 @@ import {
 
 const REQUIRED_MESSAGE = 'A value is required';
 const MUST_BE_A_NUMBER = 'Must be a number';
-const NUMBER_REGEX = /^[0-9]*$/;
-const NUMBER_EXPONENTIAL = /[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)/;
+const ONLY_DIGITS_REGEX = /^\d+$/;
 
 export const MIN_PREFIX_LENGTH = 1;
 export const MAX_PREFIX_LENGTH = {
@@ -96,9 +95,7 @@ export const networkWideValidationSchema = Yup.lazy<FormViewNetworkWideValues>(
           .required(MUST_BE_A_NUMBER)
           .min(1, `Must be more than or equal to 1`)
           .max(MAX_VLAN_ID, `Must be less than or equal to ${MAX_VLAN_ID}`)
-          .test('not-number', MUST_BE_A_NUMBER, (value) =>
-            validateNumber(value as number, values.vlanId),
-          )
+          .test('not-number', MUST_BE_A_NUMBER, () => validateNumber(values.vlanId))
           .nullable()
           .transform(transformNumber) as Yup.NumberSchema,
       }),
@@ -109,11 +106,7 @@ export const networkWideValidationSchema = Yup.lazy<FormViewNetworkWideValues>(
   },
 );
 
-export const validateNumber = (value: number, vlanId: number | '') => {
+export const validateNumber = (vlanId: FormViewNetworkWideValues['vlanId']) => {
   //We need to validate that value is a number(without letters) and is not an exponential number (ex: 1e2)
-  return (
-    value !== null &&
-    new RegExp(NUMBER_REGEX).test(value.toString()) &&
-    !new RegExp(NUMBER_EXPONENTIAL).test(vlanId.toString())
-  );
+  return new RegExp(ONLY_DIGITS_REGEX).test((vlanId || '').toString());
 };

--- a/src/ocm/components/clusterConfiguration/staticIp/components/FormViewNetworkWide/formViewNetworkWideValidationSchema.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/components/FormViewNetworkWide/formViewNetworkWideValidationSchema.tsx
@@ -12,6 +12,7 @@ import {
   getIpIsNotNetworkOrBroadcastAddressSchema,
 } from '../../commonValidationSchemas';
 const REQUIRED_MESSAGE = 'A value is required';
+const REQUIRED_MESSAGE_AND_MUST_BE_A_NUMBER = 'A value is required and must be a number';
 
 export const MIN_PREFIX_LENGTH = 1;
 export const MAX_PREFIX_LENGTH = {
@@ -89,11 +90,11 @@ export const networkWideValidationSchema = Yup.lazy<FormViewNetworkWideValues>(
       vlanId: Yup.mixed().when('useVlan', {
         is: true,
         then: Yup.number()
-          .required(REQUIRED_MESSAGE)
+          .required(REQUIRED_MESSAGE_AND_MUST_BE_A_NUMBER)
           .min(1, `Must be more than or equal to 1`)
           .max(MAX_VLAN_ID, `Must be less than or equal to ${MAX_VLAN_ID}`)
           .nullable()
-          .transform(transformNumber),
+          .transform(transformNumber) as Yup.NumberSchema,
       }),
       protocolType: Yup.string(),
       dns: getIPValidationSchema('ipv4'),

--- a/src/ocm/components/clusterConfiguration/staticIp/data/emptyData.ts
+++ b/src/ocm/components/clusterConfiguration/staticIp/data/emptyData.ts
@@ -24,7 +24,6 @@ export const getEmptyFormViewHost = (): FormViewHost => {
 
 export const getEmptyIpConfig = (): IpConfig => {
   return {
-    dns: '',
     machineNetwork: {
       ip: '',
       prefixLength: '',
@@ -49,6 +48,7 @@ export const getEmptyNetworkWideConfigurations = (): FormViewNetworkWideValues =
     protocolType: 'ipv4',
     useVlan: false,
     vlanId: '',
+    dns: '',
   };
 };
 

--- a/src/ocm/components/clusterConfiguration/staticIp/data/formDataToInfraEnvField.ts
+++ b/src/ocm/components/clusterConfiguration/staticIp/data/formDataToInfraEnvField.ts
@@ -183,5 +183,7 @@ export const networkWideToInfraEnvField = (
   }
   const currentFormData = formDataFromInfraEnvField(staticNetworkConfig);
   fixHostIps(networkWide, currentFormData.hosts);
+  //Transform vlanId to number
+  networkWide.vlanId !== '' ? (networkWide.vlanId = Number(networkWide.vlanId)) : '';
   return formDataToInfraEnvField({ networkWide, hosts: currentFormData.hosts });
 };

--- a/src/ocm/components/clusterConfiguration/staticIp/data/formDataToInfraEnvField.ts
+++ b/src/ocm/components/clusterConfiguration/staticIp/data/formDataToInfraEnvField.ts
@@ -184,6 +184,8 @@ export const networkWideToInfraEnvField = (
   const currentFormData = formDataFromInfraEnvField(staticNetworkConfig);
   fixHostIps(networkWide, currentFormData.hosts);
   //Transform vlanId to number
-  networkWide.vlanId !== '' ? (networkWide.vlanId = Number(networkWide.vlanId)) : '';
+  if (networkWide.vlanId !== '') {
+    networkWide.vlanId = Number(networkWide.vlanId);
+  }
   return formDataToInfraEnvField({ networkWide, hosts: currentFormData.hosts });
 };


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-11643

In a cluster with static IP and vlan, tried to use letters and underscore for VLAN ID value - no validation is running.

The problem is the InputField with type="Number" that is  not working well in Firefox (accepting letters) and in Chrome is not working in some cases (accepting some letters like 'e').

I've changed the field type and add a message to be more clear.

1. Validation that value is not string
![image](https://user-images.githubusercontent.com/11390125/190345153-3dcd50ce-53ce-499e-ad33-c52caf37a592.png)

2. Validation that value is a number >= 1
![image](https://user-images.githubusercontent.com/11390125/190326306-c56614fb-2c19-4c1a-a25f-137ac3ccbe77.png)

3. Validation that value is a number <= 4094
![image](https://user-images.githubusercontent.com/11390125/190326347-d0320cae-656b-47fc-a1f6-e320a3db6045.png)

