### PR TITLE
MGMT-12075 block wizard if cluster polling fails

### DIFF
--- a/src/ocm/api/utils.ts
+++ b/src/ocm/api/utils.ts
@@ -1,9 +1,13 @@
+import Axios, { AxiosError } from 'axios';
 import { Severity } from '@sentry/browser';
-import Axios from 'axios';
 import pick from 'lodash/pick';
 import { captureException } from '../sentry';
 import { isApiError } from './types';
 import { getErrorMessage } from '../../common/utils';
+import { isAxiosError } from './axiosExtensions';
+
+export const FETCH_ABORTED_ERROR_CODE = 'ERR_CANCELED';
+export const FETCH_CONNECTIVITY_ERROR_CODE = 'CONNECTIVITY_ERROR';
 
 type OnError = (arg0: unknown) => void;
 
@@ -45,4 +49,21 @@ export const getApiErrorMessage = (error: unknown): string => {
     return error.response?.data?.message || error.response?.data.reason || error.message;
   }
   return getErrorMessage(error);
+};
+
+export const getApiErrorCode = (error: Error | AxiosError): string | number => {
+  if (!isAxiosError(error)) {
+    return FETCH_CONNECTIVITY_ERROR_CODE;
+  }
+  const responseStatus = error.response?.status || 0;
+  // Error status
+  if (responseStatus >= 400 && responseStatus < 500) {
+    return responseStatus;
+  }
+  // Aborted request
+  if (error.code === FETCH_ABORTED_ERROR_CODE) {
+    return FETCH_ABORTED_ERROR_CODE;
+  }
+  // A generic connectivity issue
+  return FETCH_CONNECTIVITY_ERROR_CODE;
 };

--- a/src/ocm/api/utils.ts
+++ b/src/ocm/api/utils.ts
@@ -37,7 +37,7 @@ export const handleApiError = (error: unknown, onError?: OnError): void => {
   } else {
     captureException(error);
   }
