### PR TITLE
MGMT-12347 "Integrate with platform" is enabled and checked while no discovered hosts in cluster

### DIFF
--- a/src/ocm/components/clusterConfiguration/HostInventory.tsx
+++ b/src/ocm/components/clusterConfiguration/HostInventory.tsx
@@ -72,10 +72,7 @@ const HostInventory = ({ cluster }: { cluster: Cluster }) => {
         <StackItem>
           <Split hasGutter>
             <SplitItem>
-              <PlatformIntegration
-                clusterId={cluster.id}
-                platformType={cluster.platform?.type || 'none'}
-              />
+              <PlatformIntegration clusterId={cluster.id} />
             </SplitItem>
           </Split>
         </StackItem>

--- a/src/ocm/components/clusterConfiguration/platformIntegration/PlatformIntegration.tsx
+++ b/src/ocm/components/clusterConfiguration/platformIntegration/PlatformIntegration.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { OcmSwitchField } from '../../ui/OcmFormFields';
-import { isClusterPlatformTypeVM, Cluster, PopoverIcon, PlatformType } from '../../../../common';
+import { Cluster, PopoverIcon } from '../../../../common';
 import useClusterSupportedPlatforms, {
   SupportedPlatformIntegrationType,
 } from '../../../hooks/useClusterSupportedPlatforms';
@@ -43,13 +43,7 @@ const PlatformIntegrationLabel = ({
   );
 };
 
-const PlatformIntegration = ({
-  clusterId,
-  platformType,
-}: {
-  clusterId: Cluster['id'];
-  platformType: PlatformType;
-}) => {
+const PlatformIntegration = ({ clusterId }: { clusterId: Cluster['id'] }) => {
   const { isPlatformIntegrationSupported, supportedPlatformIntegration } =
     useClusterSupportedPlatforms(clusterId);
 
@@ -59,10 +53,7 @@ const PlatformIntegration = ({
         hidden: isPlatformIntegrationSupported,
         content: platformIntegrationTooltip,
       }}
-      isDisabled={
-        !isPlatformIntegrationSupported &&
-        !isClusterPlatformTypeVM({ platform: { type: platformType } })
-      }
+      isDisabled={!isPlatformIntegrationSupported}
       name={'usePlatformIntegration'}
       label={
         <PlatformIntegrationLabel supportedPlatformIntegration={supportedPlatformIntegration} />


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-12347
https://issues.redhat.com/browse/MGMT-12386

`make deploy_nodes PLATFORM=nutanix` with test-infra creates a cluster with `cluster.platform.type: "nutanix"` (but no hosts). This resulted in a checked and enabled Platform integration checkbox in the UI.

This PR changes it so that the only thing that determines if the platform integration switch is enabled is whether platform integration is supported for this cluster or not. Regardless of whether cluster.platform.type is set. If `clusters/{id}/supported-platforms` is correct, I don't think we need to check the host number or against `/feature-support-levels`.

As for the "is checked" part, I'm afraid there is not much the UI can do. `cluster.platform.type` is set by test-infra and any attempt to reset it to 'baremetal' fails.

Before:
![image](https://user-images.githubusercontent.com/87187179/199450488-9f149242-fb4d-49f6-8a95-c1206516a429.png)

After:
![image](https://user-images.githubusercontent.com/87187179/199450873-2b13eaea-9c14-4b27-b7da-67a59b26ade6.png)
