### PR TITLE
Fix: Adding Hosts is disabled for SNO clusters when AI deployed on-prem.

### DIFF
--- a/src/ocm/components/clusterDetail/ClusterDetail.tsx
+++ b/src/ocm/components/clusterDetail/ClusterDetail.tsx
@@ -18,6 +18,7 @@ import {
   getEnabledHosts,
   selectOlmOperators,
   isSNO,
+  useFeatureSupportLevel,
 } from '../../../common';
 import { Cluster } from '../../../common/api/types';
 import ClusterHostsTable from '../hosts/ClusterHostsTable';
@@ -49,7 +50,16 @@ const ClusterDetail: React.FC<ClusterDetailProps> = ({ cluster }) => {
   const { resetClusterDialog, cancelInstallationDialog } = useModalDialogsContext();
   const clusterVarieties = useClusterStatusVarieties(cluster);
   const { credentials, credentialsError } = clusterVarieties;
-  const canAddHosts = !isSNO(cluster) && cluster.status === 'installed' && !ocmClient;
+  const featureSupportLevelContext = useFeatureSupportLevel();
+  const canAddHosts =
+    (!isSNO(cluster) ||
+      (cluster.openshiftVersion &&
+        featureSupportLevelContext.isFeatureSupported(
+          cluster.openshiftVersion,
+          'SINGLE_NODE_EXPANSION',
+        ))) &&
+    cluster.status === 'installed' &&
+    !ocmClient;
 
   return (
     <Stack hasGutter>

--- a/src/ocm/components/clusterDetail/ClusterDetail.tsx
+++ b/src/ocm/components/clusterDetail/ClusterDetail.tsx
@@ -51,15 +51,14 @@ const ClusterDetail: React.FC<ClusterDetailProps> = ({ cluster }) => {
   const clusterVarieties = useClusterStatusVarieties(cluster);
   const { credentials, credentialsError } = clusterVarieties;
   const featureSupportLevelContext = useFeatureSupportLevel();
+  const isSNOExpansionAllowed =
+    cluster.openshiftVersion &&
+    featureSupportLevelContext.isFeatureSupported(
+      cluster.openshiftVersion,
+      'SINGLE_NODE_EXPANSION',
+    );
   const canAddHosts =
-    (!isSNO(cluster) ||
-      (cluster.openshiftVersion &&
-        featureSupportLevelContext.isFeatureSupported(
-          cluster.openshiftVersion,
-          'SINGLE_NODE_EXPANSION',
-        ))) &&
-    cluster.status === 'installed' &&
-    !ocmClient;
+    (!isSNO(cluster) || isSNOExpansionAllowed) && cluster.status === 'installed' && !ocmClient;
 
   return (
     <Stack hasGutter>


### PR DESCRIPTION
Fix to solve bug https://issues.redhat.com/browse/MGMT-12414
SNO expansion is supported since OCP v4.11 the UI must follow the response sent through features-support-level 

To test:
1. Create and install an SNO cluster with AI deployed on-prem.
2. Check there's "Add Hosts" button on the cluster details page
