### PR TITLE
MGMT-12072: handle unkown server errors

### DIFF
--- a/src/cim/components/ClusterDeployment/ClusterDeploymentHostsDiscovery.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentHostsDiscovery.tsx
@@ -30,7 +30,6 @@ const ClusterDeploymentHostsDiscovery: React.FC<ClusterDeploymentHostsDiscoveryP
   onSetInstallationDiskId,
   onSaveBMH,
   onSaveISOParams,
-  onFormSaveError,
   fetchSecret,
   onChangeBMHHostname,
   onApproveAgent,
@@ -113,7 +112,6 @@ const ClusterDeploymentHostsDiscovery: React.FC<ClusterDeploymentHostsDiscoveryP
           isOpen={!!editAgent}
           onClose={() => setEditAgent(undefined)}
           usedHostnames={usedHostnames}
-          onFormSaveError={onFormSaveError}
           agent={editAgent}
           onSave={onSaveAgent}
         />

--- a/src/cim/components/ClusterDeployment/ClusterDeploymentHostsDiscoveryStep.tsx
+++ b/src/cim/components/ClusterDeployment/ClusterDeploymentHostsDiscoveryStep.tsx
@@ -26,7 +26,6 @@ const ClusterDeploymentHostsDiscoveryStep: React.FC<ClusterDeploymentHostsDiscov
   onSetInstallationDiskId,
   onSaveBMH,
   onSaveISOParams,
-  onFormSaveError,
   fetchSecret,
   onChangeBMHHostname,
   onApproveAgent,
@@ -162,7 +161,6 @@ const ClusterDeploymentHostsDiscoveryStep: React.FC<ClusterDeploymentHostsDiscov
             onSetInstallationDiskId={onSetInstallationDiskId}
             onSaveBMH={onSaveBMH}
             onSaveISOParams={onSaveISOParams}
-            onFormSaveError={onFormSaveError}
             fetchSecret={fetchSecret}
             onChangeBMHHostname={onChangeBMHHostname}
             onApproveAgent={onApproveAgent}

