### PR TITLE
MGMT-12382 - Nutanix cluster - Trying to enable DHCP for vips returns "The DHCP server failed to allocate the IP" [BACKPORT]

### DIFF
--- a/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
@@ -38,6 +38,7 @@ import { captureException } from '../../../sentry';
 import { ClustersService } from '../../../services';
 import { updateClusterBase } from '../../../reducers/clusters';
 import { getApiErrorMessage, handleApiError } from '../../../api';
+import { useClusterSupportedPlatforms } from '../../../hooks';
 
 const NetworkConfigurationForm: React.FC<{
   cluster: Cluster;
@@ -58,19 +59,20 @@ const NetworkConfigurationForm: React.FC<{
     useFormikContext<NetworkConfigurationValues>();
   const isAutoSaveRunning = useFormikAutoSave();
   const errorFields = getFormikErrorFields(errors, touched);
+  const { supportedPlatformIntegration } = useClusterSupportedPlatforms(cluster.id);
 
-  // DHCP allocation is currently not supported with Nutanix
+  // DHCP allocation is currently not supported for Nutanix hosts
   // https://issues.redhat.com/browse/MGMT-12382
-  const isClusterPlatformTypeNutanix = React.useMemo(
-    () => cluster.platform?.type === 'nutanix',
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
+  const isHostsPlatformTypeNutanix = React.useMemo(
+    () => supportedPlatformIntegration.includes('nutanix'),
+    [supportedPlatformIntegration],
   );
+
   React.useEffect(() => {
-    if (isClusterPlatformTypeNutanix && values.vipDhcpAllocation) {
+    if (isHostsPlatformTypeNutanix && values.vipDhcpAllocation) {
       setFieldValue('vipDhcpAllocation', false);
     }
-  }, [isClusterPlatformTypeNutanix, setFieldValue, values.vipDhcpAllocation]);
+  }, [isHostsPlatformTypeNutanix, setFieldValue, values.vipDhcpAllocation]);
 
   const footer = (
     <ClusterWizardFooter
@@ -102,7 +104,7 @@ const NetworkConfigurationForm: React.FC<{
                 cluster={cluster}
                 hostSubnets={hostSubnets}
                 defaultNetworkSettings={defaultNetworkSettings}
-                isVipDhcpAllocationDisabled={isClusterPlatformTypeNutanix}
+                isVipDhcpAllocationDisabled={isHostsPlatformTypeNutanix}
               />
               <SecurityFields
                 clusterSshKey={cluster.sshPublicKey}


### PR DESCRIPTION
Backport of #1821 

> https://issues.redhat.com/browse/MGMT-12382
> 
> DHCP allocation is not supported for nutanix hosts (even if platform integration was not enabled). We need to check the supported-platforms instead of cluster.platform.type to determine whether to hide the DHCP checkbox or not.
> 
> Note that it takes a second to get the `supported-platforms` and check for nutanix. So for that second the DHCP checkbox might appear and then disappear. I figured not-hiding it initially was better than hiding it and having it appear after a second (I assume there will be more people with non-nutanix hosts than vice versa).
> 
> If anyone has any ideas for how to avoid this flashing, they are welcome.