### PR TITLE
MGMT-12386 - Can create Nutanix 4.10 cluster with "Integrate with platform" enabled and checked

### DIFF
--- a/src/ocm/components/clusterConfiguration/HostInventory.tsx
+++ b/src/ocm/components/clusterConfiguration/HostInventory.tsx
@@ -72,7 +72,10 @@ const HostInventory = ({ cluster }: { cluster: Cluster }) => {
         <StackItem>
           <Split hasGutter>
             <SplitItem>
-              <PlatformIntegration clusterId={cluster.id} />
+              <PlatformIntegration
+                clusterId={cluster.id}
+                openshiftVersion={cluster.openshiftVersion}
+              />
             </SplitItem>
           </Split>
         </StackItem>

--- a/src/ocm/components/clusterConfiguration/platformIntegration/PlatformIntegration.tsx
+++ b/src/ocm/components/clusterConfiguration/platformIntegration/PlatformIntegration.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { OcmSwitchField } from '../../ui/OcmFormFields';
-import { Cluster, PopoverIcon } from '../../../../common';
+import { Cluster, PopoverIcon, useFeatureSupportLevel } from '../../../../common';
 import useClusterSupportedPlatforms, {
   SupportedPlatformIntegrationType,
 } from '../../../hooks/useClusterSupportedPlatforms';
@@ -43,9 +43,21 @@ const PlatformIntegrationLabel = ({
   );
 };
 
-const PlatformIntegration = ({ clusterId }: { clusterId: Cluster['id'] }) => {
+const PlatformIntegration = ({
+  clusterId,
+  openshiftVersion,
+}: {
+  clusterId: Cluster['id'];
+  openshiftVersion: Cluster['openshiftVersion'];
+}) => {
   const { isPlatformIntegrationSupported, supportedPlatformIntegration } =
     useClusterSupportedPlatforms(clusterId);
+
+  const featureSupportLevels = useFeatureSupportLevel();
+  const isNutanixFeatureSupported = featureSupportLevels.isFeatureSupported(
+    openshiftVersion || '',
+    'NUTANIX_INTEGRATION',
+  );
 
   return (
     <OcmSwitchField
@@ -53,7 +65,10 @@ const PlatformIntegration = ({ clusterId }: { clusterId: Cluster['id'] }) => {
         hidden: isPlatformIntegrationSupported,
         content: platformIntegrationTooltip,
       }}
-      isDisabled={!isPlatformIntegrationSupported}
+      isDisabled={
+        !isPlatformIntegrationSupported ||
+        (supportedPlatformIntegration === 'nutanix' && !isNutanixFeatureSupported)
+      }
       name={'usePlatformIntegration'}
       label={
         <PlatformIntegrationLabel supportedPlatformIntegration={supportedPlatformIntegration} />


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-12386

Follow up on  #1708

BE doesn't seem to take feature support levels into account for `/cluster/${id}/supported-platforms`. I don't know if it should, but in any case, let's check the feature support levels before we enable the Platform integration button in the UI.