### PR TITLE
MGMT-9246: Removing traces of OCS

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -455,7 +455,6 @@
   "ai:OpenShift Cluster Manager": "OpenShift Cluster Manager",
   "ai:OpenShift Cluster Version Operator": "OpenShift Cluster Version Operator",
   "ai:OpenShift Console": "OpenShift Console",
-  "ai:OpenShift Container Storage": "OpenShift Container Storage",
   "ai:OpenShift Data Foundation": "OpenShift Data Foundation",
   "ai:OpenShift Data Foundation Logical Volume Manager": "OpenShift Data Foundation Logical Volume Manager",
   "ai:OpenShift in-place upgrades aren't expected to work with SNO. If an upgrade is needed, your system will need a redeployment.": "OpenShift in-place upgrades aren't expected to work with SNO. If an upgrade is needed, your system will need a redeployment.",

--- a/src/common/config/constants.ts
+++ b/src/common/config/constants.ts
@@ -276,7 +276,6 @@ export const diskRoleLabels = (t: TFunction): { [key in DiskRole]: string } => (
 // The API uses free-form string for operator names, so let's guard at least using constants
 export const OPERATOR_NAME_CNV = 'cnv';
 export const OPERATOR_NAME_LSO = 'lso';
-export const OPERATOR_NAME_OCS = 'ocs'; // TODO(jkilzi): Remove once OCS is replaced by ODF
 export const OPERATOR_NAME_ODF = 'odf';
 export const OPERATOR_NAME_LVM = 'lvm';
 export const OPERATOR_NAME_CVO = 'cvo';
@@ -285,7 +284,6 @@ export const OPERATOR_NAME_CONSOLE = 'console';
 export type OperatorName =
   | typeof OPERATOR_NAME_CNV
   | typeof OPERATOR_NAME_LSO
-  | typeof OPERATOR_NAME_OCS
   | typeof OPERATOR_NAME_ODF
   | typeof OPERATOR_NAME_LVM
   | typeof OPERATOR_NAME_CVO
@@ -295,7 +293,6 @@ export const operatorLabels = (t: TFunction): { [key in OperatorName]: string } 
   [OPERATOR_NAME_CONSOLE]: t('ai:OpenShift Console'),
   [OPERATOR_NAME_CVO]: t('ai:OpenShift Cluster Version Operator'),
   [OPERATOR_NAME_LSO]: t('ai:OpenShift Local Storage'),
-  [OPERATOR_NAME_OCS]: t('ai:OpenShift Container Storage'), // TODO(jkilzi): Remove once OCS is replaced by ODF
   [OPERATOR_NAME_ODF]: t('ai:OpenShift Data Foundation'),
   [OPERATOR_NAME_LVM]: t('ai:OpenShift Data Foundation Logical Volume Manager'),
   [OPERATOR_NAME_CNV]: t('ai:OpenShift Virtualization'),

--- a/src/ocm/components/clusterWizard/Operators.tsx
+++ b/src/ocm/components/clusterWizard/Operators.tsx
@@ -8,7 +8,6 @@ import {
   MonitoredOperator,
   OPERATOR_NAME_CNV,
   OPERATOR_NAME_LVM,
-  OPERATOR_NAME_OCS,
   OPERATOR_NAME_ODF,
   OperatorsValues,
   selectMonitoredOperators,
@@ -31,7 +30,7 @@ export const getOperatorsInitialValues = (
   const isOperatorEnabled = (operatorNames: string[]) =>
     !!monitoredOperators.find((operator) => operatorNames.includes(operator.name || ''));
   return {
-    useOpenShiftDataFoundation: isOperatorEnabled([OPERATOR_NAME_ODF, OPERATOR_NAME_OCS]),
+    useOpenShiftDataFoundation: isOperatorEnabled([OPERATOR_NAME_ODF]),
     useOdfLogicalVolumeManager: isOperatorEnabled([OPERATOR_NAME_LVM]),
     useContainerNativeVirtualization: isOperatorEnabled([OPERATOR_NAME_CNV]),
   };

--- a/src/ocm/services/OperatorsService.tsx
+++ b/src/ocm/services/OperatorsService.tsx
@@ -4,7 +4,6 @@ import {
   OperatorCreateParams,
   OPERATOR_NAME_CNV,
   OPERATOR_NAME_ODF,
-  OPERATOR_NAME_OCS,
   OPERATOR_NAME_LSO,
   OPERATOR_NAME_LVM,
 } from '../../common';
@@ -28,11 +27,7 @@ const OperatorsService = {
     setOperator(OPERATOR_NAME_LVM, values.useOdfLogicalVolumeManager);
     setOperator(OPERATOR_NAME_CNV, values.useContainerNativeVirtualization);
 
-    // TODO(jkilzi): remove traces of OCS once it's fully deprecated/renamed to ODF
-    setOperator(
-      OPERATOR_NAME_ODF in enabledOlmOperatorsByName ? OPERATOR_NAME_ODF : OPERATOR_NAME_OCS,
-      values.useOpenShiftDataFoundation,
-    );
+    setOperator(OPERATOR_NAME_ODF, values.useOpenShiftDataFoundation);
     // TODO(jtomasek): remove following once enabling OCS is moved into a separate storage step and LSO option is exposed to the user
     if (!hasActiveOperators(values)) {
       setOperator(OPERATOR_NAME_LSO, false);


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-9246

The only traces of OCS left in the code should be in validations ids and labels.