### PR TITLE
MGMT-12756 cluster name cannot use dot

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "prepare": "install-peers",
     "test": "run-s test:circular lint format:check",
     "test:circular": "dpdm --warning false --tree false --exit-code circular:1 ./src/index.ts",
-    "lint": "eslint . --max-warnings=222 --color",
+    "lint": "eslint . --max-warnings=203 --color",
     "lint:fix": "yarn run lint --fix",
     "format": "prettier --write '**/*.{json,md,scss,yaml,yml}'",
     "format:check": "prettier --check '**/*.{json,md,scss,yaml,yml}'",

--- a/src/common/components/ui/formik/constants.tsx
+++ b/src/common/components/ui/formik/constants.tsx
@@ -3,28 +3,27 @@ import { TFunction } from 'i18next';
 export const clusterNameValidationMessages = (t: TFunction) => ({
   INVALID_LENGTH_OCM: t('ai:1-54 characters'),
   INVALID_LENGTH_ACM: t('ai:2-54 characters'),
-  INVALID_VALUE_OCM: nameValidationMessages(t).INVALID_VALUE,
-  INVALID_VALUE_ACM: t('ai:Use lowercase alphanumeric characters or hyphen (-)'),
+  INVALID_VALUE: t('ai:Use lowercase alphanumeric characters or hyphen (-)'),
   INVALID_START_END: t('ai:Start and end with a lowercase letter or a number.'),
   NOT_UNIQUE: t('ai:Must be unique'),
 });
 
 export const ocmClusterNameValidationMessages = (t: TFunction) => ({
   INVALID_LENGTH: clusterNameValidationMessages(t).INVALID_LENGTH_OCM,
-  INVALID_VALUE: clusterNameValidationMessages(t).INVALID_VALUE_OCM,
+  INVALID_VALUE: clusterNameValidationMessages(t).INVALID_VALUE,
   INVALID_START_END: clusterNameValidationMessages(t).INVALID_START_END,
 });
 
 export const uniqueOcmClusterNameValidationMessages = (t: TFunction) => ({
   INVALID_LENGTH: clusterNameValidationMessages(t).INVALID_LENGTH_OCM,
-  INVALID_VALUE: clusterNameValidationMessages(t).INVALID_VALUE_OCM,
+  INVALID_VALUE: clusterNameValidationMessages(t).INVALID_VALUE,
   INVALID_START_END: clusterNameValidationMessages(t).INVALID_START_END,
   NOT_UNIQUE: clusterNameValidationMessages(t).NOT_UNIQUE,
 });
 
 export const acmClusterNameValidationMessages = (t: TFunction) => ({
   INVALID_LENGTH: clusterNameValidationMessages(t).INVALID_LENGTH_ACM,
-  INVALID_VALUE: clusterNameValidationMessages(t).INVALID_VALUE_ACM,
+  INVALID_VALUE: clusterNameValidationMessages(t).INVALID_VALUE,
   INVALID_START_END: clusterNameValidationMessages(t).INVALID_START_END,
   NOT_UNIQUE: clusterNameValidationMessages(t).NOT_UNIQUE,
 });

--- a/src/common/components/ui/formik/validationSchemas.ts
+++ b/src/common/components/ui/formik/validationSchemas.ts
@@ -26,9 +26,8 @@ const NAME_START_END_REGEX = /^[a-z0-9](.*[a-z0-9])?$/;
 const NAME_CHARS_REGEX = /^[a-z0-9-.]*$/;
 const CLUSTER_NAME_START_END_REGEX = /^[a-z0-9](.*[a-z0-9])?$/;
 // NOTE: based on https://github.com/openshift/assisted-service/blob/master/internal/cluster/validations/validations.go#L32
-const CLUSTER_NAME_REGEX =
-  /^[-a-z0-9]?(([a-z0-9]([-a-z0-9]*[a-z0-9])?([a-z0-9]([-a-z0-9]*[a-z0-9])?)*)*)[-a-z0-9]?$/;
-const CLUSTER_NAME_NO_DOT_REGEX = /^[a-z0-9-]*$/;
+const CLUSTER_NAME_NO_DOT_REGEX =
+  /^[a-z0-9]?(([a-z0-9]([-a-z0-9]*[a-z0-9])?([a-z0-9]([-a-z0-9]*[a-z0-9])?)*)*)[a-z0-9]?$/;
 const SSH_PUBLIC_KEY_REGEX =
   /^(ssh-rsa|ssh-ed25519|ecdsa-[-a-z0-9]*) AAAA[0-9A-Za-z+/]+[=]{0,3}( .+)?$/;
 const DNS_NAME_REGEX = /^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$/;
