### PR TITLE
MGMT-12424: Fix wrong patch request when platform integration is disabled

### DIFF
--- a/src/ocm/components/clusterWizard/HostDiscovery.tsx
+++ b/src/ocm/components/clusterWizard/HostDiscovery.tsx
@@ -76,7 +76,12 @@ const HostDiscovery = ({ cluster }: { cluster: Cluster }) => {
       : undefined;
 
     const params: V2ClusterUpdateParams = {};
-    HostDiscoveryService.setPlatform(params, platformToIntegrate as SupportedPlatformType);
+
+    HostDiscoveryService.setPlatform(
+      params,
+      platformToIntegrate as SupportedPlatformType,
+      cluster.userManagedNetworking,
+    );
     HostDiscoveryService.setSchedulableMasters(params, values, cluster);
 
     try {

--- a/src/ocm/services/HostDiscoveryService.ts
+++ b/src/ocm/services/HostDiscoveryService.ts
@@ -10,8 +10,12 @@ const HostDiscoveryService = {
   setPlatform(
     params: V2ClusterUpdateParams,
     platformToIntegrate: SupportedPlatformType | undefined,
+    userManagedNetworking: boolean | undefined,
   ): void {
-    const type = platformToIntegrate === undefined ? 'none' : platformToIntegrate;
+    //the UI client sends cluster.platform.type=none if UMN is selected.
+    //the UI client sends cluster.platform.type=baremetal if UMN is not selected.
+    const resetPlatform = userManagedNetworking ? 'none' : 'baremetal';
+    const type = platformToIntegrate === undefined ? resetPlatform : platformToIntegrate;
     params.platform = {
       type,
     };

--- a/src/ocm/services/HostDiscoveryService.ts
+++ b/src/ocm/services/HostDiscoveryService.ts
@@ -11,7 +11,7 @@ const HostDiscoveryService = {
     params: V2ClusterUpdateParams,
     platformToIntegrate: SupportedPlatformType | undefined,
   ): void {
-    const type = platformToIntegrate === undefined ? 'baremetal' : platformToIntegrate;
+    const type = platformToIntegrate === undefined ? 'none' : platformToIntegrate;
     params.platform = {
       type,
     };


### PR DESCRIPTION
Fix to solve bug: https://issues.redhat.com/browse/MGMT-12424

The conditions to modify cluster.platform.type are:

-  if UMN isn't enabled than the update request should updated the cluster to cluster.platform.type = baremetal
-  if UMN is enabled than the update request should updated the cluster to cluster.platform.type = none