### PR TITLE
MGMT-11476: elements under advanced networking should be slightly indented

### DIFF
--- a/src/ocm/components/clusterConfiguration/networkConfiguration/AdvancedNetworkFields.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/AdvancedNetworkFields.tsx
@@ -52,7 +52,7 @@ const AdvancedNetworkFields = () => {
     isSubnetIPv6(index) ? IPv6PrefixHelperText : IPv4PrefixHelperText;
 
   return (
-    <Grid hasGutter>
+    <Grid hasGutter className="pf-u-ml-lg">
       <FieldArray name="clusterNetworks">
         {() => (
           <FormGroup fieldId="clusterNetworks" labelInfo={isDualStack && 'Primary'}>


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-11476
Elements under advanced networking should be slightly indented:
![image](https://user-images.githubusercontent.com/11390125/200821058-d1569ebc-a337-47b2-a9a4-d423c9caf4fc.png)
