### PR TITLE
MGMT-11370 -  After discovery, if deleting all discovered hosts UI still allows to continue to networking and R&C pages

### DIFF
--- a/src/common/components/hosts/MassChangeHostnameModal.tsx
+++ b/src/common/components/hosts/MassChangeHostnameModal.tsx
@@ -145,13 +145,13 @@ type MassChangeHostnameFormProps = {
   canChangeHostname: (host: Host) => ActionCheck;
 };
 
-const MassChangeHostnameForm: React.FC<MassChangeHostnameFormProps> = ({
+const MassChangeHostnameForm = ({
   selectedHosts: initHosts,
   isOpen,
   patchingHost,
   onClose,
   canChangeHostname,
-}) => {
+}: MassChangeHostnameFormProps) => {
   const { values, handleSubmit, isSubmitting, status, isValid } =
     useFormikContext<EditHostFormValues>();
 
@@ -266,16 +266,18 @@ export type MassChangeHostnameModalProps = {
   // eslint-disable-next-line
   onChangeHostname: (host: Host, hostname: string) => Promise<any>;
   canChangeHostname: (host: Host) => ActionCheck;
+  reloadCluster?: VoidFunction;
 };
 
-const MassChangeHostnameModal: React.FC<MassChangeHostnameModalProps> = ({
+const MassChangeHostnameModal = ({
   isOpen,
   onClose,
   selectedHostIDs,
   hosts,
   onChangeHostname,
   canChangeHostname,
-}) => {
+  reloadCluster,
+}: MassChangeHostnameModalProps) => {
   const [patchingHost, setPatchingHost] = React.useState<number>(0);
 
   const selectedHosts = hosts.filter((h) => selectedHostIDs.includes(h.id));
@@ -308,6 +310,7 @@ const MassChangeHostnameModal: React.FC<MassChangeHostnameModalProps> = ({
               await onChangeHostname(agent, newHostname);
               i++;
             }
+            reloadCluster && reloadCluster();
             onClose();
           } catch (e) {
             formikActions.setStatus({

--- a/src/common/components/hosts/MassDeleteHostModal.tsx
+++ b/src/common/components/hosts/MassDeleteHostModal.tsx
@@ -20,15 +20,18 @@ type MassDeleteHostModalProps = {
   hosts: Host[];
   // eslint-disable-next-line
   onDelete: (host: Host) => Promise<any>;
+  reloadCluster?: VoidFunction;
+  children?: React.ReactNode;
 };
 
-const MassDeleteHostModal: React.FC<MassDeleteHostModalProps> = ({
+const MassDeleteHostModal = ({
   isOpen,
   onClose,
   onDelete,
+  reloadCluster,
   hosts,
   children,
-}) => {
+}: MassDeleteHostModalProps) => {
   const [progress, setProgress] = React.useState<number | null>(null);
   const [error, setError] = React.useState<{ title: string; message: string }>();
   const { t } = useTranslation();
@@ -42,6 +45,7 @@ const MassDeleteHostModal: React.FC<MassDeleteHostModalProps> = ({
         await onDelete(host);
       }
       setProgress(null);
+      reloadCluster && reloadCluster();
       onClose();
     } catch (e) {
       setError({

--- a/src/ocm/components/hosts/ModalDialogsContext.tsx
+++ b/src/ocm/components/hosts/ModalDialogsContext.tsx
@@ -30,12 +30,14 @@ type DiscoveryImageDialogProps = {
 type MassUpdateHostnameDialogProps = {
   cluster: Cluster;
   hostIDs: string[];
+  reloadCluster: VoidFunction;
 };
 
 type MassDeleteHostDialogProps = {
   hosts: Host[];
   // eslint-disable-next-line
   onDelete: (host: Host) => Promise<any>;
+  reloadCluster: VoidFunction;
 };
 
 type ModalDialogsDataTypes = {

--- a/src/ocm/components/hosts/use-hosts-table.tsx
+++ b/src/ocm/components/hosts/use-hosts-table.tsx
@@ -349,16 +349,21 @@ export const useHostsTable = (cluster: Cluster) => {
       const host = cluster.hosts?.find((host) => host.id === selectedHostIDs[0]);
       return host && onEditHost(host);
     }
-    return massUpdateHostnameDialog.open({ hostIDs: selectedHostIDs, cluster });
-  }, [selectedHostIDs, massUpdateHostnameDialog, cluster, onEditHost]);
+    return massUpdateHostnameDialog.open({
+      hostIDs: selectedHostIDs,
+      cluster,
+      reloadCluster: () => (resetCluster ? void resetCluster() : dispatch(forceReload())),
+    });
+  }, [selectedHostIDs, massUpdateHostnameDialog, cluster, onEditHost, resetCluster, dispatch]);
 
   const onMassDeleteHost = React.useCallback(
     () =>
       massDeleteHostDialog.open({
         hosts: (cluster.hosts || []).filter((h) => selectedHostIDs.includes(h.id)),
         onDelete: (host) => HostsService.delete(host),
+        reloadCluster: () => (resetCluster ? void resetCluster() : dispatch(forceReload())),
       }),
-    [cluster.hosts, selectedHostIDs, massDeleteHostDialog],
+    [massDeleteHostDialog, cluster.hosts, selectedHostIDs, resetCluster, dispatch],
   );
 
   return {
@@ -504,6 +509,7 @@ export const HostsTableModals: React.FC<HostsTableModalsProps> = ({
           selectedHostIDs={massUpdateHostnameDialog.data?.hostIDs || []}
           onChangeHostname={(host, hostname) => HostsService.updateHostName(host, hostname)}
           canChangeHostname={() => [true, undefined]}
+          reloadCluster={massUpdateHostnameDialog.data?.reloadCluster}
         />
       )}
       {massDeleteHostDialog.isOpen && (
@@ -512,6 +518,7 @@ export const HostsTableModals: React.FC<HostsTableModalsProps> = ({
           onClose={massDeleteHostDialog.close}
           hosts={massDeleteHostDialog.data?.hosts || []}
           onDelete={massDeleteHostDialog.data?.onDelete}
+          reloadCluster={massDeleteHostDialog.data?.reloadCluster}
         >
           <HostsTable
             hosts={massDeleteHostDialog.data?.hosts || []}


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-11370

The [changes done to the BE](https://issues.redhat.com/browse/MGMT-11536) seem to have fixed the majority of this bug. I'm adding a reload of the cluster after hosts are deleted (or renamed) so that the changes are immediately visible. Whereas before we would have to wait for the next polling cycle to see the changes.

**Before:**

https://user-images.githubusercontent.com/87187179/207077971-be41027b-a02b-4633-8110-928169c2a988.mp4

**After:**

https://user-images.githubusercontent.com/87187179/207078026-3d9b194d-f055-41d8-9f07-f6408cea3bfb.mp4

