### PR TITLE
MGMT-12121 Fix invalid comparison to enable ARM for OpenShift versions

### DIFF
--- a/src/ocm/components/clusterConfiguration/OcmOpenShiftVersionSelect.tsx
+++ b/src/ocm/components/clusterConfiguration/OcmOpenShiftVersionSelect.tsx
@@ -83,7 +83,9 @@ const OcmOpenShiftVersionSelect: React.FC<OcmOpenShiftVersionSelectProps> = ({ v
             version.supportLevel === 'beta'
               ? version.label + ' - ' + t('ai:Developer preview release')
               : version.label,
-          value: version.version,
+          // This is the "key" from openshift-versions API response
+          // It can either be in the long or short (for default versions) form
+          value: version.value,
         })),
     [versions, t],
   );


### PR DESCRIPTION
In https://github.com/openshift-assisted/assisted-ui-lib/pull/1656, a change was introduced based on my comments in the code review. 

Turns out that the assumption was wrong, and we should always keep the `key` for the OpenshiftVersion, which can be the short form `4.11` (which is an alias to the latest patch in the same release) or the specific version form `4.11.whatever`.

Due to this change, the feature that enabled ARM architecture for certain OpenShift versions stopped working.

With this change, both ARM and setting the desired OpenShift version on cluster creation work.
