### PR TITLE
MGMT-12536: Skip sending a PR to assisted-ui when a new CIM release is created (Fix)

### DIFF
--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -75,7 +75,7 @@ jobs:
         run: yarn publish --no-git-tag-version
 
   bump-openshift-assisted-ui-lib-in-assisted-ui:
-    if: ${{ !endsWith(env.NEW_VERSION, '-cim') }}
+    if: ${{ !endsWith(github.ref_name, '-cim') }}
     needs: publish-to-npm
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
Fix for  25540e761512a8498fadf650c7e17ec193096791 and 65789370f80d6dab8d808bdcbceee13bb8dd8172
