### PR TITLE
MGMT-12094: Remove unnecessary calls to the get hosts api

### DIFF
--- a/src/ocm/reducers/clusters/currentClusterSlice.ts
+++ b/src/ocm/reducers/clusters/currentClusterSlice.ts
@@ -4,7 +4,7 @@ import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
 import { AssistedInstallerPermissionTypesListType, Cluster, Host } from '../../../common';
 import { handleApiError } from '../../api/utils';
 import { ResourceUIState } from '../../../common';
-import { ClustersService, HostsService } from '../../services';
+import { ClustersService } from '../../services';
 import { isApiError } from '../../api/types';
 
 export type RetrievalErrorType = {
@@ -28,8 +28,6 @@ export const fetchClusterAsync = createAsyncThunk<
 >('currentCluster/fetchClusterAsync', async (clusterId, { rejectWithValue }) => {
   try {
     const cluster = await ClustersService.get(clusterId);
-    const hosts = await HostsService.listHostsBoundToCluster(clusterId);
-    Object.assign(cluster, { hosts: hosts });
     return cluster;
   } catch (e) {
     handleApiError(e, () => {

--- a/src/ocm/services/Day2ClusterService.ts
+++ b/src/ocm/services/Day2ClusterService.ts
@@ -1,7 +1,7 @@
 import { InfraEnvsService } from '.';
 import { Cluster } from '../../common/api/types';
 import { OcmClusterType } from '../components/AddHosts/types';
-import { ClustersAPI, HostsAPI } from './apis';
+import { ClustersAPI } from './apis';
 
 const Day2ClusterService = {
   getOpenshiftClusterId(ocmCluster?: OcmClusterType) {
@@ -36,7 +36,6 @@ const Day2ClusterService = {
 
     if (day2Clusters.length !== 0) {
       const { data } = await ClustersAPI.get(day2Clusters[0].id);
-      data.hosts = await Day2ClusterService.fetchHosts(data.id);
       return data;
     } else {
       return Day2ClusterService.createCluster(
@@ -51,7 +50,6 @@ const Day2ClusterService = {
 
   async fetchClusterById(clusterId: Cluster['id']) {
     const { data } = await ClustersAPI.get(clusterId);
-    data.hosts = await Day2ClusterService.fetchHosts(data.id);
     return data;
   },
 
@@ -76,13 +74,6 @@ const Day2ClusterService = {
       openshiftVersion,
     });
 
-    data.hosts = await Day2ClusterService.fetchHosts(data.id);
-    return data;
-  },
-
-  async fetchHosts(clusterId: Cluster['id']) {
-    const infraEnvId = await InfraEnvsService.getInfraEnvId(clusterId);
-    const { data } = await HostsAPI.list(infraEnvId);
     return data;
   },
 };

--- a/src/ocm/services/HostsService.ts
+++ b/src/ocm/services/HostsService.ts
@@ -1,7 +1,7 @@
 import { canInstallHost, Cluster, Disk, DiskRole, Host, HostUpdateParams } from '../../common';
 import { AxiosError, AxiosPromise } from 'axios';
 import InfraEnvsService from './InfraEnvsService';
-import { HostsAPI } from '../services/apis';
+import { ClustersAPI, HostsAPI } from '../services/apis';
 import { APIErrorMixin } from '../api/types';
 
 const HostsService = {
@@ -40,7 +40,7 @@ const HostsService = {
 
   async update(clusterId: Cluster['id'], hostId: Host['id'], params: HostUpdateParams) {
     const infraEnvId = await InfraEnvsService.getInfraEnvId(clusterId);
-    HostsAPI.abortLastGetRequest();
+    ClustersAPI.abortLastGetRequest();
     return HostsAPI.update(infraEnvId, hostId, params);
   },
 


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-12094

We are running 2 api calls all the time: get cluster and list hosts (polling)
Both are returning hosts. We don't need to use the 2 api calls. 
Get clusters API returns the host's clusters list in the response.

![image](https://user-images.githubusercontent.com/11390125/191664914-5c08d1a4-9a54-4425-b628-6e7d39699728.png)
