### PR TITLE
MGMT-13087: Not show nutanix message in host discovery step when nutanix is not supported

### DIFF
--- a/src/ocm/components/clusterWizard/ClusterPlatformIntegrationHint.tsx
+++ b/src/ocm/components/clusterWizard/ClusterPlatformIntegrationHint.tsx
@@ -6,12 +6,14 @@ import {
   NUTANIX_CONFIG_LINK,
   PlatformType,
   SupportedPlatformType,
+  useFeatureSupportLevel,
   VSPHERE_CONFIG_LINK,
 } from '../../../common';
 
 type ClusterPlatformIntegrationHintProps = {
   clusterId: string;
   platformType: PlatformType;
+  openshiftVersion: string;
 };
 
 const integrationBrands: Record<SupportedPlatformType, string> = {
@@ -27,13 +29,19 @@ export const integrationPlatformLinks: Record<SupportedPlatformType, string> = {
 export const ClusterPlatformIntegrationHint = ({
   clusterId,
   platformType,
+  openshiftVersion,
 }: ClusterPlatformIntegrationHintProps) => {
   const { isPlatformIntegrationSupported, supportedPlatformIntegration } =
     useClusterSupportedPlatforms(clusterId);
-
+  const featureSupportLevels = useFeatureSupportLevel();
+  const isNutanixFeatureSupported = featureSupportLevels.isFeatureSupported(
+    openshiftVersion || '',
+    'NUTANIX_INTEGRATION',
+  );
   const canIntegrateWithPlatform =
-    isPlatformIntegrationSupported &&
-    !isClusterPlatformTypeVM({ platform: { type: platformType } });
+    (isPlatformIntegrationSupported &&
+      !isClusterPlatformTypeVM({ platform: { type: platformType } })) ||
+    (supportedPlatformIntegration === 'nutanix' && isNutanixFeatureSupported);
   if (!canIntegrateWithPlatform) {
     return null;
   }

--- a/src/ocm/components/clusterWizard/ClusterPlatformIntegrationHint.tsx
+++ b/src/ocm/components/clusterWizard/ClusterPlatformIntegrationHint.tsx
@@ -34,10 +34,8 @@ export const ClusterPlatformIntegrationHint = ({
   const { isPlatformIntegrationSupported, supportedPlatformIntegration } =
     useClusterSupportedPlatforms(clusterId);
   const featureSupportLevels = useFeatureSupportLevel();
-  const isNutanixFeatureSupported = featureSupportLevels.isFeatureSupported(
-    openshiftVersion || '',
-    'NUTANIX_INTEGRATION',
-  );
+  const isNutanixFeatureSupported =
+    featureSupportLevels.isFeatureSupported(openshiftVersion || '', 'NUTANIX_INTEGRATION') ?? false;
   const canIntegrateWithPlatform =
     (isPlatformIntegrationSupported &&
       !isClusterPlatformTypeVM({ platform: { type: platformType } })) ||

--- a/src/ocm/components/clusterWizard/ClusterWizardFooter.tsx
+++ b/src/ocm/components/clusterWizard/ClusterWizardFooter.tsx
@@ -52,6 +52,7 @@ const ValidationSection = ({
         <ClusterPlatformIntegrationHint
           clusterId={cluster.id}
           platformType={cluster.platform?.type || 'none'}
+          openshiftVersion={cluster.openshiftVersion || ''}
         />
       )}
 


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-13087

For OCP <= 4.10 ->  integration with Nutanix is unsupported -> We don't have to show the nutanix message in the host discovery step:
![image](https://user-images.githubusercontent.com/11390125/210346182-ee98dd86-2a7a-4a2b-8df9-eb1fe3d1de23.png)

