### PR TITLE
MGMT-11294 default network type on creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "prepare": "install-peers",
     "test": "run-s test:circular lint format:check",
     "test:circular": "dpdm --warning false --tree false --exit-code circular:1 ./src/index.ts",
-    "lint": "eslint . --max-warnings=284 --color",
+    "lint": "eslint . --max-warnings=283 --color",
     "lint:fix": "yarn run lint --fix",
     "format": "prettier --write '**/*.{json,md,scss,yaml,yml}'",
     "format:check": "prettier --check '**/*.{json,md,scss,yaml,yml}'",

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/AdvancedNetworkFields.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/AdvancedNetworkFields.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
 import {
   Alert,
   AlertVariant,
@@ -9,19 +8,8 @@ import {
   Grid,
 } from '@patternfly/react-core';
 import { FieldArray, useFormikContext } from 'formik';
-import {
-  DUAL_STACK,
-  PREFIX_MAX_RESTRICTION,
-  useFeature,
-  NetworkConfigurationValues,
-} from '../../../../common';
-import { NetworkTypeControlGroup } from '../../../../common/components/clusterWizard/networkingSteps/NetworkTypeControlGroup';
-import { selectCurrentClusterPermissionsState } from '../../../selectors';
+import { DUAL_STACK, PREFIX_MAX_RESTRICTION, NetworkConfigurationValues } from '../../../../common';
 import { OcmInputField } from '../../ui/OcmFormFields';
-
-type AdvancedNetworkFieldsProps = {
-  isSDNSelectable: boolean;
-};
 
 const getNetworkLabelSuffix = (index: number, isDualStack: boolean) => {
   return isDualStack ? ` (${index === 0 ? 'IPv4' : 'IPv6'})` : '';
@@ -39,13 +27,8 @@ const clusterCidrHelperText =
 const serviceCidrHelperText =
   'The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.';
 
-const AdvancedNetworkFields = ({ isSDNSelectable }: AdvancedNetworkFieldsProps) => {
+const AdvancedNetworkFields = () => {
   const { setFieldValue, values, errors } = useFormikContext<NetworkConfigurationValues>();
-  const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
-
-  const isNetworkTypeSelectionEnabled = useFeature(
-    'ASSISTED_INSTALLER_NETWORK_TYPE_SELECTION_FEATURE',
-  );
 
   const isDualStack = values.stackType === DUAL_STACK;
 
@@ -131,10 +114,6 @@ const AdvancedNetworkFields = ({ isSDNSelectable }: AdvancedNetworkFieldsProps) 
 
       {typeof errors.serviceNetworks === 'string' && (
         <Alert variant={AlertVariant.warning} title={errors.serviceNetworks} isInline />
-      )}
-
-      {isNetworkTypeSelectionEnabled && (
-        <NetworkTypeControlGroup isDisabled={isViewerMode} isSDNSelectable={isSDNSelectable} />
       )}
     </Grid>
   );

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
@@ -237,7 +237,6 @@ const NetworkConfiguration = ({
         <StackTypeControlGroup
           clusterId={cluster.id}
           isDualStackSelectable={isDualStackSelectable}
-          isSNO={isSNOCluster}
           hostSubnets={hostSubnets}
         />
       )}

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from 'react';
+import React from 'react';
 import { useFormikContext } from 'formik';
 import { useSelector } from 'react-redux';
 import { Alert, AlertVariant, Grid, Tooltip } from '@patternfly/react-core';
@@ -14,7 +14,6 @@ import {
   isSNO,
   canBeDualStack,
   canSelectNetworkTypeSDN,
-  getDefaultNetworkType,
   clusterNetworksEqual,
   DUAL_STACK,
   serviceNetworksEqual,
@@ -30,6 +29,7 @@ import AdvancedNetworkFields from './AdvancedNetworkFields';
 import { useTranslation } from '../../../../common/hooks/use-translation-wrapper';
 import { selectCurrentClusterPermissionsState } from '../../../selectors';
 import { OcmCheckbox } from '../../ui/OcmFormFields';
+import { NetworkTypeControlGroup } from '../../../../common/components/clusterWizard/networkingSteps/NetworkTypeControlGroup';
 
 export type NetworkConfigurationProps = VirtualIPControlGroupProps & {
   hostSubnets: HostSubnets;
@@ -58,11 +58,8 @@ const vmsAlert = (
 const isAdvNetworkConf = (
   cluster: Cluster,
   defaultNetworkValues: Pick<ClusterDefaultConfig, 'clusterNetworksIpv4' | 'serviceNetworksIpv4'>,
-  defaultNetworkType: string,
 ) =>
   !(
-    !!cluster.networkType &&
-    cluster.networkType === defaultNetworkType &&
     serviceNetworksEqual(
       cluster.serviceNetworks || [],
       defaultNetworkValues.serviceNetworksIpv4 || [],
@@ -122,8 +119,7 @@ const NetworkConfiguration = ({
   isVipDhcpAllocationDisabled,
   defaultNetworkSettings,
   hideManagedNetworking,
-  children,
-}: PropsWithChildren<NetworkConfigurationProps>) => {
+}: NetworkConfigurationProps) => {
   const { t } = useTranslation();
   const featureSupportLevelData = useFeatureSupportLevel();
   const { setFieldValue, values, validateField } = useFormikContext<NetworkConfigurationValues>();
@@ -139,15 +135,12 @@ const NetworkConfiguration = ({
   const shouldUpdateAdvConf = !isViewerMode && isDualStack && !isUserManagedNetworking;
   const isDualStackSelectable = React.useMemo(() => canBeDualStack(hostSubnets), [hostSubnets]);
 
-  const { defaultNetworkType, isSDNSelectable } = React.useMemo(() => {
-    return {
-      defaultNetworkType: getDefaultNetworkType(isSNOCluster, isDualStack),
-      isSDNSelectable: canSelectNetworkTypeSDN(isSNOCluster, isDualStack),
-    };
+  const isSDNSelectable = React.useMemo(() => {
+    return canSelectNetworkTypeSDN(isSNOCluster, isDualStack);
   }, [isSNOCluster, isDualStack]);
 
   const [isAdvanced, setAdvanced] = React.useState(
-    isDualStack || isAdvNetworkConf(cluster, defaultNetworkSettings, defaultNetworkType),
+    isDualStack || isAdvNetworkConf(cluster, defaultNetworkSettings),
   );
 
   React.useEffect(() => {
@@ -193,13 +186,11 @@ const NetworkConfiguration = ({
             : defaultNetworkSettings.serviceNetworksIpv4,
           true,
         );
-        setFieldValue('networkType', getDefaultNetworkType(isSNOCluster, isDualStack));
       }
     },
     [
       setFieldValue,
       isDualStack,
-      isSNOCluster,
       defaultNetworkSettings.clusterNetworksDualstack,
       defaultNetworkSettings.clusterNetworksIpv4,
       defaultNetworkSettings.serviceNetworksDualstack,
@@ -237,8 +228,6 @@ const NetworkConfiguration = ({
         <UserManagedNetworkingTextContent shouldDisplayLoadBalancersBullet={isMultiNodeCluster} />
       )}
 
-      {children}
-
       {!isUserManagedNetworking &&
         !!clusterFeatureSupportLevels &&
         clusterFeatureSupportLevels['CLUSTER_MANAGED_NETWORKING_WITH_VMS'] === 'unsupported' &&
@@ -252,6 +241,7 @@ const NetworkConfiguration = ({
           hostSubnets={hostSubnets}
         />
       )}
+      <NetworkTypeControlGroup isDisabled={isViewerMode} isSDNSelectable={isSDNSelectable} />
 
       {!(isUserManagedNetworking && isMultiNodeCluster) && (
         <AvailableSubnetsControl
@@ -283,7 +273,7 @@ const NetworkConfiguration = ({
         />
       </Tooltip>
 
-      {isAdvanced && <AdvancedNetworkFields isSDNSelectable={isSDNSelectable} />}
+      {isAdvanced && <AdvancedNetworkFields />}
     </Grid>
   );
 };

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/StackTypeControl.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/StackTypeControl.tsx
@@ -8,14 +8,16 @@ import {
   HostSubnets,
   NetworkConfigurationValues,
   getFieldId,
-  getDefaultNetworkType,
   DUAL_STACK,
   IPV4_STACK,
+  NETWORK_TYPE_OVN,
+  NETWORK_TYPE_SDN,
   NO_SUBNET_SET,
   Cluster,
   ClusterNetwork,
   MachineNetwork,
   ServiceNetwork,
+  canSelectNetworkTypeSDN,
 } from '../../../../common';
 import { ConfirmationModal, PopoverIcon } from '../../../../common/components/ui';
 import { useDefaultConfiguration } from '../ClusterDefaultConfigurationContext';
@@ -66,7 +68,6 @@ export const StackTypeControlGroup = ({
 
   const setSingleStack = React.useCallback(() => {
     setFieldValue('stackType', IPV4_STACK);
-    setFieldValue('networkType', getDefaultNetworkType(isSNO, false));
 
     if (values.machineNetworks && values.machineNetworks?.length >= 2) {
       setFieldValue('machineNetworks', values.machineNetworks.slice(0, 1));
@@ -80,7 +81,6 @@ export const StackTypeControlGroup = ({
 
     void validateForm();
   }, [
-    isSNO,
     setFieldValue,
     validateForm,
     values.clusterNetworks,
@@ -90,8 +90,11 @@ export const StackTypeControlGroup = ({
 
   const setDualStack = () => {
     setFieldValue('stackType', DUAL_STACK);
-    setFieldValue('networkType', getDefaultNetworkType(isSNO, true));
     setFieldValue('vipDhcpAllocation', false);
+
+    if (values.networkType === NETWORK_TYPE_SDN && !canSelectNetworkTypeSDN(isSNO, true)) {
+      setFieldValue('networkType', NETWORK_TYPE_OVN);
+    }
 
     if (values.machineNetworks && values.machineNetworks?.length < 2) {
       setFieldValue(

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/StackTypeControl.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/StackTypeControl.tsx
@@ -17,7 +17,6 @@ import {
   ClusterNetwork,
   MachineNetwork,
   ServiceNetwork,
-  canSelectNetworkTypeSDN,
 } from '../../../../common';
 import { ConfirmationModal, PopoverIcon } from '../../../../common/components/ui';
 import { useDefaultConfiguration } from '../ClusterDefaultConfigurationContext';
@@ -27,7 +26,6 @@ import { OcmRadioField } from '../../ui/OcmFormFields';
 type StackTypeControlGroupProps = {
   clusterId: Cluster['id'];
   isDualStackSelectable: boolean;
-  isSNO: boolean;
   hostSubnets: HostSubnets;
 };
 
@@ -47,7 +45,6 @@ const hasDualStackConfigurationChanged = (
 
 export const StackTypeControlGroup = ({
   clusterId,
-  isSNO,
   isDualStackSelectable,
   hostSubnets,
 }: StackTypeControlGroupProps) => {
@@ -92,7 +89,7 @@ export const StackTypeControlGroup = ({
     setFieldValue('stackType', DUAL_STACK);
     setFieldValue('vipDhcpAllocation', false);
 
-    if (values.networkType === NETWORK_TYPE_SDN && !canSelectNetworkTypeSDN(isSNO, true)) {
+    if (values.networkType === NETWORK_TYPE_SDN) {
       setFieldValue('networkType', NETWORK_TYPE_OVN);
     }
 

--- a/src/ocm/services/ClusterDetailsService.ts
+++ b/src/ocm/services/ClusterDetailsService.ts
@@ -1,19 +1,18 @@
 import {
+  AI_UI_TAG,
   Cluster,
   V2ClusterUpdateParams,
   CpuArchitecture,
-  getClusterDetailsInitialValues,
   InfraEnv,
   ManagedDomain,
   OpenshiftVersionOptionType,
-  getDefaultNetworkType,
-  AI_UI_TAG,
+  getClusterDetailsInitialValues,
+  isArmArchitecture,
 } from '../../common';
 import { ClustersAPI, ManagedDomainsAPI } from '../services/apis';
 import InfraEnvsService from './InfraEnvsService';
 import omit from 'lodash/omit';
 import DiskEncryptionService from './DiskEncryptionService';
-import { isArmArchitecture, isSNO } from '../../common/selectors/clusterSelectors';
 import { CreateParams, HostsNetworkConfigurationType, OcmClusterDetailsValues } from './types';
 import { getDummyInfraEnvField } from '../components/clusterConfiguration/staticIp/data/dummyData';
 import ClustersService from './ClustersService';
@@ -50,7 +49,6 @@ const ClusterDetailsService = {
   },
 
   getClusterCreateParams(values: OcmClusterDetailsValues): CreateParams {
-    const isSNOCluster = isSNO(values);
     const params: CreateParams = omit(values, [
       'useRedHatDnsService',
       'SNODisclaimer',
@@ -65,7 +63,6 @@ const ClusterDetailsService = {
     if (isArmArchitecture({ cpuArchitecture: params.cpuArchitecture })) {
       params.userManagedNetworking = true;
     }
-    params.networkType = getDefaultNetworkType(isSNOCluster);
     if (values.hostsNetworkConfigurationType === HostsNetworkConfigurationType.STATIC) {
       params.staticNetworkConfig = getDummyInfraEnvField();
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-11294

The UI should not set the `network_type` when a cluster is created, it's the Backend's responsability based on many different rules.

- Stop sending `networkType` when a cluster is created
- Do not modify `networkType` for the user, unless the existing choice is not valid for the changes they are doing (eg. SDN cannot be used for DualStack clusters)
- NetworkType has been move outside the "advanced settings" section. The current behaviour of the block is to reset the settings to their default values if the section is unselected, meaning the UI would need to know the default networkType for the cluster.
This avoid duplicating the backend logic for the default networkType also in the UI.

NetworkType moved outside "advanced settings"
![network-type-outside](https://user-images.githubusercontent.com/829045/194816664-af813ebd-025c-4bd2-a8af-5b3d16c996d9.png)


PR for e2e tets adaptations: https://gitlab.cee.redhat.com/ocp-edge-qe/kni-assisted-installer-auto/-/merge_requests/912/
