### PR TITLE
BZ2119586: Hypeshift NetworkStep accepts initialValues as props

### DIFF
--- a/src/cim/components/Hypershift/HostedClusterWizard/NetworkStep/NetworkStep.tsx
+++ b/src/cim/components/Hypershift/HostedClusterWizard/NetworkStep/NetworkStep.tsx
@@ -33,9 +33,7 @@ const NetworkStep: React.FC<NetworkStepProps> = ({
   agents,
   formRef,
   onValuesChanged,
-  initAdvancedNetworking,
-  initSSHPublicKey = '',
-  isBMPlatform,
+  initialValues,
 }) => {
   const availableAgents = getAgentsForSelection(agents).filter(
     (a) => !a.spec.clusterDeploymentName,
@@ -43,20 +41,7 @@ const NetworkStep: React.FC<NetworkStepProps> = ({
 
   return (
     <Formik<NetworkFormValues>
-      initialValues={{
-        machineCIDR: '',
-        isAdvanced: initAdvancedNetworking,
-        sshPublicKey: initSSHPublicKey,
-        serviceCIDR: '172.31.0.0/16',
-        podCIDR: '10.132.0.0/14',
-        enableProxy: false,
-        httpProxy: '',
-        httpsProxy: '',
-        noProxy: '',
-        apiPublishingStrategy: isBMPlatform ? 'NodePort' : 'LoadBalancer',
-        nodePortPort: 0,
-        nodePortAddress: '',
-      }}
+      initialValues={initialValues}
       validationSchema={validationSchema}
       innerRef={formRef}
       onSubmit={noop}

--- a/src/cim/components/Hypershift/HostedClusterWizard/NetworkStep/index.ts
+++ b/src/cim/components/Hypershift/HostedClusterWizard/NetworkStep/index.ts
@@ -1,1 +1,2 @@
 export { default as HostedClusterNetworkStep } from './NetworkStep';
+export * from './types';

--- a/src/cim/components/Hypershift/HostedClusterWizard/NetworkStep/types.ts
+++ b/src/cim/components/Hypershift/HostedClusterWizard/NetworkStep/types.ts
@@ -22,8 +22,6 @@ export type NetworkStepProps = {
   agents: AgentK8sResource[];
   formRef: React.Ref<FormikProps<NetworkFormValues>>;
   onValuesChanged: (values: NetworkFormValues, initRender: boolean) => void;
-  initAdvancedNetworking: boolean;
-  initSSHPublicKey?: string;
+  initialValues: NetworkFormValues;
   count: number;
-  isBMPlatform: boolean;
 };


### PR DESCRIPTION
Motivation: Fix preserving values on Back in the Create Cluster wizard