### PR TITLE
MGMT-11964: Change text multi for "Multiple CPU architectures" 

### DIFF
--- a/src/ocm/components/clusterDetail/ClusterProperties.tsx
+++ b/src/ocm/components/clusterDetail/ClusterProperties.tsx
@@ -106,7 +106,11 @@ const ClusterProperties = ({ cluster, externalMode = false }: ClusterPropertiesP
           <DetailItem title="Base domain" value={cluster.baseDnsDomain} testId="base-dns-domain" />
           <DetailItem
             title={<CpuArchTitle isMultiArchSupported={isMultiArchSupported} />}
-            value={cluster.cpuArchitecture}
+            value={
+              cluster.cpuArchitecture === 'multi'
+                ? 'Multiple CPU architectures'
+                : cluster.cpuArchitecture
+            }
             testId="cpu-architecture"
           />
           <DetailItem


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-11964
In multiarch clusters, change the text multi for "Multiple CPU architectures" in the Review&Create page:
![image](https://user-images.githubusercontent.com/11390125/210209519-ea57b939-3a25-488f-b599-736b6c8c1b31.png)
