### PR TITLE
[2.7-cim] MGMT-12917 Fix listing of versions from clusterimageset releaseImage

### DIFF
--- a/src/cim/components/helpers/versions.ts
+++ b/src/cim/components/helpers/versions.ts
@@ -8,8 +8,10 @@ import {
 import { OpenshiftVersionOptionType, OpenshiftVersion } from '../../../common';
 
 export const getVersionFromReleaseImage = (releaseImage = '') => {
-  const releaseImageParts = releaseImage.split(':');
-  return (releaseImageParts[releaseImageParts.length - 1] || '').split('-')[0];
+  const match = /.+:(.*)-/gm.exec(releaseImage);
+  if (match && match[1]) {
+    return match[1];
+  }
 };
 
 // eslint-disable-next-line
@@ -39,7 +41,7 @@ export const getOCPVersions = (
     .map((clusterImageSet): OpenshiftVersionOptionType => {
       const version = getVersionFromReleaseImage(clusterImageSet.spec?.releaseImage);
       return {
-        label: version ? `OpenShift ${version}` : (clusterImageSet.metadata?.name as string),
+        label: `OpenShift ${version ? version : (clusterImageSet.metadata?.name as string)}`,
         version: version || clusterImageSet.metadata?.name || '',
         value: clusterImageSet.metadata?.name as string,
         default: false,


### PR DESCRIPTION
- update getVersionFromReleaseImage to use the same regex as other ACM wizards, return undefined if there is no match
- getOcpVersions uses clusterImageSet name if there is no match ^

Fixes MGMT-12917
Cherry-picked from 2c252c71