### PR TITLE
MGMT-11562: Better message when an infraenv cannot be retrieved

### DIFF
--- a/src/ocm/components/clusters/ClusterPage.tsx
+++ b/src/ocm/components/clusters/ClusterPage.tsx
@@ -148,7 +148,13 @@ const ClusterPage: React.FC<RouteComponentProps<MatchParams>> = ({ match }) => {
   if (infraEnvError) {
     return (
       <PageSection variant={PageSectionVariants.light} isFilled>
-        <ErrorState title="Failed to fetch the infra env" actions={errorStateActions} />
+        <ErrorState
+          title="Cluster not found"
+          actions={errorStateActions}
+          content={
+            'Check to make sure the cluster-ID is valid. Otherwise, the cluster may have been deleted.'
+          }
+        />
       </PageSection>
     );
   }


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/MGMT-11562

New message when cluster is not found:

![image](https://user-images.githubusercontent.com/11390125/201341362-ffd5b958-c041-49e2-99b1-d577b3032119.png)