--- a/src/cim/components/ClusterDeployment/types.ts
+++ b/src/cim/components/ClusterDeployment/types.ts
@@ -21,8 +21,6 @@ export type EditAgentModalProps = {
   onClose: () => void;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onSave: (agent: AgentK8sResource, hostname: string) => Promise<any>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onFormSaveError?: (e: any) => void | string;
 };
 
 export type AgentTableActions = {
@@ -225,7 +223,6 @@ export type ClusterDeploymentHostsDiscoveryProps = {
   onSetInstallationDiskId: AgentTableActions['onSetInstallationDiskId'];
   onSaveBMH: EditBMHModalProps['onEdit'];
   onSaveISOParams?: AddHostModalProps['onSaveISOParams'];
-  onFormSaveError?: EditAgentModalProps['onFormSaveError'];
   fetchSecret: EditBMHModalProps['fetchSecret'];
   getClusterDeploymentLink: InfraEnvAgentTableProps['getClusterDeploymentLink'];
   onChangeBMHHostname: InfraEnvAgentTableProps['onChangeBMHHostname'];

--- a/src/common/components/hosts/EditHostModal.tsx
+++ b/src/common/components/hosts/EditHostModal.tsx
@@ -2,28 +2,27 @@ import React from 'react';
 import { Modal, ModalVariant } from '@patternfly/react-core';
 import { Host, Inventory } from '../../api';
 import EditHostForm, { EditHostFormProps } from './EditHostForm';
-import { EditHostFormValues } from './types';
 
-type EditHostModalProps = {
+type EditHostModalProps = Pick<
+  EditHostFormProps,
+  'usedHostnames' | 'onSave' | 'getEditErrorMessage' | 'onHostSaveError'
+> & {
   host?: Host;
   inventory?: Inventory;
   isOpen: boolean;
-  usedHostnames: string[] | undefined;
   onClose: () => void;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  onSave: (values: EditHostFormValues) => Promise<any>;
-  onFormSaveError?: EditHostFormProps['onFormSaveError'];
 };
 
-const EditHostModal: React.FC<EditHostModalProps> = ({
+const EditHostModal = ({
   isOpen,
   host,
   inventory,
   usedHostnames,
   onClose,
   onSave,
-  onFormSaveError,
-}) =>
+  onHostSaveError,
+  getEditErrorMessage,
+}: EditHostModalProps) =>
   host && inventory ? (
     <Modal
       aria-label="Change hostname dialog"
@@ -39,7 +38,8 @@ const EditHostModal: React.FC<EditHostModalProps> = ({
         usedHostnames={usedHostnames}
         onCancel={onClose}
         onSave={onSave}
-        onFormSaveError={onFormSaveError}
+        getEditErrorMessage={getEditErrorMessage}
+        onHostSaveError={onHostSaveError}
       />
     </Modal>
   ) : null;

--- a/src/common/components/hosts/MassChangeHostnameModal.tsx
+++ b/src/common/components/hosts/MassChangeHostnameModal.tsx
@@ -269,6 +269,7 @@ export type MassChangeHostnameModalProps = {
   onChangeHostname: (host: Host, hostname: string) => Promise<any>;
   canChangeHostname: (host: Host) => ActionCheck;
   reloadCluster?: VoidFunction;
+  onHostSaveError?: (e: Error) => void;
 };
 
 const MassChangeHostnameModal = ({
@@ -279,6 +280,7 @@ const MassChangeHostnameModal = ({
   onChangeHostname,
   canChangeHostname,
   reloadCluster,
+  onHostSaveError,
 }: MassChangeHostnameModalProps) => {
   const [patchingHost, setPatchingHost] = React.useState<number>(0);
 
@@ -321,6 +323,7 @@ const MassChangeHostnameModal = ({
                 message: getApiErrorMessage(e),
               },
             });
+            onHostSaveError && onHostSaveError(e as Error);
           }
         }}
       >

--- a/src/common/types/index.ts
+++ b/src/common/types/index.ts
@@ -1,9 +1,10 @@
 export enum ResourceUIState {
   LOADING = 'LOADING',
   RELOADING = 'RELOADING',
-  ERROR = 'ERROR',
   EMPTY = 'EMPTY',
   LOADED = 'LOADED',
+  ERROR = 'ERROR', // Polling error
+  UPDATE_ERROR = 'UPDATE_ERROR',
 }
 
 export type WithTestID = {

--- a/src/common/types/index.ts
+++ b/src/common/types/index.ts
@@ -3,7 +3,7 @@ export enum ResourceUIState {
   RELOADING = 'RELOADING',
   EMPTY = 'EMPTY',
   LOADED = 'LOADED',
-  ERROR = 'ERROR', // Polling error
+  POLLING_ERROR = 'POLLING_ERROR',
   UPDATE_ERROR = 'UPDATE_ERROR',
 }
 

--- a/src/ocm/api/utils.ts
+++ b/src/ocm/api/utils.ts
@@ -8,6 +8,8 @@ import { isAxiosError } from './axiosExtensions';
 
 export const FETCH_ABORTED_ERROR_CODE = 'ERR_CANCELED';
 export const FETCH_CONNECTIVITY_ERROR_CODE = 'CONNECTIVITY_ERROR';
+export const SERVER_ERROR_CODE = 'SERVER_ERROR';
+export const PAGE_RELOAD_ERROR = 'ECONNABORTED';
 
 type OnError = (arg0: unknown) => void;
 
@@ -55,14 +57,24 @@ export const getApiErrorCode = (error: Error | AxiosError): string | number => {
   if (!isAxiosError(error)) {
     return FETCH_CONNECTIVITY_ERROR_CODE;
   }
-  const responseStatus = error.response?.status || 0;
-  // Error status
-  if (responseStatus >= 400 && responseStatus < 500) {
-    return responseStatus;
-  }
   // Aborted request
   if (error.code === FETCH_ABORTED_ERROR_CODE) {
     return FETCH_ABORTED_ERROR_CODE;
+  }
+
+  // Page is reloading and some request has been interrupted
+  if (error.code === PAGE_RELOAD_ERROR) {
+    return '';
+  }
+
+  const responseStatus = error.response?.status || 0;
+
+  // Error status
+  if (responseStatus >= 500 && responseStatus < 600) {
+    return SERVER_ERROR_CODE;
+  }
+  if (responseStatus >= 400 && responseStatus < 500) {
+    return responseStatus;
   }
   // A generic connectivity issue
   return FETCH_CONNECTIVITY_ERROR_CODE;

--- a/src/ocm/api/utils.ts
+++ b/src/ocm/api/utils.ts
@@ -53,6 +53,10 @@ export const getApiErrorMessage = (error: unknown): string => {
   return getErrorMessage(error);
 };
 
+export const isUnknownServerError = (error: Error): boolean => {
+  return getApiErrorCode(error) === SERVER_ERROR_CODE;
+};
+
 export const getApiErrorCode = (error: Error | AxiosError): string | number => {
   if (!isAxiosError(error)) {
     return FETCH_CONNECTIVITY_ERROR_CODE;

--- a/src/ocm/components/clusterConfiguration/DiscoveryImageForm.tsx
+++ b/src/ocm/components/clusterConfiguration/DiscoveryImageForm.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useDispatch } from 'react-redux';
 import Axios, { CancelTokenSource } from 'axios';
 import { FormikHelpers } from 'formik';
-import { getApiErrorMessage, handleApiError } from '../../api';
+import { getApiErrorMessage, handleApiError, isUnknownServerError } from '../../api';
 import {
   Cluster,
   CpuArchitecture,
@@ -10,7 +10,7 @@ import {
   LoadingState,
   StatusErrorType,
 } from '../../../common';
-import { forceReload, updateCluster } from '../../reducers/clusters';
+import { forceReload, setServerUpdateError, updateCluster } from '../../reducers/clusters';
 import useInfraEnv from '../../hooks/useInfraEnv';
 import { DiscoveryImageFormService } from '../../services';
 import {
@@ -76,6 +76,10 @@ const DiscoveryImageForm = ({
             };
             formikActions.setStatus(error);
           });
+          if (isUnknownServerError(e as Error)) {
+            dispatch(setServerUpdateError());
+            onCancel();
+          }
         }
       }
     }

--- a/src/ocm/components/clusterConfiguration/DiscoveryImageForm.tsx
+++ b/src/ocm/components/clusterConfiguration/DiscoveryImageForm.tsx
@@ -3,13 +3,7 @@ import { useDispatch } from 'react-redux';
 import Axios, { CancelTokenSource } from 'axios';
 import { FormikHelpers } from 'formik';
 import { getApiErrorMessage, handleApiError, isUnknownServerError } from '../../api';
-import {
-  Cluster,
-  CpuArchitecture,
-  ErrorState,
-  LoadingState,
-  StatusErrorType,
-} from '../../../common';
+import { Cluster, CpuArchitecture, ErrorState, LoadingState } from '../../../common';
 import { forceReload, setServerUpdateError, updateCluster } from '../../reducers/clusters';
 import useInfraEnv from '../../hooks/useInfraEnv';
 import { DiscoveryImageFormService } from '../../services';
@@ -66,17 +60,16 @@ const DiscoveryImageForm = ({
           );
           await onSuccess();
           dispatch(updateCluster(updatedCluster));
-        } catch (e) {
-          handleApiError(e, () => {
-            const error: StatusErrorType = {
+        } catch (error) {
+          handleApiError(error, () => {
+            formikActions.setStatus({
               error: {
                 title: 'Failed to download the discovery Image',
-                message: getApiErrorMessage(e),
+                message: getApiErrorMessage(error),
               },
-            };
-            formikActions.setStatus(error);
+            });
           });
-          if (isUnknownServerError(e as Error)) {
+          if (isUnknownServerError(error as Error)) {
             dispatch(setServerUpdateError());
             onCancel();
           }

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
@@ -36,8 +36,8 @@ import {
 import NetworkConfiguration from './NetworkConfiguration';
 import { captureException } from '../../../sentry';
 import { ClustersService } from '../../../services';
-import { updateClusterBase } from '../../../reducers/clusters';
-import { getApiErrorMessage, handleApiError } from '../../../api';
+import { setServerUpdateError, updateClusterBase } from '../../../reducers/clusters';
+import { isUnknownServerError, getApiErrorMessage, handleApiError } from '../../../api';
 
 const NetworkConfigurationForm: React.FC<{
   cluster: Cluster;
@@ -212,6 +212,9 @@ const NetworkConfigurationPage = ({ cluster }: { cluster: Cluster }) => {
       handleApiError(e, () =>
         addAlert({ title: 'Failed to update the cluster', message: getApiErrorMessage(e) }),
       );
+      if (isUnknownServerError(e as Error)) {
+        dispatch(setServerUpdateError());
+      }
     }
   };
 

--- a/src/ocm/components/clusterDetail/AssistedInstallerDetailCard.tsx
+++ b/src/ocm/components/clusterDetail/AssistedInstallerDetailCard.tsx
@@ -112,10 +112,9 @@ const AssistedInstallerDetailCard = ({
     error: infraEnvError,
     updateInfraEnv,
   } = useInfraEnv(aiClusterId, CpuArchitecture.USE_DAY1_ARCHITECTURE);
-  // TODO check
   if (uiState === ResourceUIState.LOADING || infraEnvLoading) {
     return <LoadingCard />;
-  } else if ((uiState === ResourceUIState.ERROR && !cluster) || infraEnvError) {
+  } else if ((uiState === ResourceUIState.POLLING_ERROR && !cluster) || infraEnvError) {
     return <ClusterLoadFailed clusterId={aiClusterId} />;
   }
 
@@ -136,7 +135,7 @@ const AssistedInstallerDetailCard = ({
     </ClusterWizardContextProvider>
   );
 
-  const isOutdatedClusterData = uiState === ResourceUIState.ERROR;
+  const isOutdatedClusterData = uiState === ResourceUIState.POLLING_ERROR;
   return (
     <FeatureGateContextProvider features={allEnabledFeatures}>
       <AlertsContextProvider>

--- a/src/ocm/components/clusterDetail/AssistedInstallerDetailCard.tsx
+++ b/src/ocm/components/clusterDetail/AssistedInstallerDetailCard.tsx
@@ -112,6 +112,7 @@ const AssistedInstallerDetailCard = ({
     error: infraEnvError,
     updateInfraEnv,
   } = useInfraEnv(aiClusterId, CpuArchitecture.USE_DAY1_ARCHITECTURE);
+  // TODO check
   if (uiState === ResourceUIState.LOADING || infraEnvLoading) {
     return <LoadingCard />;
   } else if ((uiState === ResourceUIState.ERROR && !cluster) || infraEnvError) {

--- a/src/ocm/components/clusterDetail/ClusterUpdateErrorModal.tsx
+++ b/src/ocm/components/clusterDetail/ClusterUpdateErrorModal.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Button, ButtonVariant, Modal, ModalVariant } from '@patternfly/react-core';
+
+const ClusterUpdateErrorModal = () => (
+  <Modal
+    title="Unable to update cluster"
+    isOpen
+    variant={ModalVariant.small}
+    showClose={false}
+    titleIconVariant="danger"
+    actions={[
+      <Button
+        key="refresh"
+        variant={ButtonVariant.primary}
+        onClick={() => window.location.reload()}
+      >
+        Refresh page
+      </Button>,
+    ]}
+  >
+    The service is down, undergoing maintenance, or experiencing another issue.
+  </Modal>
+);
+
+export default ClusterUpdateErrorModal;

--- a/src/ocm/components/clusterWizard/ClusterDetails.tsx
+++ b/src/ocm/components/clusterWizard/ClusterDetails.tsx
@@ -11,8 +11,8 @@ import {
   InfraEnv,
 } from '../../../common';
 import { usePullSecret } from '../../hooks';
-import { getApiErrorMessage, handleApiError } from '../../api';
-import { updateCluster } from '../../reducers/clusters';
+import { getApiErrorMessage, handleApiError, isUnknownServerError } from '../../api';
+import { setServerUpdateError, updateCluster } from '../../reducers/clusters';
 import { useClusterWizardContext } from './ClusterWizardContext';
 import { canNextClusterDetails, ClusterWizardFlowStateNew } from './wizardTransition';
 import { useOpenshiftVersions, useManagedDomains, useUsedClusterNames } from '../../hooks';
@@ -60,9 +60,12 @@ const ClusterDetails: React.FC<ClusterDetailsProps> = ({ cluster, infraEnv }) =>
         handleApiError(e, () =>
           addAlert({ title: 'Failed to update the cluster', message: getApiErrorMessage(e) }),
         );
+        if (isUnknownServerError(e as Error)) {
+          dispatch(setServerUpdateError());
+        }
       }
     },
-    [clearAlerts, cluster?.tags, dispatch, clusterWizardContext, addAlert],
+    [clearAlerts, addAlert, dispatch, cluster?.tags, clusterWizardContext],
   );
 
   const handleClusterCreate = React.useCallback(
@@ -75,9 +78,12 @@ const ClusterDetails: React.FC<ClusterDetailsProps> = ({ cluster, infraEnv }) =>
         handleApiError(e, () =>
           addAlert({ title: 'Failed to create new cluster', message: getApiErrorMessage(e) }),
         );
+        if (isUnknownServerError(e as Error)) {
+          dispatch(setServerUpdateError());
+        }
       }
     },
-    [addAlert, clearAlerts, history],
+    [clearAlerts, addAlert, dispatch, history],
   );
 
   if (pullSecret === undefined || !managedDomains || loadingOCPVersions || !usedClusterNames) {

--- a/src/ocm/components/clusterWizard/HostDiscovery.tsx
+++ b/src/ocm/components/clusterWizard/HostDiscovery.tsx
@@ -15,8 +15,8 @@ import {
 import HostInventory from '../clusterConfiguration/HostInventory';
 import { useClusterWizardContext } from './ClusterWizardContext';
 import { canNextHostDiscovery } from './wizardTransition';
-import { getApiErrorMessage, handleApiError } from '../../api';
-import { updateCluster } from '../../reducers/clusters';
+import { getApiErrorMessage, handleApiError, isUnknownServerError } from '../../api';
+import { setServerUpdateError, updateCluster } from '../../reducers/clusters';
 import ClusterWizardFooter from './ClusterWizardFooter';
 import ClusterWizardNavigation from './ClusterWizardNavigation';
 import { ClustersService, HostDiscoveryService } from '../../services';
@@ -92,6 +92,9 @@ const HostDiscovery = ({ cluster }: { cluster: Cluster }) => {
       handleApiError(e, () =>
         addAlert({ title: 'Failed to update the cluster', message: getApiErrorMessage(e) }),
       );
+      if (isUnknownServerError(e as Error)) {
+        dispatch(setServerUpdateError());
+      }
     }
   };
 

--- a/src/ocm/components/clusterWizard/Operators.tsx
+++ b/src/ocm/components/clusterWizard/Operators.tsx
@@ -19,8 +19,8 @@ import ClusterWizardFooter from '../clusterWizard/ClusterWizardFooter';
 import ClusterWizardNavigation from '../clusterWizard/ClusterWizardNavigation';
 import { OperatorsStep } from './OperatorsStep';
 import { ClustersService, OperatorsService } from '../../services';
-import { updateCluster } from '../../reducers/clusters';
-import { handleApiError } from '../../api';
+import { setServerUpdateError, updateCluster } from '../../reducers/clusters';
+import { handleApiError, isUnknownServerError } from '../../api';
 import { canNextOperators } from './wizardTransition';
 import { getErrorMessage } from '../../../common/utils';
 import { useHistory, useLocation } from 'react-router-dom';
@@ -115,6 +115,9 @@ const Operators = ({ cluster }: { cluster: Cluster }) => {
       handleApiError(e, () =>
         addAlert({ title: 'Failed to update the cluster', message: getErrorMessage(e) }),
       );
+      if (isUnknownServerError(e as Error)) {
+        dispatch(setServerUpdateError());
+      }
     }
   };
 

--- a/src/ocm/components/clusters/ClusterPage.tsx
+++ b/src/ocm/components/clusters/ClusterPage.tsx
@@ -29,6 +29,7 @@ import { forceReload } from '../../reducers/clusters';
 import { getErrorStateActions, ClusterUiError } from './ClusterPageErrors';
 import ClusterLoading from './ClusterLoading';
 import ClusterPollingErrorModal from '../clusterDetail/ClusterPollingErrorModal';
+import ClusterUpdateErrorModal from '../clusterDetail/ClusterUpdateErrorModal';
 
 type MatchParams = {
   clusterId: string;
@@ -137,7 +138,6 @@ const ClusterPage: React.FC<RouteComponentProps<MatchParams>> = ({ match }) => {
   }
 
   if (cluster && infraEnv) {
-    const isOutdatedClusterData = uiState === ResourceUIState.ERROR;
     return (
       <AlertsContextProvider>
         <SentryErrorMonitorContextProvider>
@@ -148,7 +148,8 @@ const ClusterPage: React.FC<RouteComponentProps<MatchParams>> = ({ match }) => {
             >
               <FeatureSupportLevelProvider loadingUi={<ClusterLoading />} cluster={cluster}>
                 {getContent(cluster, infraEnv)}
-                {isOutdatedClusterData && <ClusterPollingErrorModal />}
+                {uiState === ResourceUIState.ERROR && <ClusterPollingErrorModal />}
+                {uiState === ResourceUIState.UPDATE_ERROR && <ClusterUpdateErrorModal />}
                 <CancelInstallationModal />
                 <ResetClusterModal />
                 <DiscoveryImageModal />

--- a/src/ocm/components/clusters/ClusterPage.tsx
+++ b/src/ocm/components/clusters/ClusterPage.tsx
@@ -106,7 +106,7 @@ const ClusterPage: React.FC<RouteComponentProps<MatchParams>> = ({ match }) => {
     return <ClusterLoading />;
   }
 
-  if (uiState === ResourceUIState.ERROR && !cluster) {
+  if (uiState === ResourceUIState.POLLING_ERROR && !cluster) {
     if (Number(errorDetail?.code) === 404) {
       return <Redirect to={`${routeBasePath}/clusters`} />;
     }
@@ -148,7 +148,7 @@ const ClusterPage: React.FC<RouteComponentProps<MatchParams>> = ({ match }) => {
             >
               <FeatureSupportLevelProvider loadingUi={<ClusterLoading />} cluster={cluster}>
                 {getContent(cluster, infraEnv)}
-                {uiState === ResourceUIState.ERROR && <ClusterPollingErrorModal />}
+                {uiState === ResourceUIState.POLLING_ERROR && <ClusterPollingErrorModal />}
                 {uiState === ResourceUIState.UPDATE_ERROR && <ClusterUpdateErrorModal />}
                 <CancelInstallationModal />
                 <ResetClusterModal />

--- a/src/ocm/components/clusters/Clusters.tsx
+++ b/src/ocm/components/clusters/Clusters.tsx
@@ -33,7 +33,7 @@ import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
 type ClustersProps = RouteComponentProps;
 
 const Clusters: React.FC<ClustersProps> = ({ history }) => {
-  const { LOADING, EMPTY, ERROR, RELOADING } = ResourceUIState;
+  const { LOADING, EMPTY, POLLING_ERROR, RELOADING } = ResourceUIState;
   const { addAlert } = useAlerts();
   const { t } = useTranslation();
   const clusterRows = useSelector(selectClusterTableRows(t));
@@ -72,7 +72,7 @@ const Clusters: React.FC<ClustersProps> = ({ history }) => {
           <LoadingState />
         </PageSection>
       );
-    case ERROR:
+    case POLLING_ERROR:
       return (
         <PageSection variant={PageSectionVariants.light} isFilled>
           <ErrorState title="Failed to fetch clusters." fetchData={fetchClusters} />

--- a/src/ocm/components/clusters/clusterPolling.ts
+++ b/src/ocm/components/clusters/clusterPolling.ts
@@ -11,7 +11,7 @@ import {
 import { selectCurrentClusterState } from '../../selectors';
 
 const shouldRefetch = (uiState: ResourceUIState, hasClusterData: boolean) => {
-  if (uiState === ResourceUIState.ERROR) {
+  if (uiState === ResourceUIState.POLLING_ERROR) {
     return hasClusterData;
   }
   return ![

--- a/src/ocm/components/clusters/clusterPolling.ts
+++ b/src/ocm/components/clusters/clusterPolling.ts
@@ -14,7 +14,11 @@ const shouldRefetch = (uiState: ResourceUIState, hasClusterData: boolean) => {
   if (uiState === ResourceUIState.ERROR) {
     return hasClusterData;
   }
-  return ![ResourceUIState.LOADING, ResourceUIState.RELOADING].includes(uiState);
+  return ![
+    ResourceUIState.LOADING,
+    ResourceUIState.RELOADING,
+    ResourceUIState.UPDATE_ERROR,
+  ].includes(uiState);
 };
 
 export const useFetchCluster = (clusterId: string) => {

--- a/src/ocm/components/hosts/use-hosts-table.tsx
+++ b/src/ocm/components/hosts/use-hosts-table.tsx
@@ -319,6 +319,9 @@ export const useHostsTable = (cluster: Cluster) => {
         handleApiError(e, () =>
           addAlert({ title: 'Failed to set role', message: getApiErrorMessage(e) }),
         );
+        if (isUnknownServerError(e as Error)) {
+          dispatch(setServerUpdateError());
+        }
       }
     },
     [addAlert, dispatch, resetCluster],

--- a/src/ocm/components/hosts/use-hosts-table.tsx
+++ b/src/ocm/components/hosts/use-hosts-table.tsx
@@ -19,7 +19,7 @@ import {
   AdditionalNTPSourcesDialog,
   AdditionalNTPSourcesFormProps,
 } from '../../../common/components/hosts/AdditionalNTPSourcesDialog';
-import { getApiErrorCode, getApiErrorMessage, handleApiError, SERVER_ERROR_CODE } from '../../api';
+import { getApiErrorMessage, handleApiError, isUnknownServerError } from '../../api';
 import {
   forceReload,
   setServerUpdateError,
@@ -149,6 +149,9 @@ export const useHostsTable = (cluster: Cluster) => {
         handleApiError(e, () =>
           addAlert({ title: 'Failed to set disk role', message: getApiErrorMessage(e) }),
         );
+        if (isUnknownServerError(e as Error)) {
+          dispatch(setServerUpdateError());
+        }
       }
     },
     [dispatch, resetCluster, addAlert, cluster.hosts],
@@ -168,6 +171,9 @@ export const useHostsTable = (cluster: Cluster) => {
         handleApiError(e, () =>
           addAlert({ title: 'Failed to update ODF status', message: getErrorMessage(e) }),
         );
+        if (isUnknownServerError(e as Error)) {
+          dispatch(setServerUpdateError());
+        }
       }
     },
     [cluster.hosts, resetCluster, dispatch, addAlert],
@@ -182,6 +188,9 @@ export const useHostsTable = (cluster: Cluster) => {
         dispatch(updateCluster(data));
       } catch (e) {
         handleApiError(e, () => onError(getApiErrorMessage(e)));
+        if (isUnknownServerError(e as Error)) {
+          dispatch(setServerUpdateError());
+        }
       }
     },
     [cluster.id, cluster.tags, dispatch],
@@ -223,6 +232,9 @@ export const useHostsTable = (cluster: Cluster) => {
             message: getApiErrorMessage(e),
           }),
         );
+        if (isUnknownServerError(e as Error)) {
+          dispatch(setServerUpdateError());
+        }
       }
     },
     [dispatch, addAlert, cluster, resetCluster],
@@ -488,8 +500,7 @@ export const HostsTableModals = ({
             editHostDialog.close();
           }}
           onHostSaveError={(e: Error) => {
-            const hasServerError = getApiErrorCode(e) === SERVER_ERROR_CODE;
-            if (hasServerError) {
+            if (isUnknownServerError(e)) {
               dispatch(setServerUpdateError());
               editHostDialog.close();
             }
@@ -527,8 +538,7 @@ export const HostsTableModals = ({
           selectedHostIDs={massUpdateHostnameDialog.data?.hostIDs || []}
           onChangeHostname={(host, hostname) => HostsService.updateHostName(host, hostname)}
           onHostSaveError={(e: Error) => {
-            const hasServerError = getApiErrorCode(e) === SERVER_ERROR_CODE;
-            if (hasServerError) {
+            if (isUnknownServerError(e)) {
               dispatch(setServerUpdateError());
               editHostDialog.close();
             }

--- a/src/ocm/components/hosts/use-hosts-table.tsx
+++ b/src/ocm/components/hosts/use-hosts-table.tsx
@@ -444,6 +444,7 @@ export const HostsTableModals = ({
   const paginationProps = usePagination(massDeleteHostDialog.data?.hosts?.length || 0);
 
   if (uiState === ResourceUIState.UPDATE_ERROR) {
+    // Do not show a modal beneath the ServerUpdateError
     return null;
   }
 

--- a/src/ocm/reducers/clusters/clustersSlice.ts
+++ b/src/ocm/reducers/clusters/clustersSlice.ts
@@ -35,7 +35,7 @@ export const clustersSlice = createSlice({
     }),
   },
   extraReducers: (builder) => {
-    const { LOADED, LOADING, RELOADING, ERROR } = ResourceUIState;
+    const { LOADED, LOADING, RELOADING, POLLING_ERROR } = ResourceUIState;
     builder
       .addCase(fetchClustersAsync.pending, (state) => {
         const uiState = state.uiState === LOADED ? RELOADING : LOADING;
@@ -48,7 +48,7 @@ export const clustersSlice = createSlice({
       }))
       .addCase(fetchClustersAsync.rejected, (state) => ({
         ...state,
-        uiState: ERROR,
+        uiState: POLLING_ERROR,
       }));
   },
 });

--- a/src/ocm/reducers/clusters/currentClusterSlice.ts
+++ b/src/ocm/reducers/clusters/currentClusterSlice.ts
@@ -13,6 +13,7 @@ import {
   getApiErrorCode,
   handleApiError,
   FETCH_ABORTED_ERROR_CODE,
+  SERVER_ERROR_CODE,
 } from '../../api';
 import { ClustersService } from '../../services';
 
@@ -77,6 +78,9 @@ export const currentClusterSlice = createSlice({
       }
       return state;
     },
+    setServerUpdateError: (state) => {
+      return { ...state, uiState: ResourceUIState.UPDATE_ERROR };
+    },
     cleanCluster: () => initialState,
     forceReload: (state) => ({
       ...state,
@@ -135,6 +139,7 @@ export const {
   updateCluster,
   updateClusterBase,
   updateHost,
+  setServerUpdateError,
   cleanCluster,
   forceReload,
   cancelForceReload,

--- a/src/ocm/reducers/clusters/currentClusterSlice.ts
+++ b/src/ocm/reducers/clusters/currentClusterSlice.ts
@@ -13,7 +13,6 @@ import {
   getApiErrorCode,
   handleApiError,
   FETCH_ABORTED_ERROR_CODE,
-  SERVER_ERROR_CODE,
 } from '../../api';
 import { ClustersService } from '../../services';
 

--- a/src/ocm/reducers/clusters/currentClusterSlice.ts
+++ b/src/ocm/reducers/clusters/currentClusterSlice.ts
@@ -102,7 +102,7 @@ export const currentClusterSlice = createSlice({
       .addCase(fetchClusterAsync.pending, (state) => {
         const needsReload =
           state.uiState === ResourceUIState.LOADED ||
-          (state.uiState === ResourceUIState.ERROR && state.data);
+          (state.uiState === ResourceUIState.POLLING_ERROR && state.data);
         return {
           ...state,
           uiState: needsReload ? ResourceUIState.RELOADING : ResourceUIState.LOADING,
@@ -127,7 +127,7 @@ export const currentClusterSlice = createSlice({
         }
         return {
           ...state,
-          uiState: ResourceUIState.ERROR,
+          uiState: ResourceUIState.POLLING_ERROR,
           errorDetail: error,
         };
       });


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-12072

Currently, when an error 500 is received on a PATCH request, we show an error but allow the user to continue using the applcation.

With these changes, we'll show a modal with a message to the user to reload the page in the cases below:

- Cluster Wizard: Details step (cluster creation and update)
- Cluster Wizard: Operators step
- Cluster Wizard: Host Discovery step
   * Main form submission
   * Generate ISO
   * Rename host and Mass rename hosts
   * Editing role 
- Cluster Wizard: Storage step
   * Main form submission
  * Updating "skip formatting disks"
- Cluster Wizard: Networking step

The video shows most of the cases where we'll show this modal.


https://user-images.githubusercontent.com/829045/207855880-6e8dca3c-05fc-4801-ae53-a38b6a05ed5e.mp4

