### PR TITLE
MGMT-12658 Change platform integration label

### DIFF
--- a/src/ocm/components/clusterConfiguration/platformIntegration/PlatformIntegration.tsx
+++ b/src/ocm/components/clusterConfiguration/platformIntegration/PlatformIntegration.tsx
@@ -33,7 +33,7 @@ const PlatformIntegrationLabel = ({
 }) => {
   return (
     <>
-      <span>Integrate with platform (vSphere/Nutanix)</span>{' '}
+      <span>Integrate with your virtualization platform</span>{' '}
       <PopoverIcon
         bodyContent={messages[supportedPlatformIntegration]}
         footerContent={supportedPlatformIntegration === 'vsphere' && <PlatformIntegrationVsphere />}


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-12658

Made the label generic. The current tooltip is specific to the supported virtualization platform when all hosts are originated from the same one.

No platform supported yet:
![no-platform-supported-yet](https://user-images.githubusercontent.com/829045/208138524-f8700938-088f-462d-bab2-87ad496890e6.png)

Vsphere integration supported:
![vsphere-discovered-hosts](https://user-images.githubusercontent.com/829045/208138530-2b1bd048-0ced-4465-90dd-67788002bb4f.png)

Nutanix integration supported:
![nutanix-discovered-hosts](https://user-images.githubusercontent.com/829045/208138542-879b2875-93e6-4a83-be4d-b66aa1d6e2ae.png)
