### PR TITLE
MGMT-12308: Adding additional requirements in minimum hardware modal

### DIFF
--- a/src/ocm/components/hosts/HostRequirementsContent.tsx
+++ b/src/ocm/components/hosts/HostRequirementsContent.tsx
@@ -67,6 +67,7 @@ const HostRequirementsContent = ({
           <br />
           <ExternalLink href={DISK_WRITE_SPEED_LINK}>Learn more</ExternalLink>
         </ListItem>
+        <ListItem>Operators might require additional resources.</ListItem>
       </List>
     );
   }


### PR DESCRIPTION
Related to : https://issues.redhat.com/browse/MGMT-12308
Minimum hardware modal does not mention additional requirements in case when operators are selected

![image](https://user-images.githubusercontent.com/11390125/199741493-cf520ecc-61b1-41b9-8009-938cec146652.png)