-  if (onError) onError(error);
+  if (onError) return onError(error);
 };
 
 export const getApiErrorMessage = (error: unknown): string => {

--- a/src/ocm/components/clusterConfiguration/ClusterDefaultConfigurationContext.tsx
+++ b/src/ocm/components/clusterConfiguration/ClusterDefaultConfigurationContext.tsx
@@ -54,7 +54,7 @@ export const ClusterDefaultConfigurationProvider = ({
     return () => {
       mounted = false;
     };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []);
 
   const render = (state: State<ClusterDefaultConfig>) => {
     let result: {

--- a/src/ocm/components/clusterDetail/ClusterPollingErrorModal.tsx
+++ b/src/ocm/components/clusterDetail/ClusterPollingErrorModal.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Modal, ModalVariant } from '@patternfly/react-core';
+
+const ClusterPollingErrorModal = () => {
+  // TODO not fully implemented
+  // TODO check what happens if a request is willingly aborted by us
+  const onClose = () => {
+    console.log('%c should close', 'font-size: 16px; color: red');
+  };
+
+  return (
+    <Modal
+      title="The cluster details could not be updated"
+      isOpen
+      variant={ModalVariant.small}
+      onClose={onClose}
+    >
+      This means that you wouldn't be able to see the latest cluster status. We are trying to update
+      your cluster details. Please wait for this window to close, or <a>retry now</a>
+    </Modal>
+  );
+};
+
+export default ClusterPollingErrorModal;

--- a/src/ocm/components/clusterDetail/ClusterPollingErrorModal.tsx
+++ b/src/ocm/components/clusterDetail/ClusterPollingErrorModal.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { Modal, ModalVariant } from '@patternfly/react-core';
 
 const ClusterPollingErrorModal = () => {
-  // TODO not fully implemented
-  // TODO check what happens if a request is willingly aborted by us
+  // TODO camador needs correct copy and to implement the retry action if there will be one
   const onClose = () => {
     console.log('%c should close', 'font-size: 16px; color: red');
   };

--- a/src/ocm/components/clusters/ClusterLoading.tsx
+++ b/src/ocm/components/clusters/ClusterLoading.tsx
@@ -1,0 +1,11 @@
+import { PageSection, PageSectionVariants } from '@patternfly/react-core';
+import { LoadingState } from '../../../common';
+import React from 'react';
+
+const ClusterLoading = () => (
+  <PageSection variant={PageSectionVariants.light} isFilled>
+    <LoadingState />
+  </PageSection>
+);
+
+export default ClusterLoading;

--- a/src/ocm/components/clusters/ClusterPage.tsx
+++ b/src/ocm/components/clusters/ClusterPage.tsx
@@ -1,13 +1,6 @@
 import React from 'react';
-import { Link, Redirect, RouteComponentProps } from 'react-router-dom';
-import {
-  Button,
-  ButtonVariant,
-  PageSection,
-  PageSectionVariants,
-  Text,
-  TextContent,
-} from '@patternfly/react-core';
+import { Redirect, RouteComponentProps } from 'react-router-dom';
+import { PageSection, PageSectionVariants, Text, TextContent } from '@patternfly/react-core';
 import {
   AddHostsContextProvider,
   AlertsContextProvider,
@@ -15,7 +8,6 @@ import {
   CpuArchitecture,
   ErrorState,
   InfraEnv,
-  LoadingState,
   ResourceUIState,
 } from '../../../common';
 import ClusterDetail from '../clusterDetail/ClusterDetail';
@@ -28,12 +20,15 @@ import ClusterWizard from '../clusterWizard/ClusterWizard';
 import { ModalDialogsContextProvider } from '../hosts/ModalDialogsContext';
 import { useClusterPolling, useFetchCluster } from './clusterPolling';
 import { DiscoveryImageModal } from '../clusterConfiguration/DiscoveryImageModal';
-import { isSingleClusterMode, routeBasePath } from '../../config';
+import { routeBasePath } from '../../config';
 import { FeatureSupportLevelProvider } from '../featureSupportLevels';
 import ClusterWizardContextProvider from '../clusterWizard/ClusterWizardContextProvider';
 import useInfraEnv from '../../hooks/useInfraEnv';
 import { SentryErrorMonitorContextProvider } from '../SentryErrorMonitorContextProvider';
 import { forceReload } from '../../reducers/clusters';
+import { getErrorStateActions, ClusterUiError } from './ClusterPageErrors';
+import ClusterLoading from './ClusterLoading';
+import ClusterPollingErrorModal from '../clusterDetail/ClusterPollingErrorModal';
 
 type MatchParams = {
   clusterId: string;
@@ -49,18 +44,7 @@ const ClusterPage: React.FC<RouteComponentProps<MatchParams>> = ({ match }) => {
     error: infraEnvError,
     updateInfraEnv,
   } = useInfraEnv(clusterId, CpuArchitecture.USE_DAY1_ARCHITECTURE);
-  const errorStateActions = [];
-  if (!isSingleClusterMode()) {
-    errorStateActions.push(
-      <Button
-        key="cancel"
-        variant={ButtonVariant.secondary}
-        component={(props) => <Link to={`${routeBasePath}/clusters`} {...props} />}
-      >
-        Back
-      </Button>,
-    );
-  }
+
   const getContent = (cluster: Cluster, infraEnv: InfraEnv) => {
     if (cluster.status === 'adding-hosts') {
       return (
@@ -117,21 +101,14 @@ const ClusterPage: React.FC<RouteComponentProps<MatchParams>> = ({ match }) => {
     }
   };
 
-  const loadingUI = (
-    <PageSection variant={PageSectionVariants.light} isFilled>
-      <LoadingState />
-    </PageSection>
-  );
-
   if (uiState === ResourceUIState.LOADING || infraEnvLoading) {
-    return loadingUI;
+    return <ClusterLoading />;
   }
 
-  if (uiState === ResourceUIState.ERROR) {
+  if (uiState === ResourceUIState.ERROR && !cluster) {
     if (Number(errorDetail?.code) === 404) {
       return <Redirect to={`${routeBasePath}/clusters`} />;
     }
-
     return (
       <PageSection variant={PageSectionVariants.light} isFilled>
         <ErrorState
@@ -139,7 +116,7 @@ const ClusterPage: React.FC<RouteComponentProps<MatchParams>> = ({ match }) => {
           fetchData={
             Number(errorDetail?.code) === 401 ? () => window.location.reload() : fetchCluster
           }
-          actions={errorStateActions}
+          actions={getErrorStateActions()}
         />
       </PageSection>
     );
@@ -150,7 +127,7 @@ const ClusterPage: React.FC<RouteComponentProps<MatchParams>> = ({ match }) => {
       <PageSection variant={PageSectionVariants.light} isFilled>
         <ErrorState
           title="Cluster not found"
-          actions={errorStateActions}
+          actions={getErrorStateActions()}
           content={
             'Check to make sure the cluster-ID is valid. Otherwise, the cluster may have been deleted.'
           }
@@ -159,23 +136,19 @@ const ClusterPage: React.FC<RouteComponentProps<MatchParams>> = ({ match }) => {
     );
   }
 
-  const errorUI = (
-    <PageSection variant={PageSectionVariants.light} isFilled>
-      <ErrorState
-        title="Failed to retrieve the default configuration"
-        actions={errorStateActions}
-      />
-    </PageSection>
-  );
-
   if (cluster && infraEnv) {
+    const isOutdatedClusterData = uiState === ResourceUIState.ERROR;
     return (
       <AlertsContextProvider>
         <SentryErrorMonitorContextProvider>
           <ModalDialogsContextProvider>
-            <ClusterDefaultConfigurationProvider loadingUI={loadingUI} errorUI={errorUI}>
-              <FeatureSupportLevelProvider loadingUi={loadingUI} cluster={cluster}>
+            <ClusterDefaultConfigurationProvider
+              loadingUI={<ClusterLoading />}
+              errorUI={<ClusterUiError />}
+            >
+              <FeatureSupportLevelProvider loadingUi={<ClusterLoading />} cluster={cluster}>
                 {getContent(cluster, infraEnv)}
+                {isOutdatedClusterData && <ClusterPollingErrorModal />}
                 <CancelInstallationModal />
                 <ResetClusterModal />
                 <DiscoveryImageModal />

--- a/src/ocm/components/clusters/ClusterPage.tsx
+++ b/src/ocm/components/clusters/ClusterPage.tsx
@@ -29,6 +29,7 @@ import { forceReload } from '../../reducers/clusters';
 import { getErrorStateActions, ClusterUiError } from './ClusterPageErrors';
 import ClusterLoading from './ClusterLoading';
 import ClusterPollingErrorModal from '../clusterDetail/ClusterPollingErrorModal';
+import { ClustersAPI } from '../../services/apis';
 
 type MatchParams = {
   clusterId: string;

--- a/src/ocm/components/clusters/ClusterPage.tsx
+++ b/src/ocm/components/clusters/ClusterPage.tsx
@@ -29,7 +29,6 @@ import { forceReload } from '../../reducers/clusters';
 import { getErrorStateActions, ClusterUiError } from './ClusterPageErrors';
 import ClusterLoading from './ClusterLoading';
 import ClusterPollingErrorModal from '../clusterDetail/ClusterPollingErrorModal';
-import { ClustersAPI } from '../../services/apis';
 
 type MatchParams = {
   clusterId: string;

--- a/src/ocm/components/clusters/ClusterPageErrors.tsx
+++ b/src/ocm/components/clusters/ClusterPageErrors.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Button, ButtonVariant, PageSection, PageSectionVariants } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+import { ErrorState } from '../../../common';
+import { isSingleClusterMode, routeBasePath } from '../../config';
+
+export const getErrorStateActions = () => {
+  if (isSingleClusterMode()) {
+    return [];
+  }
+
+  return [
+    <Button
+      key="cancel"
+      variant={ButtonVariant.secondary}
+      component={(props) => <Link to={`${routeBasePath}/clusters`} {...props} />}
+    >
+      Back
+    </Button>,
+  ];
+};
+
+export const ClusterUiError = () => (
+  <PageSection variant={PageSectionVariants.light} isFilled>
+    <ErrorState
+      title="Failed to retrieve the default configuration"
+      actions={getErrorStateActions()}
+    />
+  </PageSection>
+);

--- a/src/ocm/components/clusters/NewClusterPage.tsx
+++ b/src/ocm/components/clusters/NewClusterPage.tsx
@@ -1,50 +1,24 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
-import {
-  PageSectionVariants,
-  TextContent,
-  Text,
-  Button,
-  ButtonVariant,
-  PageSection,
-} from '@patternfly/react-core';
-import { AlertsContextProvider, ErrorState, LoadingState } from '../../../common';
+import { PageSectionVariants, TextContent, Text, PageSection } from '@patternfly/react-core';
+import { AlertsContextProvider } from '../../../common';
 import ClusterBreadcrumbs from './ClusterBreadcrumbs';
 import { ClusterDefaultConfigurationProvider } from '../clusterConfiguration/ClusterDefaultConfigurationContext';
 import NewClusterWizard from '../clusterWizard/NewClusterWizard';
-import { routeBasePath } from '../../config';
 import { FeatureSupportLevelProvider } from '../featureSupportLevels';
 import ClusterWizardContextProvider from '../clusterWizard/ClusterWizardContextProvider';
 import { SentryErrorMonitorContextProvider } from '../SentryErrorMonitorContextProvider';
-const loadingUI = (
-  <PageSection variant={PageSectionVariants.light} isFilled>
-    <LoadingState />
-  </PageSection>
-);
+import ClusterLoading from './ClusterLoading';
+import { ClusterUiError } from './ClusterPageErrors';
 
-const errorUI = (
-  <PageSection variant={PageSectionVariants.light} isFilled>
-    <ErrorState
-      title="Failed to retrieve the default configuration"
-      actions={[
-        <Button
-          key="cancel"
-          variant={ButtonVariant.secondary}
-          component={(props) => <Link to={`${routeBasePath}/clusters`} {...props} />}
-        >
-          Back
-        </Button>,
-      ]}
-    />
-  </PageSection>
-);
-
-const NewClusterPage: React.FC = () => {
+const NewClusterPage = () => {
   return (
     <AlertsContextProvider>
       <SentryErrorMonitorContextProvider>
-        <ClusterDefaultConfigurationProvider loadingUI={loadingUI} errorUI={errorUI}>
-          <FeatureSupportLevelProvider loadingUi={loadingUI}>
+        <ClusterDefaultConfigurationProvider
+          loadingUI={<ClusterLoading />}
+          errorUI={<ClusterUiError />}
+        >
+          <FeatureSupportLevelProvider loadingUi={<ClusterLoading />}>
             <ClusterBreadcrumbs clusterName="New cluster" />
             <PageSection variant={PageSectionVariants.light}>
               <TextContent>

--- a/src/ocm/components/clusters/clusterPolling.ts
+++ b/src/ocm/components/clusters/clusterPolling.ts
@@ -1,15 +1,14 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { Cluster, POLLING_INTERVAL } from '../../../common';
+import { Cluster, ResourceUIState, POLLING_INTERVAL } from '../../../common';
 import {
   fetchClusterAsync,
   cleanCluster,
   forceReload,
   cancelForceReload,
-  RetrievalErrorType,
-} from '../../reducers/clusters/currentClusterSlice';
+  FetchErrorType,
+} from '../../reducers/clusters';
 import { selectCurrentClusterState } from '../../selectors';
-import { ResourceUIState } from '../../../common';
 
 export const useFetchCluster = (clusterId: string) => {
   const dispatch = useDispatch();
@@ -21,7 +20,7 @@ export const useClusterPolling = (
 ): {
   cluster: Cluster | undefined;
   uiState: ResourceUIState;
-  errorDetail: RetrievalErrorType | undefined;
+  errorDetail: FetchErrorType | undefined;
 } => {
   const { isReloadScheduled, uiState, data, errorDetail } = useSelector(selectCurrentClusterState);
   const dispatch = useDispatch();

--- a/src/ocm/components/clusters/clusterPolling.ts
+++ b/src/ocm/components/clusters/clusterPolling.ts
@@ -29,11 +29,7 @@ export const useClusterPolling = (
 
   React.useEffect(() => {
     if (isReloadScheduled) {
-      const bannedUIStates = [
-        ResourceUIState.LOADING,
-        ResourceUIState.RELOADING,
-        ResourceUIState.ERROR,
-      ];
+      const bannedUIStates = [ResourceUIState.LOADING, ResourceUIState.RELOADING];
       if (!bannedUIStates.includes(uiState)) {
         fetchCluster();
       }

--- a/src/ocm/reducers/clusters/currentClusterSlice.ts
+++ b/src/ocm/reducers/clusters/currentClusterSlice.ts
@@ -2,10 +2,9 @@ import findIndex from 'lodash/findIndex';
 import set from 'lodash/set';
 import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
 import { AssistedInstallerPermissionTypesListType, Cluster, Host } from '../../../common';
-import { handleApiError } from '../../api/utils';
+import { getApiErrorMessage, handleApiError } from '../../api';
 import { ResourceUIState } from '../../../common';
 import { ClustersService } from '../../services';
-import { isApiError } from '../../api/types';
 
 export type RetrievalErrorType = {
   code: string;
@@ -30,8 +29,9 @@ export const fetchClusterAsync = createAsyncThunk<
     const cluster = await ClustersService.get(clusterId);
     return cluster;
   } catch (e) {
-    handleApiError(e, () => {
-      return isApiError(e) && e.response?.data && rejectWithValue(e.response?.data);
+    return handleApiError(e, () => {
+      const rejectError = getApiErrorMessage(e);
+      return rejectWithValue(rejectError as unknown as RetrievalErrorType);
     });
   }
 });

--- a/src/ocm/reducers/clusters/currentClusterSlice.ts
+++ b/src/ocm/reducers/clusters/currentClusterSlice.ts
@@ -114,11 +114,12 @@ export const currentClusterSlice = createSlice({
       })
       .addCase(fetchClusterAsync.rejected, (state, action) => {
         const error = action.payload as FetchErrorType;
-        if (error.code === FETCH_ABORTED_ERROR_CODE) {
-          // The request was aborted as the cluster was being updated by PATCH / DELETE etc requests
+        if (error.code === FETCH_ABORTED_ERROR_CODE && !!state.data) {
+          // This failure is due to having aborted the request on purpose (to avoid conflicts with update operations).
+          // The error can be ignored, and the data will be refreshed on the next polling
           return {
             ...state,
-            uiState: state.data ? ResourceUIState.LOADED : ResourceUIState.LOADED,
+            uiState: ResourceUIState.LOADED,
           };
         }
         return {


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-12075

When the cluster polling fails due to Network / API down issues, we may be showing outdated cluster information to the user.
To ensure the cluster data integrity, we want to stop the user from interacting with the UI until the connectivity has been restored.

We need to show a new modal to the user when the cluster data may be out of date, due to network error. But we don't want to show it in other cases, such as when we abort a polling request during some update operations.

Therefore, we need to handle error types differently:
1. Error 40x --> custom error state (I don't think this worked before as we were not pass the `code` field to the `errorDetail` object)
2. Aborted request -->These errors are ignored, as the cluster may be updated from the write operation, or if not, it will be in the next polling.
3. Network errors, etc --> the `uiState` is set to  `ERROR`. We don't interrupt the polling if we already had cluster data, which means that the moment the connectivity is restored, the modal will close automatically. 
