### PR TITLE
MGMT-12323 - In UI - installation starts and after ~1 min UI "jumps" back to operators page

### DIFF
--- a/src/ocm/components/clusterWizard/Operators.tsx
+++ b/src/ocm/components/clusterWizard/Operators.tsx
@@ -23,6 +23,7 @@ import { updateCluster } from '../../reducers/clusters';
 import { handleApiError } from '../../api';
 import { canNextOperators } from './wizardTransition';
 import { getErrorMessage } from '../../../common/utils';
+import { useHistory, useLocation } from 'react-router-dom';
 
 export const getOperatorsInitialValues = (
   monitoredOperators: MonitoredOperator[],
@@ -41,6 +42,8 @@ const OperatorsForm = ({ cluster }: { cluster: Cluster }) => {
   const clusterWizardContext = useClusterWizardContext();
   const isAutoSaveRunning = useFormikAutoSave();
   const { errors, touched, isSubmitting, isValid } = useFormikContext<OperatorsValues>();
+  const history = useHistory();
+  const { pathname } = useLocation();
 
   const isNextDisabled =
     isAutoSaveRunning ||
@@ -48,6 +51,11 @@ const OperatorsForm = ({ cluster }: { cluster: Cluster }) => {
     !!alerts.length ||
     isSubmitting ||
     !canNextOperators({ cluster });
+
+  const handleNext = () => {
+    history.replace(pathname, undefined);
+    clusterWizardContext.moveNext();
+  };
 
   return (
     <ClusterWizardStep
@@ -58,7 +66,7 @@ const OperatorsForm = ({ cluster }: { cluster: Cluster }) => {
           errorFields={getFormikErrorFields(errors, touched)}
           isSubmitting={isSubmitting}
           isNextDisabled={isNextDisabled}
-          onNext={() => clusterWizardContext.moveNext()}
+          onNext={handleNext}
           onBack={() => clusterWizardContext.moveBack()}
         />
       }


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-12323

This bug initially appeared as fixed by #1701 but after further investigation I learned that it still reproduces if the user stays on the original tab where the cluster was created (which QE/their tests were doing and I wasn't) because we still had `"new"` inside the location state.

https://github.com/openshift-assisted/assisted-ui-lib/blob/2fb10afc9b23a58627476eb00bb33f78c221b87a/src/ocm/components/clusterWizard/wizardTransition.ts#L40-L42

So in this PR, I'm removing the `"new"` location state when the users click Next on the "Operators" step. With that, the initial step they land on after reloading the page will not be "Operators" but one of "Host discovery", "Networking", etc.

If we want a different condition for "is the first step "Operators" or not", I'm happy to hold a discussion.