### PR TITLE
MGMT-12993 multi issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "prepare": "install-peers",
     "test": "run-s test:circular lint format:check",
     "test:circular": "dpdm --warning false --tree false --exit-code circular:1 ./src/index.ts",
-    "lint": "eslint . --max-warnings=234 --color",
+    "lint": "eslint . --max-warnings=222 --color",
     "lint:fix": "yarn run lint --fix",
     "format": "prettier --write '**/*.{json,md,scss,yaml,yml}'",
     "format:check": "prettier --check '**/*.{json,md,scss,yaml,yml}'",

--- a/src/common/components/clusterConfiguration/utils.ts
+++ b/src/common/components/clusterConfiguration/utils.ts
@@ -20,12 +20,49 @@ import {
 import {
   HostDiscoveryValues,
   HostSubnets,
+  OpenshiftVersionOptionType,
   StorageValues,
   Validation,
   ValidationGroup,
   ValidationsInfo,
-} from '../../types/clusters';
+  WithRequired,
+} from '../../types';
 import { getHostname } from '../hosts/utils';
+
+type VersionConfig = WithRequired<Pick<Cluster, 'openshiftVersion'>, 'openshiftVersion'> & {
+  cpuArchitecture?: Cluster['cpuArchitecture'];
+  versions?: OpenshiftVersionOptionType[];
+  withPreviewText?: boolean;
+  withMultiText?: boolean;
+};
+
+const getBetaVersionText = (
+  openshiftVersion: string,
+  versions: OpenshiftVersionOptionType[],
+): string => {
+  const versionSelected = versions.find((version) => version.version === openshiftVersion);
+  return versionSelected?.supportLevel === 'beta' ? '- Developer preview release' : '';
+};
+
+const getMultiVersionText = (
+  openshiftVersion: string,
+  cpuArchitecture: Cluster['cpuArchitecture'],
+) => {
+  if (!cpuArchitecture || openshiftVersion.includes('multi')) {
+    return '';
+  }
+  return cpuArchitecture === 'multi' ? ' (multi)' : '';
+};
+
+export const getOpenshiftVersionText = (params: VersionConfig) => {
+  return `${params.openshiftVersion} ${
+    params.withPreviewText && params.versions
+      ? getBetaVersionText(params.openshiftVersion, params.versions)
+      : ''
+  } ${
+    params.withMultiText ? getMultiVersionText(params.openshiftVersion, params.cpuArchitecture) : ''
+  }`;
+};
 
 export const getSubnet = (cidr: string): Address6 | Address4 | null => {
   if (Address4.isValid(cidr)) {

--- a/src/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
+++ b/src/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
@@ -11,7 +11,6 @@ import {
   OpenshiftVersionOptionType,
   PullSecret,
   SNOControlGroup,
-  StaticTextField,
   ocmClusterNameValidationMessages,
   uniqueOcmClusterNameValidationMessages,
 } from '../../../common';
@@ -23,6 +22,7 @@ import {
   OcmRichInputField,
   OcmSelectField,
 } from '../ui/OcmFormFields';
+import OcmOpenShiftVersion from './OcmOpenShiftVersion';
 import OcmOpenShiftVersionSelect from './OcmOpenShiftVersionSelect';
 
 export type OcmClusterDetailsFormFieldsProps = {
@@ -35,6 +35,7 @@ export type OcmClusterDetailsFormFieldsProps = {
   toggleRedHatDnsService?: (checked: boolean) => void;
   isPullSecretSet: boolean;
   clusterExists: boolean;
+  cpuArchitecture?: string;
 };
 
 const BaseDnsHelperText = ({ name, baseDnsDomain }: { name?: string; baseDnsDomain?: string }) => (
@@ -57,6 +58,7 @@ export const OcmClusterDetailsFormFields = ({
   forceOpenshiftVersion,
   isOcm,
   clusterExists,
+  cpuArchitecture,
 }: OcmClusterDetailsFormFieldsProps) => {
   const { values } = useFormikContext<ClusterDetailsValues>();
   const { name, baseDnsDomain, highAvailabilityMode, useRedHatDnsService } = values;
@@ -111,10 +113,13 @@ export const OcmClusterDetailsFormFields = ({
         />
       )}
       {forceOpenshiftVersion ? (
-        <StaticTextField name="openshiftVersion" label="OpenShift version" isRequired>
-          OpenShift {forceOpenshiftVersion}{' '}
-          {getDeveloperPreviewText(forceOpenshiftVersion, versions)}
-        </StaticTextField>
+        <OcmOpenShiftVersion
+          versions={versions}
+          openshiftVersion={forceOpenshiftVersion}
+          cpuArchitecture={cpuArchitecture}
+          withPreviewText
+          withMultiText
+        />
       ) : (
         <OcmOpenShiftVersionSelect versions={versions} />
       )}
@@ -131,10 +136,3 @@ export const OcmClusterDetailsFormFields = ({
     </Form>
   );
 };
-function getDeveloperPreviewText(
-  forceOpenshiftVersion: string,
-  versions: OpenshiftVersionOptionType[],
-): string {
-  const versionSelected = versions.find((version) => version.version === forceOpenshiftVersion);
-  return versionSelected?.supportLevel === 'beta' ? '- Developer preview release' : '';
-}

--- a/src/ocm/components/clusterConfiguration/OcmOpenShiftVersion.tsx
+++ b/src/ocm/components/clusterConfiguration/OcmOpenShiftVersion.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import {
+  getOpenshiftVersionText,
+  OpenshiftVersionOptionType,
+  StaticTextField,
+} from '../../../common';
+
+type OcmOpenShiftVersionProps = {
+  versions: OpenshiftVersionOptionType[];
+  openshiftVersion: string;
+  cpuArchitecture: string | undefined;
+  withPreviewText?: boolean;
+  withMultiText?: boolean;
+};
+
+const OcmOpenShiftVersion = ({
+  openshiftVersion,
+  cpuArchitecture,
+  versions,
+  withPreviewText,
+  withMultiText,
+}: OcmOpenShiftVersionProps) => {
+  return (
+    <StaticTextField name="openshiftVersion" label="OpenShift version" isRequired>
+      Openshift{' '}
+      {getOpenshiftVersionText({
+        openshiftVersion,
+        cpuArchitecture,
+        versions,
+        withPreviewText,
+        withMultiText,
+      })}
+    </StaticTextField>
+  );
+};
+
+export default OcmOpenShiftVersion;

--- a/src/ocm/components/clusterDetail/OpenShiftVersionDetail.tsx
+++ b/src/ocm/components/clusterDetail/OpenShiftVersionDetail.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import { Cluster, DetailItem } from '../../../common';
-import { useOpenshiftVersions } from '../../hooks';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens/dist/js/global_warning_color_100';
 import { Popover, Text, TextContent, TextVariants } from '@patternfly/react-core';
+
+import { Cluster, DetailItem, getOpenshiftVersionText } from '../../../common';
+import { useOpenshiftVersions } from '../../hooks';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
 
 const UnsupportedVersion = ({ version }: { version: string }) => {
@@ -27,14 +28,25 @@ const UnsupportedVersion = ({ version }: { version: string }) => {
 };
 
 const OpenShiftVersionDetail = ({ cluster }: { cluster: Cluster }) => {
-  const { isSupportedOpenShiftVersion } = useOpenshiftVersions();
   const { t } = useTranslation();
-  const { openshiftVersion: version } = cluster;
-  const isSupported = isSupportedOpenShiftVersion(version);
+  const { openshiftVersion } = cluster;
+  const { isSupportedOpenShiftVersion, versions } = useOpenshiftVersions();
+  const isSupported = isSupportedOpenShiftVersion(openshiftVersion);
+
+  const version = React.useMemo(() => {
+    return getOpenshiftVersionText({
+      versions,
+      openshiftVersion: openshiftVersion || '',
+      cpuArchitecture: cluster.cpuArchitecture,
+      withPreviewText: true,
+      withMultiText: true,
+    });
+  }, [versions, cluster.cpuArchitecture, openshiftVersion]);
+
   return (
     <DetailItem
       title={t('ai:OpenShift version')}
-      value={isSupported ? version : <UnsupportedVersion version={version || ''} />}
+      value={isSupported ? version : <UnsupportedVersion version={version} />}
       testId="openshift-version"
     />
   );

--- a/src/ocm/components/clusterWizard/ClusterDetailsForm.tsx
+++ b/src/ocm/components/clusterWizard/ClusterDetailsForm.tsx
@@ -129,6 +129,7 @@ const ClusterDetailsForm = (props: ClusterDetailsFormProps) => {
                   isOcm={!!ocmClient}
                   managedDomains={managedDomains}
                   clusterExists={!!cluster}
+                  cpuArchitecture={cluster?.cpuArchitecture}
                 />
               </GridItem>
             </Grid>

--- a/src/ocm/components/clusters/ClustersTable.tsx
+++ b/src/ocm/components/clusters/ClustersTable.tsx
@@ -34,6 +34,7 @@ interface ClustersTableProps {
 }
 
 type TablePropsCellType = TableProps['cells'][0];
+type StoredFilters = { filters: ClusterFiltersType; sortBy: ISortBy; searchString: string };
 
 const columnConfig: TablePropsCellType = {
   transforms: [sortable],
@@ -98,7 +99,7 @@ const ClustersTable: React.FC<ClustersTableProps> = ({ rows, deleteCluster }) =>
     const marshalled = window.sessionStorage.getItem(STORAGE_KEY_CLUSTERS_FILTER);
     if (marshalled) {
       try {
-        const parsed = JSON.parse(marshalled);
+        const parsed = JSON.parse(marshalled) as StoredFilters;
         parsed.filters && setFilters(parsed.filters);
         parsed.sortBy && setSortBy(parsed.sortBy);
         parsed.searchString && setSearchString(parsed.searchString);
@@ -127,7 +128,7 @@ const ClustersTable: React.FC<ClustersTableProps> = ({ rows, deleteCluster }) =>
         },
       },
     ],
-    [setDeleteClusterID],
+    [t],
   );
 
   const onSort: OnSort = React.useCallback(

--- a/src/ocm/components/featureSupportLevels/FeatureSupportLevelProvider.tsx
+++ b/src/ocm/components/featureSupportLevels/FeatureSupportLevelProvider.tsx
@@ -54,10 +54,11 @@ const getVersionSupportLevelsMap = (
   versionName: string,
   supportLevelData: FeatureSupportLevelsMap,
 ): FeatureIdToSupportLevel | undefined => {
-  const versionKey = Object.keys(supportLevelData).find((key) => {
-    const versionNameMatch = new RegExp(`^${key}(\\..*)?$`); // For version 4.10 match 4.10, 4.10.3, not 4.1, 4.1.5
-    return versionNameMatch.test(versionName);
-  });
+  // There is only one feature-support-level item per minor OpenShift version
+  // To solve the problem of partial matching (4.1 vs 4.11), we sort the list from most recent to least recent.
+  const versionKey = Object.keys(supportLevelData)
+    .reverse()
+    .find((key) => versionName.startsWith(key));
   if (!versionKey) {
     return undefined;
   }

--- a/src/ocm/selectors/clusters.tsx
+++ b/src/ocm/selectors/clusters.tsx
@@ -2,26 +2,26 @@ import React from 'react';
 import { createSelector } from 'reselect';
 import { IRow, IRowData } from '@patternfly/react-table';
 import { Link } from 'react-router-dom';
+import { TFunction } from 'i18next';
 
-import { ClusterTableRows } from '../../common/types/clusters';
 import {
   Cluster,
   DASH,
   getDateTimeCell,
   getEnabledHostCount,
+  getOpenshiftVersionText,
   getTotalHostCount,
+  ClusterTableRows,
   HostsCount,
   HumanizedSortable,
   ResourceUIState,
 } from '../../common';
 import ClusterStatus, { getClusterStatusText } from '../components/clusters/ClusterStatus';
-import { routeBasePath } from '../config/routeBaseBath';
-import { TFunction } from 'i18next';
+import { routeBasePath } from '../config';
 import { RootState } from '../store';
 
 const selectClusters = (state: RootState) => state.clusters.data;
 const clustersUIState = (state: RootState) => state.clusters.uiState;
-const currentClusterName = (state: RootState) => state.currentCluster.data?.name;
 
 export const selectClustersUIState = createSelector(
   [selectClusters, clustersUIState],
@@ -32,8 +32,13 @@ export const selectClustersUIState = createSelector(
 );
 
 const clusterToClusterTableRow = (cluster: Cluster, t: TFunction): IRow => {
-  const { id, name = '', openshiftVersion, baseDnsDomain, createdAt } = cluster;
+  const { id, name = '', baseDnsDomain, createdAt } = cluster;
   const dateTimeCell = getDateTimeCell(createdAt);
+  const versionText = getOpenshiftVersionText({
+    openshiftVersion: cluster.openshiftVersion || '',
+    cpuArchitecture: cluster.cpuArchitecture,
+    withMultiText: true,
+  });
   return {
     cells: [
       {
@@ -51,9 +56,9 @@ const clusterToClusterTableRow = (cluster: Cluster, t: TFunction): IRow => {
         sortableValue: baseDnsDomain,
       },
       {
-        title: openshiftVersion,
+        title: versionText,
         props: { 'data-testid': `cluster-version-${name}` },
-        sortableValue: openshiftVersion,
+        sortableValue: versionText,
       },
       {
         title: <ClusterStatus status={cluster.status} />,
@@ -92,10 +97,4 @@ export const selectClusterTableRows = (t: TFunction) => {
 
 export const selectClusterNames = createSelector(selectClusters, (clusters) =>
   clusters.map((c) => c.name),
-);
-
-export const selectClusterNamesButCurrent = createSelector(
-  selectClusterNames,
-  currentClusterName,
-  (clusterNames, currentName) => clusterNames.filter((n) => n !== currentName),
 );


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-12993

Fixes problems related to "multi" OpenShift version releases:

1. The SNO disclaimer wasn't appearing for version `4.12-multi` because the format didn't match the one we were checking. Changed the way we do the matching, so that it finds the proper version in feature-support-level.

2. Created a common function that can be used to display the OpenShift version. It can be configured to append "multi" for multi versions which don't contain the text ("multi") in the version name.

https://user-images.githubusercontent.com/829045/208673196-34592952-6198-4243-af68-8b8806561535.mp4

