### PR TITLE
[2.6-cim] Bug 2120954: Don't allow using dots in cluster name

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -632,7 +632,7 @@
   "ai:Use a comma to separate each listed domain. Preface a domain with <bold>.</bold> to include its subdomains. Use <bold>*</bold> to bypass the proxy for all destinations.": "Use a comma to separate each listed domain. Preface a domain with <bold>.</bold> to include its subdomains. Use <bold>*</bold> to bypass the proxy for all destinations.",
   "ai:Use advanced networking": "Use advanced networking",
   "ai:Use alphanumeric characters, dot (.), underscore (_) or hyphen (-)": "Use alphanumeric characters, dot (.), underscore (_) or hyphen (-)",
-  "ai:Use lowercase alphanumeric characters, '-' or '.'": "Use lowercase alphanumeric characters, '-' or '.'",
+  "ai:Use lowercase alphanumeric characters or hyphen (-)": "Use lowercase alphanumeric characters or hyphen (-)",
   "ai:Use lowercase alphanumeric characters, dot (.) or hyphen (-)": "Use lowercase alphanumeric characters, dot (.) or hyphen (-)",
   "ai:Use the same host discovery SSH key": "Use the same host discovery SSH key",
   "ai:useAlerts must be used within AlertsContextProvider": "useAlerts must be used within AlertsContextProvider",

--- a/scripts/i18n.sh
+++ b/scripts/i18n.sh
@@ -2,4 +2,4 @@
 
 i18next \"src/**/*.{js,jsx,ts,tsx}\" [-oc] -c ./scripts/i18next-parser.config.js;
 
-find ./locales -type f -exec sed -i '' 's/": "ai:/": "/' {} \;
+find ./locales -type f -exec sed -i 's/": "ai:/": "/' {} \;

--- a/src/common/components/ui/formik/constants.tsx
+++ b/src/common/components/ui/formik/constants.tsx
@@ -3,27 +3,28 @@ import { TFunction } from 'i18next';
 export const clusterNameValidationMessages = (t: TFunction) => ({
   INVALID_LENGTH_OCM: t('ai:1-54 characters'),
   INVALID_LENGTH_ACM: t('ai:2-54 characters'),
-  INVALID_VALUE: t("ai:Use lowercase alphanumeric characters, '-' or '.'"),
+  INVALID_VALUE_OCM: nameValidationMessages(t).INVALID_VALUE,
+  INVALID_VALUE_ACM: t('ai:Use lowercase alphanumeric characters or hyphen (-)'),
   INVALID_START_END: t('ai:Start and end with a lowercase letter or a number.'),
   NOT_UNIQUE: t('ai:Must be unique'),
 });
 
 export const ocmClusterNameValidationMessages = (t: TFunction) => ({
   INVALID_LENGTH: clusterNameValidationMessages(t).INVALID_LENGTH_OCM,
-  INVALID_VALUE: clusterNameValidationMessages(t).INVALID_VALUE,
+  INVALID_VALUE: clusterNameValidationMessages(t).INVALID_VALUE_OCM,
   INVALID_START_END: clusterNameValidationMessages(t).INVALID_START_END,
 });
 
 export const uniqueOcmClusterNameValidationMessages = (t: TFunction) => ({
   INVALID_LENGTH: clusterNameValidationMessages(t).INVALID_LENGTH_OCM,
-  INVALID_VALUE: clusterNameValidationMessages(t).INVALID_VALUE,
+  INVALID_VALUE: clusterNameValidationMessages(t).INVALID_VALUE_OCM,
   INVALID_START_END: clusterNameValidationMessages(t).INVALID_START_END,
   NOT_UNIQUE: clusterNameValidationMessages(t).NOT_UNIQUE,
 });
 
 export const acmClusterNameValidationMessages = (t: TFunction) => ({
   INVALID_LENGTH: clusterNameValidationMessages(t).INVALID_LENGTH_ACM,
-  INVALID_VALUE: clusterNameValidationMessages(t).INVALID_VALUE,
+  INVALID_VALUE: clusterNameValidationMessages(t).INVALID_VALUE_ACM,
   INVALID_START_END: clusterNameValidationMessages(t).INVALID_START_END,
   NOT_UNIQUE: clusterNameValidationMessages(t).NOT_UNIQUE,
 });


### PR DESCRIPTION
BZ2120954 https://bugzilla.redhat.com/show_bug.cgi?id=2120954 Cherry-picked from 263dfdff
2.6-cim Backport of https://github.com/openshift-assisted/assisted-ui-lib/pull/1786