### PR TITLE
MGMT-11636: Align the styles for tables in different pages (host discovery, storage, networking)

### DIFF
--- a/src/common/components/hosts/AITable.tsx
+++ b/src/common/components/hosts/AITable.tsx
@@ -4,7 +4,6 @@ import {
   Table,
   TableHeader,
   TableBody,
-  TableVariant,
   IRow,
   SortByDirection,
   ISortBy,
@@ -55,7 +54,6 @@ const TableMemo: React.FC<WithTestID & TableMemoProps> = React.memo(
           rows={rows}
           cells={cells}
           onCollapse={onCollapse}
-          variant={TableVariant.compact}
           aria-label="Hosts table"
           className={classnames(className, 'hosts-table')}
           sortBy={sortBy}

--- a/src/common/components/hosts/HostsTable.css
+++ b/src/common/components/hosts/HostsTable.css
@@ -13,7 +13,3 @@
 .hosts-table {
   height: 1rem; /* Workaround for: https://bugzilla.redhat.com/show_bug.cgi?id=1879378 in FF; The actual table height will be recalculated accordingly. */
 }
-
-table.hosts-table.pf-m-compact {
-  height: auto;
-}


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-11636

To keep all the tables with same appearance in the different steps we delete the compact option in tables and delete also the height auto style.

Hosts discovery table:
![hosts_discovery_table](https://user-images.githubusercontent.com/11390125/203300342-0b061cf1-1e20-4743-8246-6257c9550321.png)

Storage table:
![storage_table](https://user-images.githubusercontent.com/11390125/203300366-aa5e8327-c38e-4654-8221-d1875660c95e.png)

Networking hosts inventory table:
![hosts_inventory_table](https://user-images.githubusercontent.com/11390125/203300392-f411e821-6279-4b77-be4b-2c7db100a92e.png)
