### PR TITLE
MGMT-11548: Add inline info message for Static IP view chooser

### DIFF
--- a/src/ocm/components/clusterConfiguration/staticIp/components/StaticIpViewRadioGroup.tsx
+++ b/src/ocm/components/clusterConfiguration/staticIp/components/StaticIpViewRadioGroup.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ButtonVariant, Form, FormGroup } from '@patternfly/react-core';
+import { Alert, AlertVariant, ButtonVariant, Form, FormGroup } from '@patternfly/react-core';
 import { StaticIpView } from '../data/dataTypes';
 import { getFieldId } from '../../../../../common';
 import ConfirmationModal from '../../../../../common/components/ui/ConfirmationModal';
@@ -43,6 +43,8 @@ const StaticIpViewRadioGroup = ({
     return view === StaticIpView.YAML ? 'YAML' : 'form';
   };
 
+  const isFormViewSelected = view === StaticIpView.FORM;
+
   return (
     <>
       <Form isHorizontal>
@@ -58,7 +60,7 @@ const StaticIpViewRadioGroup = ({
             data-testid="select-form-view"
             id="select-form-view"
             value={StaticIpView.FORM}
-            isChecked={view === StaticIpView.FORM}
+            isChecked={isFormViewSelected}
             onChange={handleChange}
           />
           <OcmRadio
@@ -67,11 +69,20 @@ const StaticIpViewRadioGroup = ({
             data-testid="select-yaml-view"
             id="select-yaml-view"
             value={StaticIpView.YAML}
-            isChecked={view === StaticIpView.YAML}
+            isChecked={!isFormViewSelected}
             onChange={handleChange}
           />
         </FormGroup>
       </Form>
+      {isFormViewSelected && (
+        <Alert
+          variant={AlertVariant.info}
+          isInline
+          title={
+            'Form view supports basic configurations. Select YAML view for advanced configurations.'
+          }
+        />
+      )}
       {confirmView && (
         <ConfirmationModal
           title={'Change configuration option?'}


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-11548

Added a message for the configuration method in Static IP. It is displayed in both subpages of the Form View (Network-wide and Host specific configurations)
![form-view-message](https://user-images.githubusercontent.com/829045/192507095-25228c06-6e69-449f-ae8b-a0b62c04fcd4.png)

