### PR TITLE
MGMT-9722 Preflight validations with better spacing

### DIFF
--- a/src/ocm/components/clusterConfiguration/review/ReviewPreflightChecks.tsx
+++ b/src/ocm/components/clusterConfiguration/review/ReviewPreflightChecks.tsx
@@ -15,6 +15,13 @@ import {
   InfoCircleIcon,
 } from '@patternfly/react-icons';
 import {
+  global_success_color_100 as okColor,
+  global_info_color_100 as infoColor,
+  global_danger_color_100 as dangerColor,
+  global_warning_color_100 as warningColor,
+} from '@patternfly/react-tokens';
+
+import {
   Cluster,
   ClusterValidations,
   DetailItem,
@@ -36,24 +43,18 @@ import {
   SupportLevelMemo,
   getSupportLevelInfo,
 } from '../../featureSupportLevels/ReviewClusterFeatureSupportLevels';
-import {
-  global_success_color_100 as okColor,
-  global_info_color_100 as infoColor,
-  global_danger_color_100 as dangerColor,
-  global_warning_color_100 as warningColor,
-} from '@patternfly/react-tokens';
-import { useTranslation } from '../../../../common/hooks/use-translation-wrapper';
 
+import { useTranslation } from '../../../../common/hooks/use-translation-wrapper';
 import { ValidationsInfo as ClusterValidationsInfo } from '../../../../common/types/clusters';
 import { ValidationsInfo as HostValidationsInfo } from '../../../../common/types/hosts';
 
-const ValidationsDetailExpanded = ({ cluster }: { cluster: Cluster }) => {
+const PreflightChecksDetailExpanded = ({ cluster }: { cluster: Cluster }) => {
   const clusterWizardContext = useClusterWizardContext();
 
   return (
     <DetailList>
       <DetailItem
-        title="Cluster validations"
+        title="Cluster preflight checks"
         value={
           <ClusterValidations<ClusterWizardStepsType>
             validationsInfo={cluster.validationsInfo}
@@ -62,10 +63,11 @@ const ValidationsDetailExpanded = ({ cluster }: { cluster: Cluster }) => {
             wizardStepsValidationsMap={wizardStepsValidationsMap}
           />
         }
-        testId="cluster-validations"
+        classNameValue={'pf-u-mb-md'}
+        testId="cluster-preflight-checks"
       />
       <DetailItem
-        title="Host validations"
+        title="Host preflight checks"
         value={
           <HostsValidations<ClusterWizardStepsType, typeof allClusterWizardSoftValidationIds>
             hosts={cluster.hosts}
@@ -75,24 +77,29 @@ const ValidationsDetailExpanded = ({ cluster }: { cluster: Cluster }) => {
             wizardStepsValidationsMap={wizardStepsValidationsMap}
           />
         }
-        testId="host-validations"
+        classNameValue={'pf-u-mb-md'}
+        testId="host-preflight-checks"
       />
       <ClusterFeatureSupportLevelsDetailItem cluster={cluster} />
     </DetailList>
   );
 };
 
-const ValidationsInfo = ({
+const PreflightCheckInfo = ({
   title,
   icon,
   span = 3,
+  offset,
+  className,
 }: {
   title: string;
   icon: React.ReactNode;
   span?: gridSpans;
+  offset?: gridSpans;
+  className?: string;
 }) => {
   return (
-    <GridItem span={span}>
+    <GridItem span={span} offset={offset} className={className}>
       <Split hasGutter>
         <SplitItem>{icon}</SplitItem>
         <SplitItem>
@@ -103,7 +110,7 @@ const ValidationsInfo = ({
   );
 };
 
-const getValidationsIcon = (validationStatuses: string[]) => {
+const getCheckIcon = (validationStatuses: string[]) => {
   if (validationStatuses.includes('failure') || validationStatuses.includes('error')) {
     return <ExclamationCircleIcon color={dangerColor.value} size="sm" />;
   } else if (validationStatuses.includes('warning')) {
@@ -114,7 +121,7 @@ const getValidationsIcon = (validationStatuses: string[]) => {
   return <CheckCircleIcon color={okColor.value} />;
 };
 
-const ValidationsDetailCollapsed = ({ cluster }: { cluster: Cluster }) => {
+const PreflightChecksDetailCollapsed = ({ cluster }: { cluster: Cluster }) => {
   const { t } = useTranslation();
   const featureSupportLevelData = useFeatureSupportLevel();
   const { isSupportedOpenShiftVersion } = useOpenshiftVersions();
@@ -157,9 +164,12 @@ const ValidationsDetailCollapsed = ({ cluster }: { cluster: Cluster }) => {
 
   return (
     <>
-      <ValidationsInfo title="Cluster validations" icon={getValidationsIcon(clusterValidations)} />
-      <ValidationsInfo title="Host validations" icon={getValidationsIcon(hostValidations)} />
-      <ValidationsInfo
+      <PreflightCheckInfo
+        title="Cluster preflight checks"
+        icon={getCheckIcon(clusterValidations)}
+      />
+      <PreflightCheckInfo title="Host preflight checks" icon={getCheckIcon(hostValidations)} />
+      <PreflightCheckInfo
         title={`Cluster support level: ${isFullySupported ? 'Full' : 'Limited'}`}
         icon={supportLevelIcon}
         span={4}
@@ -168,8 +178,8 @@ const ValidationsDetailCollapsed = ({ cluster }: { cluster: Cluster }) => {
   );
 };
 
-export const ReviewValidations = ({ cluster }: { cluster: Cluster }) => {
-  const [isValidationsExpanded, setValidationsExpanded] = React.useState(false);
+const ReviewPreflightChecks = ({ cluster }: { cluster: Cluster }) => {
+  const [isChecksExpanded, setChecksExpanded] = React.useState(false);
   return (
     <>
       <Divider />
@@ -177,18 +187,20 @@ export const ReviewValidations = ({ cluster }: { cluster: Cluster }) => {
       <ExpandableSection
         toggleContent={
           <Grid>
-            <GridItem span={2}>Validations</GridItem>
-            {!isValidationsExpanded && <ValidationsDetailCollapsed cluster={cluster} />}
+            <GridItem span={2}>Preflight checks</GridItem>
+            {!isChecksExpanded && <PreflightChecksDetailCollapsed cluster={cluster} />}
           </Grid>
         }
         isIndented
-        isExpanded={isValidationsExpanded}
-        onToggle={() => setValidationsExpanded(!isValidationsExpanded)}
+        isExpanded={isChecksExpanded}
+        onToggle={() => setChecksExpanded(!isChecksExpanded)}
         className={'review-expandable'}
       >
-        <ValidationsDetailExpanded cluster={cluster} />
+        <PreflightChecksDetailExpanded cluster={cluster} />
       </ExpandableSection>
       <Divider />
     </>
   );
 };
+
+export default ReviewPreflightChecks;

--- a/src/ocm/components/clusterConfiguration/review/ReviewStep.tsx
+++ b/src/ocm/components/clusterConfiguration/review/ReviewStep.tsx
@@ -10,8 +10,8 @@ import ClusterWizardNavigation from '../../clusterWizard/ClusterWizardNavigation
 import { ClustersService } from '../../../services';
 import { useStateSafely } from '../../../../common/hooks';
 import { selectCurrentClusterPermissionsState } from '../../../selectors';
-import { ReviewValidations } from './ReviewValidations';
-import { ReviewSummary } from './ReviewSummary';
+import ReviewPreflightChecks from './ReviewPreflightChecks';
+import ReviewSummary from './ReviewSummary';
 import './ReviewCluster.css';
 
 const ReviewStep = ({ cluster }: { cluster: Cluster }) => {
@@ -67,7 +67,7 @@ const ReviewStep = ({ cluster }: { cluster: Cluster }) => {
         <GridItem>
           <ClusterWizardStepHeader>Review and create</ClusterWizardStepHeader>
         </GridItem>
-        <ReviewValidations cluster={cluster} />
+        <ReviewPreflightChecks cluster={cluster} />
         <ReviewSummary cluster={cluster} />
       </Grid>
     </ClusterWizardStep>

--- a/src/ocm/components/clusterConfiguration/review/ReviewSummary.tsx
+++ b/src/ocm/components/clusterConfiguration/review/ReviewSummary.tsx
@@ -15,7 +15,7 @@ import {
   TableSummaryExpandable,
 } from '.';
 
-export const ReviewSummary = ({ cluster }: { cluster: Cluster }) => {
+const ReviewSummary = ({ cluster }: { cluster: Cluster }) => {
   const showOperatorsSummary =
     hasEnabledOperators(cluster.monitoredOperators, OPERATOR_NAME_CNV) ||
     hasEnabledOperators(cluster.monitoredOperators, OPERATOR_NAME_ODF) ||
@@ -48,3 +48,5 @@ export const ReviewSummary = ({ cluster }: { cluster: Cluster }) => {
     </ExpandableSection>
   );
 };
+
+export default ReviewSummary;

--- a/src/ocm/components/featureSupportLevels/ReviewClusterFeatureSupportLevels.tsx
+++ b/src/ocm/components/featureSupportLevels/ReviewClusterFeatureSupportLevels.tsx
@@ -172,6 +172,7 @@ const SupportLevel = ({ cluster }: SupportLevelProps) => {
           />
         )
       }
+      classNameValue={'pf-u-mb-md'}
       testId="feature-support-levels"
     />
   );


### PR DESCRIPTION
Extracted from https://github.com/openshift-assisted/assisted-ui-lib/pull/1826 everything except the new design for the Platform Integration note.



-   The section "validations" had been renamed to "preflight checks" although the design was not updated
-   Increased the spacing in the "preflight checks" section titles.
