### PR TITLE
Problems in SNO clusters when changing role to installation disk on formattable disks

### DIFF
--- a/src/common/components/clusterWizard/validationsInfoUtils.ts
+++ b/src/common/components/clusterWizard/validationsInfoUtils.ts
@@ -261,3 +261,24 @@ export const areOnlySoftValidationsOfWizardStepFailing = <ClusterWizardStepsType
   }
   return true;
 };
+
+export const findValidationStep = <ClusterWizardStepsType extends string>(
+  {
+    validationId,
+  }: {
+    // validation IDs are unique
+    validationId: ClusterValidationId | HostValidationId;
+  },
+  wizardStepsValidationsMap: WizardStepsValidationMap<ClusterWizardStepsType>,
+): ClusterWizardStepsType | undefined => {
+  const keys = lodashKeys(wizardStepsValidationsMap) as ClusterWizardStepsType[];
+  return keys.find((key) => {
+    // find first matching validation-map name
+    const { cluster: clusterValidationMap, host: hostValidationMap } =
+      wizardStepsValidationsMap[key];
+    return (
+      clusterValidationMap.validationIds.includes(validationId as ClusterValidationId) ||
+      hostValidationMap.validationIds.includes(validationId as HostValidationId)
+    );
+  });
+};

--- a/src/common/components/clusterWizard/validationsInfoUtils.ts
+++ b/src/common/components/clusterWizard/validationsInfoUtils.ts
@@ -263,17 +263,20 @@ export const areOnlySoftValidationsOfWizardStepFailing = <ClusterWizardStepsType
 };
 
 export const findValidationStep = <ClusterWizardStepsType extends string>(
-  {
-    validationId,
-  }: {
-    // validation IDs are unique
-    validationId: ClusterValidationId | HostValidationId;
-  },
+  validationId: ClusterValidationId | HostValidationId,
   wizardStepsValidationsMap: WizardStepsValidationMap<ClusterWizardStepsType>,
+  minimumStep: ClusterWizardStepsType,
 ): ClusterWizardStepsType | undefined => {
   const wizardStepsIds = lodashKeys(wizardStepsValidationsMap) as ClusterWizardStepsType[];
+  let isBeforeMinimumStep = true;
   return wizardStepsIds.find((wizardStepId) => {
-    // find first matching validation-map name
+    if (wizardStepId === minimumStep) {
+      isBeforeMinimumStep = false;
+    }
+    if (isBeforeMinimumStep) {
+      return false;
+    }
+    // find first matching validation-map name, ignoring steps before minimumStep
     const { host: hostValidationMap } = wizardStepsValidationsMap[wizardStepId];
     return hostValidationMap.validationIds.includes(validationId as HostValidationId);
   });

--- a/src/common/components/clusterWizard/validationsInfoUtils.ts
+++ b/src/common/components/clusterWizard/validationsInfoUtils.ts
@@ -271,14 +271,10 @@ export const findValidationStep = <ClusterWizardStepsType extends string>(
   },
   wizardStepsValidationsMap: WizardStepsValidationMap<ClusterWizardStepsType>,
 ): ClusterWizardStepsType | undefined => {
-  const keys = lodashKeys(wizardStepsValidationsMap) as ClusterWizardStepsType[];
-  return keys.find((key) => {
+  const wizardStepsIds = lodashKeys(wizardStepsValidationsMap) as ClusterWizardStepsType[];
+  return wizardStepsIds.find((wizardStepId) => {
     // find first matching validation-map name
-    const { cluster: clusterValidationMap, host: hostValidationMap } =
-      wizardStepsValidationsMap[key];
-    return (
-      clusterValidationMap.validationIds.includes(validationId as ClusterValidationId) ||
-      hostValidationMap.validationIds.includes(validationId as HostValidationId)
-    );
+    const { host: hostValidationMap } = wizardStepsValidationsMap[wizardStepId];
+    return hostValidationMap.validationIds.includes(validationId as HostValidationId);
   });
 };

--- a/src/common/components/hosts/FormatDiskCheckbox.tsx
+++ b/src/common/components/hosts/FormatDiskCheckbox.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Checkbox, Tooltip } from '@patternfly/react-core';
 import { Disk, Host } from '../../api';
-import { getInventory, OpticalDiskDriveType, trimCommaSeparatedList } from '../..';
+import { trimCommaSeparatedList } from '../..';
 
 export type DiskFormattingType = (
   shouldFormatDisk: boolean,
@@ -51,13 +51,10 @@ export const isFormatDiskDisabled = (
   diskId: string | undefined,
   installationDiskId: Host['installationDiskId'],
 ) => {
-  const inventory = getInventory(host);
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const disk = (inventory.disks || []).find((disk) => disk.id === diskId)!;
-  const isInstallationDisk = disk.id === installationDiskId;
-  const condition =
-    disk.driveType === OpticalDiskDriveType || disk.driveType === 'Unknown' || isInstallationDisk;
-  return condition;
+  return (
+    !isDiskFormattable(host, diskId) ||
+    (isInstallationDisk(diskId, installationDiskId) && !isDiskSkipFormatting(host, diskId))
+  );
 };
 
 const onSelectFormattingDisk = (

--- a/src/common/components/hosts/FormatDiskCheckbox.tsx
+++ b/src/common/components/hosts/FormatDiskCheckbox.tsx
@@ -9,7 +9,7 @@ export type DiskFormattingType = (
   diskId: Disk['id'],
 ) => void;
 
-type SkipFormattingProps = {
+type FormatDiskProps = {
   host: Host;
   index: number;
   updateDiskSkipFormatting?: DiskFormattingType;
@@ -35,11 +35,11 @@ export const isDiskFormattable = (host: Host, diskId: string | undefined) => {
   );
 };
 
-export const isSkipFormattingChecked = (host: Host, diskId: string | undefined) => {
+export const isDiskToBeFormatted = (host: Host, diskId: string | undefined) => {
   return isDiskFormattable(host, diskId) && !isDiskSkipFormatting(host, diskId);
 };
 
-export const isSkipFormattingDisabled = (
+export const isFormatDiskDisabled = (
   host: Host,
   diskId: string | undefined,
   installationDiskId: string | undefined,
@@ -59,7 +59,7 @@ const onSelectFormattingDisk = (
   updateDiskSkipFormatting ? updateDiskSkipFormatting(shouldFormatDisk, hostId, diskId) : '';
 };
 
-const SkipFormattingCheckbox: React.FC<SkipFormattingProps> = ({
+const FormatDiskCheckbox: React.FC<FormatDiskProps> = ({
   host,
   diskId,
   installationDiskId,
@@ -73,13 +73,13 @@ const SkipFormattingCheckbox: React.FC<SkipFormattingProps> = ({
     >
       <Checkbox
         id={`select-formatted-${host.id}-${index}`}
-        isChecked={isSkipFormattingChecked(host, diskId)}
+        isChecked={isDiskToBeFormatted(host, diskId)}
         onChange={(checked: boolean) =>
           onSelectFormattingDisk(checked, host.id, diskId, updateDiskSkipFormatting)
         }
-        isDisabled={isSkipFormattingDisabled(host, diskId, installationDiskId)}
+        isDisabled={isFormatDiskDisabled(host, diskId, installationDiskId)}
       />
     </Tooltip>
   );
 };
-export default SkipFormattingCheckbox;
+export default FormatDiskCheckbox;

--- a/src/common/components/hosts/SkipFormattingCheckbox.tsx
+++ b/src/common/components/hosts/SkipFormattingCheckbox.tsx
@@ -35,6 +35,23 @@ export const isDiskFormattable = (host: Host, diskId: string | undefined) => {
   );
 };
 
+export const isSkipFormattingChecked = (host: Host, diskId: string | undefined) => {
+  return isDiskFormattable(host, diskId) && !isDiskSkipFormatting(host, diskId);
+};
+
+export const isSkipFormattingDisabled = (
+  host: Host,
+  diskId: string | undefined,
+  installationDiskId: string | undefined,
+) => {
+  return (
+    !isDiskFormattable(host, diskId) ||
+    (isDiskFormattable(host, diskId) &&
+      isInstallationDisk(diskId, installationDiskId) &&
+      !isDiskSkipFormatting(host, diskId))
+  );
+};
+
 const onSelectSkipFormatting = (
   shouldFormatDisk: boolean,
   hostId: string,
@@ -58,13 +75,11 @@ const SkipFormattingCheckbox: React.FC<SkipFormattingProps> = ({
     >
       <Checkbox
         id={`select-formatted-${host.id}-${index}`}
-        isChecked={
-          isInstallationDisk(diskId, installationDiskId) || !isDiskSkipFormatting(host, diskId)
-        }
+        isChecked={isSkipFormattingChecked(host, diskId)}
         onChange={(checked: boolean) =>
           onSelectSkipFormatting(checked, host.id, diskId, updateDiskSkipFormatting)
         }
-        isDisabled={isInstallationDisk(diskId, installationDiskId) || !updateDiskSkipFormatting}
+        isDisabled={isSkipFormattingDisabled(host, diskId, installationDiskId)}
       />
     </Tooltip>
   );

--- a/src/common/components/hosts/SkipFormattingCheckbox.tsx
+++ b/src/common/components/hosts/SkipFormattingCheckbox.tsx
@@ -46,13 +46,11 @@ export const isSkipFormattingDisabled = (
 ) => {
   return (
     !isDiskFormattable(host, diskId) ||
-    (isDiskFormattable(host, diskId) &&
-      isInstallationDisk(diskId, installationDiskId) &&
-      !isDiskSkipFormatting(host, diskId))
+    (isInstallationDisk(diskId, installationDiskId) && !isDiskSkipFormatting(host, diskId))
   );
 };
 
-const onSelectSkipFormatting = (
+const onSelectFormattingDisk = (
   shouldFormatDisk: boolean,
   hostId: string,
   diskId?: string,
@@ -77,7 +75,7 @@ const SkipFormattingCheckbox: React.FC<SkipFormattingProps> = ({
         id={`select-formatted-${host.id}-${index}`}
         isChecked={isSkipFormattingChecked(host, diskId)}
         onChange={(checked: boolean) =>
-          onSelectSkipFormatting(checked, host.id, diskId, updateDiskSkipFormatting)
+          onSelectFormattingDisk(checked, host.id, diskId, updateDiskSkipFormatting)
         }
         isDisabled={isSkipFormattingDisabled(host, diskId, installationDiskId)}
       />

--- a/src/common/components/storage/DisksTable.tsx
+++ b/src/common/components/storage/DisksTable.tsx
@@ -10,7 +10,7 @@ import {
   IRow,
 } from '@patternfly/react-table';
 import { ExtraParamsType } from '@patternfly/react-table/dist/js/components/Table/base';
-import { Disk, fileSize, Host, OpticalDiskDriveType, WithTestID } from '../../index';
+import { Disk, fileSize, Host, WithTestID } from '../../index';
 import DiskRole, { OnDiskRoleType } from '../hosts/DiskRole';
 import DiskLimitations from '../hosts/DiskLimitations';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
@@ -95,20 +95,18 @@ const DisksTable = ({
           props: { 'data-testid': 'disk-role' },
         },
         { title: <DiskLimitations disk={disk} />, props: { 'data-testid': 'disk-limitations' } },
-        disk.driveType !== OpticalDiskDriveType &&
-          disk.driveType !== 'Unknown' &&
-          disk.bootable && {
-            title: (
-              <SkipFormattingCheckbox
-                host={host}
-                diskId={disk.id}
-                installationDiskId={installationDiskId}
-                index={index}
-                updateDiskSkipFormatting={updateDiskSkipFormatting}
-              />
-            ),
-            props: { 'data-testid': 'disk-formatted' },
-          },
+        {
+          title: (
+            <SkipFormattingCheckbox
+              host={host}
+              diskId={disk.id}
+              installationDiskId={installationDiskId}
+              index={index}
+              updateDiskSkipFormatting={updateDiskSkipFormatting}
+            />
+          ),
+          props: { 'data-testid': 'disk-formatted' },
+        },
         { title: disk.driveType, props: { 'data-testid': 'drive-type' } },
         { title: fileSize(disk.sizeBytes || 0, 2, 'si'), props: { 'data-testid': 'disk-size' } },
         { title: disk.serial, props: { 'data-testid': 'disk-serial' } },

--- a/src/common/components/storage/DisksTable.tsx
+++ b/src/common/components/storage/DisksTable.tsx
@@ -18,7 +18,7 @@ import { global_warning_color_100 as warningColor } from '@patternfly/react-toke
 import SkipFormattingCheckbox, {
   DiskFormattingType,
   isDiskSkipFormatting,
-} from '../hosts/SkipFormattingCheckbox';
+} from '../hosts/FormatDiskCheckbox';
 
 interface DisksTableProps extends WithTestID {
   canEditDisks?: (host: Host) => boolean;

--- a/src/common/components/storage/DisksTable.tsx
+++ b/src/common/components/storage/DisksTable.tsx
@@ -10,7 +10,7 @@ import {
   IRow,
 } from '@patternfly/react-table';
 import { ExtraParamsType } from '@patternfly/react-table/dist/js/components/Table/base';
-import { Disk, fileSize, Host, WithTestID } from '../../index';
+import { Disk, fileSize, Host, OpticalDiskDriveType, WithTestID } from '../../index';
 import DiskRole, { OnDiskRoleType } from '../hosts/DiskRole';
 import DiskLimitations from '../hosts/DiskLimitations';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
@@ -18,8 +18,6 @@ import { global_warning_color_100 as warningColor } from '@patternfly/react-toke
 import SkipFormattingCheckbox, {
   DiskFormattingType,
   isDiskSkipFormatting,
-  isInstallationDisk,
-  isDiskFormattable,
 } from '../hosts/SkipFormattingCheckbox';
 
 interface DisksTableProps extends WithTestID {
@@ -97,18 +95,20 @@ const DisksTable = ({
           props: { 'data-testid': 'disk-role' },
         },
         { title: <DiskLimitations disk={disk} />, props: { 'data-testid': 'disk-limitations' } },
-        (isDiskFormattable(host, disk.id) || isInstallationDisk(disk.id, installationDiskId)) && {
-          title: (
-            <SkipFormattingCheckbox
-              host={host}
-              diskId={disk.id}
-              installationDiskId={installationDiskId}
-              index={index}
-              updateDiskSkipFormatting={updateDiskSkipFormatting}
-            />
-          ),
-          props: { 'data-testid': 'disk-formatted' },
-        },
+        disk.driveType !== OpticalDiskDriveType &&
+          disk.driveType !== 'Unknown' &&
+          disk.bootable && {
+            title: (
+              <SkipFormattingCheckbox
+                host={host}
+                diskId={disk.id}
+                installationDiskId={installationDiskId}
+                index={index}
+                updateDiskSkipFormatting={updateDiskSkipFormatting}
+              />
+            ),
+            props: { 'data-testid': 'disk-formatted' },
+          },
         { title: disk.driveType, props: { 'data-testid': 'drive-type' } },
         { title: fileSize(disk.sizeBytes || 0, 2, 'si'), props: { 'data-testid': 'disk-size' } },
         { title: disk.serial, props: { 'data-testid': 'disk-serial' } },

--- a/src/common/components/storage/DisksTable.tsx
+++ b/src/common/components/storage/DisksTable.tsx
@@ -17,7 +17,7 @@ import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens/dist/js/global_warning_color_100';
 import FormatDiskCheckbox, {
   DiskFormattingType,
-  isDiskSkipFormatting,
+  isInDiskSkipFormattingList,
 } from '../hosts/FormatDiskCheckbox';
 
 interface DisksTableProps extends WithTestID {
@@ -71,7 +71,7 @@ const DisksTable = ({
         {
           title: (
             <>
-              {isDiskSkipFormatting(host, disk.id) && (
+              {isInDiskSkipFormattingList(host, disk.id) && (
                 <Popover bodyContent={<SkipFormattingDisk />} minWidth="20rem" maxWidth="30rem">
                   <ExclamationTriangleIcon color={warningColor.value} size="sm" />
                 </Popover>

--- a/src/common/components/storage/DisksTable.tsx
+++ b/src/common/components/storage/DisksTable.tsx
@@ -15,7 +15,7 @@ import DiskRole, { OnDiskRoleType } from '../hosts/DiskRole';
 import DiskLimitations from '../hosts/DiskLimitations';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens/dist/js/global_warning_color_100';
-import SkipFormattingCheckbox, {
+import FormatDiskCheckbox, {
   DiskFormattingType,
   isDiskSkipFormatting,
 } from '../hosts/FormatDiskCheckbox';
@@ -97,7 +97,7 @@ const DisksTable = ({
         { title: <DiskLimitations disk={disk} />, props: { 'data-testid': 'disk-limitations' } },
         {
           title: (
-            <SkipFormattingCheckbox
+            <FormatDiskCheckbox
               host={host}
               diskId={disk.id}
               installationDiskId={installationDiskId}

--- a/src/common/components/storage/StorageDetail.tsx
+++ b/src/common/components/storage/StorageDetail.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Grid, GridItem } from '@patternfly/react-core';
 import { getInventory, Host } from '../../index';
 import { OnDiskRoleType } from '../hosts/DiskRole';
-import { DiskFormattingType } from '../hosts/SkipFormattingCheckbox';
+import { DiskFormattingType } from '../hosts/FormatDiskCheckbox';
 import DisksTable from './DisksTable';
 import SectionTitle from '../ui/SectionTitle';
 

--- a/src/common/components/ui/WizardNavItem.tsx
+++ b/src/common/components/ui/WizardNavItem.tsx
@@ -9,7 +9,7 @@ const getNavItemContent = (
   isDisabled?: boolean,
   isCurrent?: boolean,
 ): ReactNode => {
-  if (!isDisabled && (!isCurrent || (isCurrent && content === 'Storage')) && !isValid()) {
+  if (!isDisabled && !isCurrent && !isValid()) {
     return (
       <>
         {content}

--- a/src/common/components/ui/WizardNavItem.tsx
+++ b/src/common/components/ui/WizardNavItem.tsx
@@ -9,7 +9,7 @@ const getNavItemContent = (
   isDisabled?: boolean,
   isCurrent?: boolean,
 ): ReactNode => {
-  if (!isDisabled && !isCurrent && !isValid()) {
+  if (!isDisabled && (!isCurrent || (isCurrent && content === 'Storage')) && !isValid()) {
     return (
       <>
         {content}

--- a/src/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
+++ b/src/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
@@ -39,7 +39,12 @@ const ClusterWizardContextProvider: React.FC<
 
   React.useEffect(() => {
     const staticIpInfo = infraEnv ? getStaticIpInfo(infraEnv) : undefined;
-    const firstStep = getClusterWizardFirstStep(locationState, staticIpInfo, cluster?.status);
+    const firstStep = getClusterWizardFirstStep(
+      locationState,
+      staticIpInfo,
+      cluster?.status,
+      cluster?.hosts,
+    );
     const firstStepIds = getWizardStepIds(staticIpInfo?.view);
     setCurrentStepId(firstStep);
     setWizardStepIds(firstStepIds);

--- a/src/ocm/components/clusterWizard/ClusterWizardNavigation.tsx
+++ b/src/ocm/components/clusterWizard/ClusterWizardNavigation.tsx
@@ -24,10 +24,10 @@ const isStepValid = (stepId: ClusterWizardStepsType, cluster?: Cluster): boolean
     case 'static-ip-host-configurations':
     case 'static-ip-network-wide-configurations':
       return canNextClusterDetails({ cluster });
-    case 'storage':
-      return canNextStorage({ cluster });
     case 'host-discovery':
       return canNextHostDiscovery({ cluster });
+    case 'storage':
+      return canNextStorage({ cluster });
     case 'networking':
       return canNextNetwork({ cluster });
     default:

--- a/src/ocm/components/clusterWizard/wizardTransition.ts
+++ b/src/ocm/components/clusterWizard/wizardTransition.ts
@@ -60,18 +60,15 @@ export const getClusterWizardFirstStep = (
 
 const getStepForFailingHostValidations = (hosts: Host[] | undefined) => {
   const failingValidations: HostValidationId[] = getHostFailingValidationIds(hosts);
+  const minimumStep = 'host-discovery';
   let step;
   for (const failingValidationId of failingValidations) {
-    step = findValidationStep<string>(
-      { validationId: failingValidationId },
-      wizardStepsValidationsMap,
-    );
-    console.log(step);
+    step = findValidationStep<string>(failingValidationId, wizardStepsValidationsMap, minimumStep);
     if (step !== undefined) {
       break;
     }
   }
-  return step ? (step as ClusterWizardStepsType) : 'host-discovery';
+  return (step || minimumStep) as ClusterWizardStepsType;
 };
 
 const getHostFailingValidationIds = (hosts: Host[] | undefined) => {

--- a/src/ocm/components/clusterWizard/wizardTransition.ts
+++ b/src/ocm/components/clusterWizard/wizardTransition.ts
@@ -1,11 +1,19 @@
 import {
   Cluster,
+  findValidationStep,
   getAllClusterWizardSoftValidationIds,
   getWizardStepClusterStatus,
+  Host,
+  HostValidationId,
+  stringToJSON,
   WizardStepsValidationMap,
   WizardStepValidationMap,
 } from '../../../common';
 import { StaticIpInfo, StaticIpView } from '../clusterConfiguration/staticIp/data/dataTypes';
+import {
+  ValidationsInfo as HostValidationsInfo,
+  Validation as HostValidation,
+} from '../../../common/types/hosts';
 
 export type ClusterWizardStepsType =
   | 'cluster-details'
@@ -25,6 +33,7 @@ export const getClusterWizardFirstStep = (
   locationState: ClusterWizardFlowStateType | undefined,
   staticIpInfo: StaticIpInfo | undefined,
   state?: ClusterWizardFlowStateType,
+  hosts?: Host[] | undefined,
 ): ClusterWizardStepsType => {
   // Move to operators just the first time after the cluster is created
   if (locationState === ClusterWizardFlowStateNew && !staticIpInfo) {
@@ -37,16 +46,46 @@ export const getClusterWizardFirstStep = (
     }
     return 'static-ip-network-wide-configurations';
   }
+  const step = getStepIdByHostValidations(hosts);
   switch (state) {
     case 'ready':
       return 'review';
     case 'pending-for-input':
     case 'adding-hosts':
     case 'insufficient':
-      return 'host-discovery';
+      return step ? step : 'host-discovery';
     default:
       return 'cluster-details';
   }
+};
+
+const getStepIdByHostValidations = (hosts: Host[] | undefined) => {
+  const failingValidations: HostValidationId[] = getHostValidations(hosts);
+  let step = '';
+  failingValidations.forEach((failingValidationId) => {
+    const stepFound = findValidationStep<string>(
+      { validationId: failingValidationId },
+      wizardStepsValidationsMap,
+    );
+    if (stepFound !== undefined) step = stepFound;
+  });
+  return step as ClusterWizardStepsType;
+};
+
+const getHostValidations = (hosts: Host[] | undefined) => {
+  const failingValidations: HostValidationId[] = [];
+  hosts?.forEach((host) => {
+    const validationsInfo = stringToJSON<HostValidationsInfo>(host.validationsInfo) || {};
+    Object.keys(validationsInfo).forEach((group) => {
+      const f: (validation: HostValidation) => void = (validation) => {
+        if (validation.status === 'failure') {
+          failingValidations.push(validation.id);
+        }
+      };
+      validationsInfo[group].forEach(f);
+    });
+  });
+  return failingValidations;
 };
 
 type TransitionProps = { cluster: Cluster };

--- a/src/ocm/components/clusterWizard/wizardTransition.ts
+++ b/src/ocm/components/clusterWizard/wizardTransition.ts
@@ -141,7 +141,7 @@ const hostDiscoveryStepValidationsMap: WizardStepValidationMap = {
       'cnv-requirements-satisfied',
     ],
   },
-  softValidationIds: [],
+  softValidationIds: ['no-skip-installation-disk', 'no-skip-missing-disk'],
 };
 
 const storageStepValidationsMap: WizardStepValidationMap = {

--- a/src/ocm/components/hosts/use-hosts-table.tsx
+++ b/src/ocm/components/hosts/use-hosts-table.tsx
@@ -140,6 +140,10 @@ export const useHostsTable = (cluster: Cluster) => {
         }
 
         const { data } = await HostsService.updateDiskRole(host, diskId, role);
+        //once selecting a disk which is in role none as a installation disk , the skip formatting attribute should be unselected and set to false
+        if (role === 'install') {
+          await HostsService.updateFormattingDisks(host, diskId, false);
+        }
         resetCluster ? void resetCluster() : dispatch(updateHost(data));
       } catch (e) {
         handleApiError(e, () =>

--- a/src/ocm/components/hosts/use-hosts-table.tsx
+++ b/src/ocm/components/hosts/use-hosts-table.tsx
@@ -140,10 +140,7 @@ export const useHostsTable = (cluster: Cluster) => {
         }
 
         const { data } = await HostsService.updateDiskRole(host, diskId, role);
-        //once selecting a disk which is in role none as a installation disk , the skip formatting attribute should be unselected and set to false
-        if (role === 'install') {
-          await HostsService.updateFormattingDisks(host, diskId, false);
-        }
+
         resetCluster ? void resetCluster() : dispatch(updateHost(data));
       } catch (e) {
         handleApiError(e, () =>

--- a/src/ocm/services/HostsService.ts
+++ b/src/ocm/services/HostsService.ts
@@ -40,9 +40,13 @@ const HostsService = {
   },
 
   updateDiskRole(host: Host, diskId: Required<Disk>['id'], newDiskRole: DiskRole) {
-    return HostsService.update(host, {
+    const params: HostUpdateParams = {
       disksSelectedConfig: [{ id: diskId, role: newDiskRole }],
-    });
+    };
+    if (newDiskRole === 'install') {
+      params.disksSkipFormatting = [{ diskId, skipFormatting: false }];
+    }
+    return HostsService.update(host, params);
   },
 
   updateFormattingDisks(host: Host, diskIdValue: Required<Disk>['id'], shouldSkipFormat: boolean) {


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-12328

New behavior:
1. Move the validation error to the storage tab
2. For disks that are installation disks and are also in the "skip formatting" list, show an empty non-disabled checkbox that the user can tick. This will allow the user to fix the validation error. The checkbox would immediately become disabled but ticked just like installation disks usually appear, and the validation would disappear because the installation disk is no longer in the skip list
3, For disks that are not in the candidate list for formatting, show a disabled empty checkbox to indicate to the user that the disk is safe. It's not going to be formatted. Currently we only show nothing - no check box, and that is a bit ambiguous and might make the user worry

Workflow 1: formattable disk select skip formatting option:

https://user-images.githubusercontent.com/11390125/197727184-61fd212f-fb03-492d-98f0-79d2c0e3be1c.mp4


Workflow 2: formattable disk that is skip formatting and is selected to be installation disk:


https://user-images.githubusercontent.com/11390125/197765705-beb2ba4c-660d-406f-9658-3e6f1c871ef6.mp4



