### PR TITLE
Fix: typo in VIP Control Group 

### DIFF
--- a/src/ocm/components/clusterConfiguration/networkConfiguration/VirtualIPControlGroup.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/VirtualIPControlGroup.tsx
@@ -26,7 +26,7 @@ const VipStaticValue = ({ vipName, cluster, validationErrorMessage }: VipStaticV
   const machineNetworkCidr = selectMachineNetworkCIDR(cluster);
 
   if (vipDhcpAllocation && cluster[vipName]) {
-    return <>cluster[vipName]</>;
+    return <>{cluster[vipName]}</>;
   }
   if (vipDhcpAllocation && validationErrorMessage) {
     return (


### PR DESCRIPTION
Fixing a typo, we were displaying this instead of the actual values:

![image](https://user-images.githubusercontent.com/87187179/191254896-3c1abe4b-4350-4246-b6ba-73f72828b349.png)
