### PR TITLE
MGMT-12275 Fix logic to determine platform integration

### DIFF
--- a/src/common/types/clusters.ts
+++ b/src/common/types/clusters.ts
@@ -59,3 +59,4 @@ export enum CpuArchitecture {
   ARM = 'arm64',
 }
 export const SupportedPlatformIntegrations: PlatformType[] = ['vsphere', 'nutanix'];
+export const NonPlatformIntegrations: PlatformType[] = ['baremetal', 'none'];

--- a/src/ocm/hooks/useClusterSupportedPlatforms.ts
+++ b/src/ocm/hooks/useClusterSupportedPlatforms.ts
@@ -6,6 +6,7 @@ import { ClustersAPI } from '../services/apis';
 import {
   PlatformType,
   POLLING_INTERVAL,
+  NonPlatformIntegrations,
   SupportedPlatformIntegrations,
   useAlerts,
 } from '../../common';
@@ -14,10 +15,13 @@ import { APIErrorMixin } from '../api/types';
 export type PlatformIntegrationType = typeof SupportedPlatformIntegrations[number];
 export type SupportedPlatformIntegrationType = 'no-active-integrations' | PlatformIntegrationType;
 
-function getIntegrablePlatformIntegration(platform: PlatformType[]) {
-  const platformsSet = Array.from(new Set(platform));
-  if (platformsSet.length === 1) {
-    const [exclusivelyAvailablePlatform] = platformsSet;
+function getIntegrablePlatformIntegration(allClusterPlatforms: PlatformType[]) {
+  const integrationPlatforms = allClusterPlatforms.filter(
+    (platform) => !NonPlatformIntegrations.includes(platform),
+  );
+  const uniqueIntegrationPlatforms = Array.from(new Set(integrationPlatforms));
+  if (integrationPlatforms.length === 1) {
+    const [exclusivelyAvailablePlatform] = uniqueIntegrationPlatforms;
     return SupportedPlatformIntegrations.includes(exclusivelyAvailablePlatform)
       ? exclusivelyAvailablePlatform
       : undefined;


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-12275

The logic to determine when the platform integrations are possible was wrong because it was expecting a different API response.

For a cluster with Vsphere hosts, we are receiving 
```
"supported-platforms": ['vsphere', 'none', 'metal']
```
So we should filter out `none` and `metal` and apply the same algorithm as before with those reduced values.
 