### PR TITLE
MGMT-12497: When autosave is running, the Back button should be disabled

### DIFF
--- a/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
@@ -86,6 +86,7 @@ const NetworkConfigurationForm: React.FC<{
       }
       onNext={() => clusterWizardContext.moveNext()}
       onBack={() => clusterWizardContext.moveBack()}
+      isBackDisabled={isSubmitting || isAutoSaveRunning}
     />
   );
 

--- a/src/ocm/components/clusterWizard/ClusterDetailsForm.tsx
+++ b/src/ocm/components/clusterWizard/ClusterDetailsForm.tsx
@@ -147,6 +147,7 @@ const ClusterDetailsForm = (props: ClusterDetailsFormProps) => {
                 (dirty || (cluster && canNextClusterDetails({ cluster })))
               )
             }
+            isBackDisabled={isSubmitting}
             onNext={handleOnNext(dirty, submitForm, cluster)}
           />
         );

--- a/src/ocm/components/clusterWizard/HostDiscovery.tsx
+++ b/src/ocm/components/clusterWizard/HostDiscovery.tsx
@@ -45,6 +45,7 @@ const HostDiscoveryForm = ({ cluster }: { cluster: Cluster }) => {
       isNextDisabled={isNextDisabled}
       onNext={() => clusterWizardContext.moveNext()}
       onBack={() => clusterWizardContext.moveBack()}
+      isBackDisabled={isSubmitting || isAutoSaveRunning}
     />
   );
 

--- a/src/ocm/components/clusterWizard/Operators.tsx
+++ b/src/ocm/components/clusterWizard/Operators.tsx
@@ -60,6 +60,7 @@ const OperatorsForm = ({ cluster }: { cluster: Cluster }) => {
           isNextDisabled={isNextDisabled}
           onNext={() => clusterWizardContext.moveNext()}
           onBack={() => clusterWizardContext.moveBack()}
+          isBackDisabled={isSubmitting || isAutoSaveRunning}
         />
       }
     >

--- a/src/ocm/components/clusterWizard/StaticIp.tsx
+++ b/src/ocm/components/clusterWizard/StaticIp.tsx
@@ -53,6 +53,7 @@ const StaticIp: React.FC<StaticIpProps & { cluster: Cluster }> = ({
       onNext={() => clusterWizardContext.moveNext()}
       onBack={() => clusterWizardContext.moveBack()}
       isNextDisabled={isNextDisabled}
+      isBackDisabled={formState.isSubmitting || formState.isAutoSaveRunning}
     />
   );
 

--- a/src/ocm/components/clusterWizard/Storage.tsx
+++ b/src/ocm/components/clusterWizard/Storage.tsx
@@ -35,6 +35,7 @@ const StorageForm = ({ cluster }: { cluster: Cluster }) => {
       isNextDisabled={isNextDisabled}
       onNext={() => clusterWizardContext.moveNext()}
       onBack={() => clusterWizardContext.moveBack()}
+      isBackDisabled={isSubmitting || isAutoSaveRunning}
     />
   );
   return (


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-12497

When autosave is running, the Back button should be disabled in all the wizard steps.

- Operators step:
https://user-images.githubusercontent.com/11390125/204296510-99e682fb-239d-4df9-8326-7243b269b8d5.mp4

- Host discovery step:
https://user-images.githubusercontent.com/11390125/204296953-297ca0d0-54f1-45c6-b1e9-433a74937bba.mp4

- Networking step:
https://user-images.githubusercontent.com/11390125/204297647-38b2ae2b-57bb-4f86-be13-c9a7ae081362.mp4


