### PR TITLE
Fix: Unable to select Boot drive when adding a new node

### DIFF
--- a/src/common/components/hosts/utils.ts
+++ b/src/common/components/hosts/utils.ts
@@ -52,7 +52,7 @@ export const canReset = (clusterStatus: Cluster['status'], status: Host['status'
   ['error', 'installing-pending-user-action'].includes(status);
 
 export const canEditHost = (clusterStatus: Cluster['status'], status: Host['status']) =>
-  ['pending-for-input', 'insufficient', 'ready'].includes(clusterStatus) &&
+  ['pending-for-input', 'insufficient', 'ready', 'adding-hosts'].includes(clusterStatus) &&
   [
     'discovering',
     'discovering-unbound',

--- a/src/ocm/components/hosts/ClusterHostsTable.tsx
+++ b/src/ocm/components/hosts/ClusterHostsTable.tsx
@@ -19,14 +19,24 @@ import { HostDetail } from '../../../common/components/hosts/HostRowDetail';
 import { ExpandComponentProps } from '../../../common/components/hosts/AITable';
 import { UpdateDay2ApiVipDialogToggle } from './UpdateDay2ApiVipDialogToggle';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
+import {
+  HostsTableDetailContextProvider,
+  useHostsTableDetailContext,
+} from '../../../common/components/hosts/HostsTableDetailContext';
 
-const ExpandComponent = ({ obj }: ExpandComponentProps<Host>) => (
-  <HostDetail
-    host={obj}
-    AdditionalNTPSourcesDialogToggleComponent={AdditionalNTPSourcesDialogToggle}
-    hideNTPStatus
-  />
-);
+export function ExpandComponent({ obj: host }: ExpandComponentProps<Host>) {
+  const { onDiskRole, canEditDisks, updateDiskSkipFormatting } = useHostsTableDetailContext();
+  return (
+    <HostDetail
+      host={host}
+      AdditionalNTPSourcesDialogToggleComponent={AdditionalNTPSourcesDialogToggle}
+      hideNTPStatus
+      onDiskRole={onDiskRole}
+      canEditDisks={canEditDisks}
+      updateDiskSkipFormatting={updateDiskSkipFormatting}
+    />
+  );
+}
 
 export interface ClusterHostsTableProps {
   cluster: Cluster;
@@ -34,8 +44,15 @@ export interface ClusterHostsTableProps {
 }
 
 const ClusterHostsTable = ({ cluster, skipDisabled }: ClusterHostsTableProps) => {
-  const { onEditHost, actionChecks, onEditRole, actionResolver, ...modalProps } =
-    useHostsTable(cluster);
+  const {
+    onEditHost,
+    onEditRole,
+    actionChecks,
+    onDiskRole,
+    actionResolver,
+    updateDiskSkipFormatting,
+    ...modalProps
+  } = useHostsTable(cluster);
   const { t } = useTranslation();
   const content = React.useMemo(
     () => [
@@ -56,16 +73,22 @@ const ClusterHostsTable = ({ cluster, skipDisabled }: ClusterHostsTableProps) =>
 
   return (
     <>
-      <HostsTable
-        hosts={hosts}
-        skipDisabled={skipDisabled}
-        ExpandComponent={ExpandComponent}
-        content={content}
-        actionResolver={actionResolver}
-        {...paginationProps}
+      <HostsTableDetailContextProvider
+        canEditDisks={actionChecks.canEditDisks}
+        onDiskRole={onDiskRole}
+        updateDiskSkipFormatting={updateDiskSkipFormatting}
       >
-        <HostsTableEmptyState isSingleNode={isSNO(cluster)} />
-      </HostsTable>
+        <HostsTable
+          hosts={hosts}
+          skipDisabled={skipDisabled}
+          ExpandComponent={ExpandComponent}
+          content={content}
+          actionResolver={actionResolver}
+          {...paginationProps}
+        >
+          <HostsTableEmptyState isSingleNode={isSNO(cluster)} />
+        </HostsTable>
+      </HostsTableDetailContextProvider>
       <HostsTableModals cluster={cluster} {...modalProps} />
     </>
   );


### PR DESCRIPTION
Quixk fix to solve https://issues.redhat.com/browse/OCPBUGS-3043 / https://issues.redhat.com/browse/MGMT-12420
Now we can edit disk role and skip formatting disks in hosts added in day2 cluster:
![image](https://user-images.githubusercontent.com/11390125/199528355-bf6cc61b-1f96-465e-8d6f-cd37cd7782e8.png)


We need to change day2 flow to add storage step