### PR TITLE
Fix id generation for skip formatting disks checkboxes

### DIFF
--- a/src/common/components/hosts/SkipFormattingCheckbox.tsx
+++ b/src/common/components/hosts/SkipFormattingCheckbox.tsx
@@ -57,7 +57,7 @@ const SkipFormattingCheckbox: React.FC<SkipFormattingProps> = ({
       content={'Installation disks are always being formatted'}
     >
       <Checkbox
-        id={`select-formatted-${index}`}
+        id={`select-formatted-${host.id}-${index}`}
         isChecked={
           isInstallationDisk(diskId, installationDiskId) || !isDiskSkipFormatting(host, diskId)
         }


### PR DESCRIPTION
When I was working with integration tests i've found that the id of skip formatting disks checkboxes is not well generated.
![image](https://user-images.githubusercontent.com/11390125/194543100-63ef1744-1e26-4609-b9d6-a81d2d62a163.png)
