### PR TITLE
[2.6-cim] Bug 2126047 Use host/bmh status to determine infra env hosts tab warning

### DIFF
--- a/src/cim/components/InfraEnv/InfraEnvHostsTabAgentsWarning.tsx
+++ b/src/cim/components/InfraEnv/InfraEnvHostsTabAgentsWarning.tsx
@@ -1,28 +1,54 @@
 import * as React from 'react';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens';
-import { getFailingAgentConditions } from '../helpers';
-import { AgentK8sResource } from '../../types';
+import { getAgentStatus, getBMHStatus } from '../helpers';
+import { AgentK8sResource, BareMetalHostK8sResource } from '../../types';
+import { AGENT_BMH_NAME_LABEL_KEY } from '../common';
 
 export type InfraEnvHostsTabAgentsWarning = {
   infraAgents: AgentK8sResource[];
+  infraBMHs: BareMetalHostK8sResource[];
 };
 
 const InfraEnvHostsTabAgentsWarning: React.FC<InfraEnvHostsTabAgentsWarning> = ({
   infraAgents,
+  infraBMHs,
 }) => {
-  const faiingAgentConditions = getFailingAgentConditions(infraAgents);
-  const failingAgentNames = Object.getOwnPropertyNames(faiingAgentConditions);
-  if (!failingAgentNames.length) {
-    return null;
-  }
+  const agentsBMHNames = infraAgents.reduce<string[]>((names, agent) => {
+    const name = agent.metadata?.labels?.[AGENT_BMH_NAME_LABEL_KEY];
+    name && names.push(name);
+    return names;
+  }, []);
 
-  return (
-    <ExclamationTriangleIcon
-      color={warningColor.value}
-      className="infra-env-hosts-tab-title__icon"
-    />
+  const bmhsWithoutAgents = infraBMHs.filter((bmh) =>
+    agentsBMHNames.includes(bmh.metadata?.name || ''),
   );
+
+  const agentStates = infraAgents.map((agent) => getAgentStatus(agent, true).status);
+  const bmhStates = bmhsWithoutAgents.map((bmh) => getBMHStatus(bmh).state);
+
+  const hostStates = [...agentStates, ...bmhStates];
+
+  const problemStates = [
+    'bmh-error',
+    'preparing-failed',
+    'disconnected-unbound',
+    'disconnected',
+    'insufficient-unbound',
+    'insufficient',
+    'cancelled',
+    'error',
+  ];
+
+  if (hostStates.some(({ key }) => problemStates.includes(key))) {
+    return (
+      <ExclamationTriangleIcon
+        color={warningColor.value}
+        className="infra-env-hosts-tab-title__icon"
+      />
+    );
+  }
+  return null;
 };
 
 export default InfraEnvHostsTabAgentsWarning;


### PR DESCRIPTION
Fixes BZ2126047
Cherry-picked from 429b63bb