### PR TITLE
MGMT-11432 : Add new line in use advanced networking before " Cluster network host prefix" text

### DIFF
--- a/src/ocm/components/clusterConfiguration/networkConfiguration/AdvancedNetworkFields.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/AdvancedNetworkFields.tsx
@@ -6,6 +6,7 @@ import {
   StackItem,
   TextInputTypes,
   Grid,
+  Stack,
 } from '@patternfly/react-core';
 import { FieldArray, useFormikContext } from 'formik';
 import { DUAL_STACK, PREFIX_MAX_RESTRICTION, NetworkConfigurationValues } from '../../../../common';
@@ -59,8 +60,8 @@ const AdvancedNetworkFields = () => {
             {values.clusterNetworks?.map((_, index) => {
               const networkSuffix = getNetworkLabelSuffix(index, isDualStack);
               return (
-                <>
-                  <StackItem key={index} className={'network-field-group pf-u-pb-md'}>
+                <Stack key={index}>
+                  <StackItem className={'network-field-group pf-u-pb-md'}>
                     <OcmInputField
                       name={`clusterNetworks.${index}.cidr`}
                       label={`Cluster network CIDR${networkSuffix}`}
@@ -69,7 +70,7 @@ const AdvancedNetworkFields = () => {
                       labelInfo={index === 0 && isDualStack ? 'Primary' : ''}
                     />
                   </StackItem>
-                  <StackItem key={index} className={'network-field-group pf-u-pb-md'}>
+                  <StackItem className={'network-field-group pf-u-pb-md'}>
                     <OcmInputField
                       name={`clusterNetworks.${index}.hostPrefix`}
                       label={`Cluster network host prefix${networkSuffix}`}
@@ -87,7 +88,7 @@ const AdvancedNetworkFields = () => {
                       isRequired
                     />
                   </StackItem>
-                </>
+                </Stack>
               );
             })}
           </FormGroup>

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/AdvancedNetworkFields.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/AdvancedNetworkFields.tsx
@@ -59,32 +59,35 @@ const AdvancedNetworkFields = () => {
             {values.clusterNetworks?.map((_, index) => {
               const networkSuffix = getNetworkLabelSuffix(index, isDualStack);
               return (
-                <StackItem key={index} className={'network-field-group'}>
-                  <OcmInputField
-                    name={`clusterNetworks.${index}.cidr`}
-                    label={`Cluster network CIDR${networkSuffix}`}
-                    helperText={clusterCidrHelperText}
-                    isRequired
-                    labelInfo={index === 0 && isDualStack ? 'Primary' : ''}
-                  />
-                  <br />
-                  <OcmInputField
-                    name={`clusterNetworks.${index}.hostPrefix`}
-                    label={`Cluster network host prefix${networkSuffix}`}
-                    type={TextInputTypes.number}
-                    min={clusterNetworkCidrPrefix(index)}
-                    max={
-                      isSubnetIPv6(index)
-                        ? PREFIX_MAX_RESTRICTION.IPv6
-                        : PREFIX_MAX_RESTRICTION.IPv4
-                    }
-                    onBlur={(e: React.ChangeEvent<HTMLInputElement>) =>
-                      formatClusterNetworkHostPrefix(e, index)
-                    }
-                    helperText={clusterNetworkHostPrefixHelperText(index)}
-                    isRequired
-                  />
-                </StackItem>
+                <>
+                  <StackItem key={index} className={'network-field-group pf-u-pb-md'}>
+                    <OcmInputField
+                      name={`clusterNetworks.${index}.cidr`}
+                      label={`Cluster network CIDR${networkSuffix}`}
+                      helperText={clusterCidrHelperText}
+                      isRequired
+                      labelInfo={index === 0 && isDualStack ? 'Primary' : ''}
+                    />
+                  </StackItem>
+                  <StackItem key={index} className={'network-field-group pf-u-pb-md'}>
+                    <OcmInputField
+                      name={`clusterNetworks.${index}.hostPrefix`}
+                      label={`Cluster network host prefix${networkSuffix}`}
+                      type={TextInputTypes.number}
+                      min={clusterNetworkCidrPrefix(index)}
+                      max={
+                        isSubnetIPv6(index)
+                          ? PREFIX_MAX_RESTRICTION.IPv6
+                          : PREFIX_MAX_RESTRICTION.IPv4
+                      }
+                      onBlur={(e: React.ChangeEvent<HTMLInputElement>) =>
+                        formatClusterNetworkHostPrefix(e, index)
+                      }
+                      helperText={clusterNetworkHostPrefixHelperText(index)}
+                      isRequired
+                    />
+                  </StackItem>
+                </>
               );
             })}
           </FormGroup>
@@ -99,7 +102,7 @@ const AdvancedNetworkFields = () => {
         {() => (
           <FormGroup fieldId="serviceNetworks" labelInfo={isDualStack && 'Primary'}>
             {values.serviceNetworks?.map((_, index) => (
-              <StackItem key={index} className={'network-field-group'}>
+              <StackItem key={index} className={'network-field-group pf-u-pb-md'}>
                 <OcmInputField
                   name={`serviceNetworks.${index}.cidr`}
                   label={`Service network CIDR${getNetworkLabelSuffix(index, isDualStack)}`}

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/AdvancedNetworkFields.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/AdvancedNetworkFields.tsx
@@ -67,6 +67,7 @@ const AdvancedNetworkFields = () => {
                     isRequired
                     labelInfo={index === 0 && isDualStack ? 'Primary' : ''}
                   />
+                  <br />
                   <OcmInputField
                     name={`clusterNetworks.${index}.hostPrefix`}
                     label={`Cluster network host prefix${networkSuffix}`}


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-11432
Add spaces between fields in advanced networking:
1. No dual-stack cluster:

![image](https://user-images.githubusercontent.com/11390125/201085336-83a3e40b-0837-4213-bb05-b5698a9fb724.png)

2. Dual-stack cluster:
![image](https://user-images.githubusercontent.com/11390125/201109630-dce6028d-8e91-41d6-9e05-b48921b77ace.png)