@@ -54,7 +53,7 @@ export const nameValidationSchema = (
   const clusterNameValidationMessagesList = clusterNameValidationMessages(t);
   return Yup.string()
     .required('Required')
-    .matches(isOcm ? CLUSTER_NAME_REGEX : CLUSTER_NAME_NO_DOT_REGEX, {
+    .matches(CLUSTER_NAME_NO_DOT_REGEX, {
       message: clusterNameValidationMessagesList.INVALID_VALUE,
       excludeEmptyString: true,
     })

--- a/src/common/components/ui/formik/validationSchemas.ts
+++ b/src/common/components/ui/formik/validationSchemas.ts
@@ -27,7 +27,7 @@ const NAME_CHARS_REGEX = /^[a-z0-9-.]*$/;
 const CLUSTER_NAME_START_END_REGEX = /^[a-z0-9](.*[a-z0-9])?$/;
 // NOTE: based on https://github.com/openshift/assisted-service/blob/master/internal/cluster/validations/validations.go#L32
 const CLUSTER_NAME_REGEX =
-  /^[.-a-z0-9]?(([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)*)[.-a-z0-9]?$/;
+  /^[-a-z0-9]?(([a-z0-9]([-a-z0-9]*[a-z0-9])?([a-z0-9]([-a-z0-9]*[a-z0-9])?)*)*)[-a-z0-9]?$/;
 const CLUSTER_NAME_NO_DOT_REGEX = /^[a-z0-9-]*$/;
 const SSH_PUBLIC_KEY_REGEX =
   /^(ssh-rsa|ssh-ed25519|ecdsa-[-a-z0-9]*) AAAA[0-9A-Za-z+/]+[=]{0,3}( .+)?$/;
@@ -55,9 +55,7 @@ export const nameValidationSchema = (
   return Yup.string()
     .required('Required')
     .matches(isOcm ? CLUSTER_NAME_REGEX : CLUSTER_NAME_NO_DOT_REGEX, {
-      message: isOcm
-        ? clusterNameValidationMessagesList.INVALID_VALUE_OCM
-        : clusterNameValidationMessagesList.INVALID_VALUE_ACM,
+      message: clusterNameValidationMessagesList.INVALID_VALUE,
       excludeEmptyString: true,
     })
     .matches(CLUSTER_NAME_START_END_REGEX, {

--- a/src/common/components/ui/formik/validationSchemas.ts
+++ b/src/common/components/ui/formik/validationSchemas.ts
@@ -25,9 +25,7 @@ const ALPHANUMERIC_REGEX = /^[a-zA-Z0-9]+$/;
 const NAME_START_END_REGEX = /^[a-z0-9](.*[a-z0-9])?$/;
 const NAME_CHARS_REGEX = /^[a-z0-9-.]*$/;
 const CLUSTER_NAME_START_END_REGEX = /^[a-z0-9](.*[a-z0-9])?$/;
-// NOTE: based on https://github.com/openshift/assisted-service/blob/master/internal/cluster/validations/validations.go#L32
-const CLUSTER_NAME_NO_DOT_REGEX =
-  /^[a-z0-9]?(([a-z0-9]([-a-z0-9]*[a-z0-9])?([a-z0-9]([-a-z0-9]*[a-z0-9])?)*)*)[a-z0-9]?$/;
+const CLUSTER_NAME_VALID_CHARS_REGEX = /^[a-z0-9-]*$/;
 const SSH_PUBLIC_KEY_REGEX =
   /^(ssh-rsa|ssh-ed25519|ecdsa-[-a-z0-9]*) AAAA[0-9A-Za-z+/]+[=]{0,3}( .+)?$/;
 const DNS_NAME_REGEX = /^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$/;
@@ -53,7 +51,7 @@ export const nameValidationSchema = (
   const clusterNameValidationMessagesList = clusterNameValidationMessages(t);
   return Yup.string()
     .required('Required')
-    .matches(CLUSTER_NAME_NO_DOT_REGEX, {
+    .matches(CLUSTER_NAME_VALID_CHARS_REGEX, {
       message: clusterNameValidationMessagesList.INVALID_VALUE,
       excludeEmptyString: true,
     })


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-12756

Prevent cluster name to contain "dot" character
Similar to https://github.com/openshift-assisted/assisted-ui-lib/pull/1786/files

plus some Eslint fixes