### PR TITLE
MGMT-11369 - Hosts table overflows from its container's space

### DIFF
--- a/src/common/components/hosts/AITable.tsx
+++ b/src/common/components/hosts/AITable.tsx
@@ -15,6 +15,7 @@ import {
   IAction,
   ISeparator,
   TableProps,
+  InnerScrollContainer,
 } from '@patternfly/react-table';
 import { ExtraParamsType } from '@patternfly/react-table/dist/js/components/Table/base';
 import xor from 'lodash/xor';
@@ -49,23 +50,25 @@ const TableMemo: React.FC<WithTestID & TableMemoProps> = React.memo(
       canCollapseAll: false,
     };
     return (
-      <Table
-        rows={rows}
-        cells={cells}
-        onCollapse={onCollapse}
-        variant={TableVariant.compact}
-        aria-label="Hosts table"
-        className={classnames(className, 'hosts-table')}
-        sortBy={sortBy}
-        onSort={onSort}
-        rowWrapper={rowWrapper}
-        data-testid={testId}
-        actionResolver={actionResolver ? tableActionResolver : undefined}
-        {...newProps}
-      >
-        <TableHeader />
-        <TableBody rowKey={rowKey} />
-      </Table>
+      <InnerScrollContainer>
+        <Table
+          rows={rows}
+          cells={cells}
+          onCollapse={onCollapse}
+          variant={TableVariant.compact}
+          aria-label="Hosts table"
+          className={classnames(className, 'hosts-table')}
+          sortBy={sortBy}
+          onSort={onSort}
+          rowWrapper={rowWrapper}
+          data-testid={testId}
+          actionResolver={actionResolver ? tableActionResolver : undefined}
+          {...newProps}
+        >
+          <TableHeader />
+          <TableBody rowKey={rowKey} />
+        </Table>
+      </InnerScrollContainer>
     );
   },
 );

--- a/src/common/components/hosts/HostsTable.css
+++ b/src/common/components/hosts/HostsTable.css
@@ -13,3 +13,7 @@
 .hosts-table {
   height: 1rem; /* Workaround for: https://bugzilla.redhat.com/show_bug.cgi?id=1879378 in FF; The actual table height will be recalculated accordingly. */
 }
+
+table.hosts-table.pf-m-compact {
+  height: auto;
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-11369

A scrollbar will appear under the table if the parent container is too small. Applies to all tables.

**Before:**

https://user-images.githubusercontent.com/87187179/200327018-c3b2a01a-ef70-4e4e-b553-1cb190def5c7.mp4

After:

https://user-images.githubusercontent.com/87187179/200327047-f28c10c9-717a-46c1-ba8b-4bf6d4e3ca2b.mp4

