### PR TITLE
MGMT-12311: LMV + CNV fixes

### DIFF
--- a/src/ocm/components/clusterConfiguration/operators/CnvCheckbox.tsx
+++ b/src/ocm/components/clusterConfiguration/operators/CnvCheckbox.tsx
@@ -6,13 +6,12 @@ import {
   ClusterOperatorProps,
   CNV_LINK,
   getFieldId,
-  OPERATOR_NAME_CNV,
   OperatorsValues,
   PopoverIcon,
   useFeatureSupportLevel,
 } from '../../../../common';
 import CnvHostRequirements from './CnvHostRequirements';
-import { getCnvAndLvmIncompatibilityReason } from '../../featureSupportLevels/featureStateUtils';
+import { getCnvIncompatibleWithLvmReason } from '../../featureSupportLevels/featureStateUtils';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
 
 const CNV_FIELD_NAME = 'useContainerNativeVirtualization';
@@ -53,7 +52,8 @@ const CnvCheckbox = ({ clusterId, openshiftVersion }: ClusterOperatorProps) => {
     if (openshiftVersion) {
       reason = featureSupportLevel.getFeatureDisabledReason(openshiftVersion, 'CNV');
       if (!reason) {
-        reason = getCnvAndLvmIncompatibilityReason(values, openshiftVersion, OPERATOR_NAME_CNV);
+        const lvmSupport = featureSupportLevel.getFeatureSupportLevel(openshiftVersion, 'LVM');
+        reason = getCnvIncompatibleWithLvmReason(values, openshiftVersion, lvmSupport);
       }
     }
     setDisabledReason(reason);

--- a/src/ocm/components/clusterConfiguration/operators/LvmCheckbox.tsx
+++ b/src/ocm/components/clusterConfiguration/operators/LvmCheckbox.tsx
@@ -5,13 +5,12 @@ import {
   ClusterOperatorProps,
   FeatureSupportLevelBadge,
   getFieldId,
-  OPERATOR_NAME_LVM,
   OperatorsValues,
   PopoverIcon,
   useFeatureSupportLevel,
 } from '../../../../common';
 import LvmHostRequirements from './LvmHostRequirements';
-import { getCnvAndLvmIncompatibilityReason } from '../../featureSupportLevels/featureStateUtils';
+import { getLvmIncompatibleWithCnvReason } from '../../featureSupportLevels/featureStateUtils';
 import { OcmCheckboxField } from '../../ui/OcmFormFields';
 
 const LVM_FIELD_NAME = 'useOdfLogicalVolumeManager';
@@ -40,7 +39,8 @@ const LvmCheckbox = ({ clusterId, openshiftVersion }: ClusterOperatorProps) => {
     if (openshiftVersion) {
       reason = featureSupportLevel.getFeatureDisabledReason(openshiftVersion, 'LVM');
       if (!reason) {
-        reason = getCnvAndLvmIncompatibilityReason(values, openshiftVersion, OPERATOR_NAME_LVM);
+        const lvmSupport = featureSupportLevel.getFeatureSupportLevel(openshiftVersion, 'LVM');
+        reason = getLvmIncompatibleWithCnvReason(values, openshiftVersion, lvmSupport);
       }
     }
     setDisabledReason(reason);

--- a/src/ocm/components/clusterWizard/Operators.tsx
+++ b/src/ocm/components/clusterWizard/Operators.tsx
@@ -93,9 +93,10 @@ const Operators = ({ cluster }: { cluster: Cluster }) => {
         olmOperators: enabledOperators,
       });
 
-      const updatedOperators = OperatorsService.getOLMOperators(values, updatedCluster);
-
-      const needSyncOperators = OperatorsService.syncOperators(enabledOperators, updatedOperators);
+      const needSyncOperators = OperatorsService.syncOperators(
+        enabledOperators,
+        updatedCluster.monitoredOperators,
+      );
       Object.keys(needSyncOperators).forEach((operatorName) => {
         setFieldValue(operatorName, true);
       });

--- a/src/ocm/services/OperatorsService.tsx
+++ b/src/ocm/services/OperatorsService.tsx
@@ -43,17 +43,16 @@ const OperatorsService = {
    */
   syncOperators(
     uiOperators: OperatorCreateParams[],
-    updatedOperators: OperatorCreateParams[],
+    updatedOperators: Cluster['monitoredOperators'],
   ): Partial<OperatorsValues> {
     // LVM operator can be automatically selected depending on Openshift version + other operators
-    const prevInactive = uiOperators?.find((op) => op.name === OPERATOR_NAME_LVM);
-    const nowActive = updatedOperators?.find((op) => op.name === OPERATOR_NAME_LVM);
+    const prevInactive = uiOperators?.find((op) => op.name === OPERATOR_NAME_LVM) === undefined;
+    const nowActive = updatedOperators?.find((op) => op.name === OPERATOR_NAME_LVM) !== undefined;
 
     const updates: Partial<OperatorsValues> = {};
     if (prevInactive && nowActive) {
       updates.useOdfLogicalVolumeManager = true;
     }
-
     return updates;
   },
 };


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-12311

Fixes related to operators CNV and LVM:

- The detection of LVM being automatically added on the API after selecting CNV on a 4.12 SNO was not working. It's fixed now

- The detection of when to disable CNV and which message to show was not 100% accurate, now:
 * For an SNO with version 4.11 or below --> If CNV is selected, LVM cannot be. Similarly, if LVM is selected, CNV cannot be.
 * For an SNO with version 4.12 or above --> If CNV is selected, LVM becomes enabled on the API. CNV must be enabled, and LVM must be disabled as it's a requisite for CNV.
  * For an SNO with version 4.12 or above --> If LVM is selected, CNV can optionally be selected by the user. So CNV must not be disabled.

See video with all possible cases.
https://user-images.githubusercontent.com/829045/203276789-6a59be6e-a094-4a75-94cf-aa6ebb8cf4bb.mp4

