### PR TITLE
MGMT-12597: Update the user instructions link in the UI for Nutanix post deployment

### DIFF
--- a/src/common/config/constants.ts
+++ b/src/common/config/constants.ts
@@ -307,3 +307,5 @@ export const OCP_STATIC_IP_DOC =
 export const AI_UI_TAG = 'ui_ocm';
 
 export const OCP_RELEASES_PAGE = 'openshift/releases';
+
+export const NUTANIX_CONFIG_LINK = 'https://access.redhat.com/solutions/6983944';

--- a/src/ocm/components/clusterConfiguration/ReviewCluster.tsx
+++ b/src/ocm/components/clusterConfiguration/ReviewCluster.tsx
@@ -19,19 +19,29 @@ import {
   HostsValidations,
   isDualStack,
   isClusterPlatformTypeVM,
+  NUTANIX_CONFIG_LINK,
 } from '../../../common';
 import { wizardStepNames } from '../clusterWizard/constants';
 import './ReviewCluster.css';
 import OpenShiftVersionDetail from '../clusterDetail/OpenShiftVersionDetail';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
+import useClusterSupportedPlatforms, {
+  SupportedPlatformIntegrationType,
+} from '../../hooks/useClusterSupportedPlatforms';
 
-const PlatformIntegrationNote = () => {
+const PlatformIntegrationNote = ({
+  supportedPlatformIntegration,
+}: {
+  supportedPlatformIntegration: SupportedPlatformIntegrationType;
+}) => {
   return (
     <p>
       <ExclamationTriangleIcon color={warningColor.value} size="sm" /> You will need to modify your
       platform configuration after cluster installation is completed.{' '}
       <a
-        href={VSPHERE_CONFIG_LINK}
+        href={
+          supportedPlatformIntegration === 'nutanix' ? NUTANIX_CONFIG_LINK : VSPHERE_CONFIG_LINK
+        }
         target="_blank"
         rel="noopener noreferrer"
         data-ouia-component-id="vm-integration-kb-page"
@@ -45,6 +55,7 @@ const PlatformIntegrationNote = () => {
 const ReviewCluster = ({ cluster }: { cluster: Cluster }) => {
   const clusterWizardContext = useClusterWizardContext();
   const { t } = useTranslation();
+  const { supportedPlatformIntegration } = useClusterSupportedPlatforms(cluster.id);
   return (
     <DetailList>
       <DetailItem
@@ -112,7 +123,9 @@ const ReviewCluster = ({ cluster }: { cluster: Cluster }) => {
       <RenderIf condition={isClusterPlatformTypeVM(cluster)}>
         <DetailItem
           title="Platform integration"
-          value={<PlatformIntegrationNote />}
+          value={
+            <PlatformIntegrationNote supportedPlatformIntegration={supportedPlatformIntegration} />
+          }
           testId="platform-integration"
         />
       </RenderIf>

--- a/src/ocm/components/clusterConfiguration/ReviewCluster.tsx
+++ b/src/ocm/components/clusterConfiguration/ReviewCluster.tsx
@@ -13,35 +13,30 @@ import {
   DetailList,
   DetailItem,
   RenderIf,
-  VSPHERE_CONFIG_LINK,
   ReviewHostsInventory,
   ClusterValidations,
   HostsValidations,
   isDualStack,
   isClusterPlatformTypeVM,
-  NUTANIX_CONFIG_LINK,
+  PlatformType,
 } from '../../../common';
 import { wizardStepNames } from '../clusterWizard/constants';
 import './ReviewCluster.css';
 import OpenShiftVersionDetail from '../clusterDetail/OpenShiftVersionDetail';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
-import useClusterSupportedPlatforms, {
-  SupportedPlatformIntegrationType,
-} from '../../hooks/useClusterSupportedPlatforms';
+import { integrationPlatformLinks } from '../clusterWizard/ClusterPlatformIntegrationHint';
 
-const PlatformIntegrationNote = ({
-  supportedPlatformIntegration,
-}: {
-  supportedPlatformIntegration: SupportedPlatformIntegrationType;
-}) => {
+const PlatformIntegrationNote = ({ platformType }: { platformType: PlatformType | undefined }) => {
+  const integrationPlatformLink: string = platformType
+    ? (integrationPlatformLinks[platformType] as string)
+    : '';
+
   return (
     <p>
       <ExclamationTriangleIcon color={warningColor.value} size="sm" /> You will need to modify your
       platform configuration after cluster installation is completed.{' '}
       <a
-        href={
-          supportedPlatformIntegration === 'nutanix' ? NUTANIX_CONFIG_LINK : VSPHERE_CONFIG_LINK
-        }
+        href={integrationPlatformLink}
         target="_blank"
         rel="noopener noreferrer"
         data-ouia-component-id="vm-integration-kb-page"
@@ -55,7 +50,6 @@ const PlatformIntegrationNote = ({
 const ReviewCluster = ({ cluster }: { cluster: Cluster }) => {
   const clusterWizardContext = useClusterWizardContext();
   const { t } = useTranslation();
-  const { supportedPlatformIntegration } = useClusterSupportedPlatforms(cluster.id);
   return (
     <DetailList>
       <DetailItem
@@ -123,9 +117,7 @@ const ReviewCluster = ({ cluster }: { cluster: Cluster }) => {
       <RenderIf condition={isClusterPlatformTypeVM(cluster)}>
         <DetailItem
           title="Platform integration"
-          value={
-            <PlatformIntegrationNote supportedPlatformIntegration={supportedPlatformIntegration} />
-          }
+          value={<PlatformIntegrationNote platformType={cluster.platform?.type} />}
           testId="platform-integration"
         />
       </RenderIf>

--- a/src/ocm/components/clusterWizard/ClusterPlatformIntegrationHint.tsx
+++ b/src/ocm/components/clusterWizard/ClusterPlatformIntegrationHint.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { Alert, AlertVariant } from '@patternfly/react-core';
 import { useClusterSupportedPlatforms } from '../../hooks';
-import { isClusterPlatformTypeVM, PlatformType, SupportedPlatformType } from '../../../common';
+import {
+  isClusterPlatformTypeVM,
+  NUTANIX_CONFIG_LINK,
+  PlatformType,
+  SupportedPlatformType,
+  VSPHERE_CONFIG_LINK,
+} from '../../../common';
 
 type ClusterPlatformIntegrationHintProps = {
   clusterId: string;
@@ -11,6 +17,11 @@ type ClusterPlatformIntegrationHintProps = {
 const integrationBrands: Record<SupportedPlatformType, string> = {
   vsphere: 'vSphere',
   nutanix: 'Nutanix',
+};
+
+export const integrationPlatformLinks: Record<SupportedPlatformType, string> = {
+  vsphere: VSPHERE_CONFIG_LINK,
+  nutanix: NUTANIX_CONFIG_LINK,
 };
 
 export const ClusterPlatformIntegrationHint = ({


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-12597

The link for Nutanix is added in this page ("Review and create"):
![review_create_link_nutanix](https://user-images.githubusercontent.com/11390125/203076441-1ffce481-d199-47fa-899a-00b76bd1f7c0.png)

When platform.type='vsphere' the link "Learn more" is: 
https://access.redhat.com/solutions/6677901

and when platform.type='nutanix' the link "Learn more" is: 
https://access.redhat.com/solutions/6983944