### PR TITLE
[2.7-cim] MGMT-13054 Fix feature support in CIM

### DIFF
--- a/src/cim/components/featureSupportLevels/ACMFeatureSupportLevelProvider.tsx
+++ b/src/cim/components/featureSupportLevels/ACMFeatureSupportLevelProvider.tsx
@@ -49,10 +49,13 @@ export const ACMFeatureSupportLevelProvider: React.FC<ACMFeatureSupportLevelProv
 
   const getNormalizedVersion = React.useCallback(
     (versionName: string) => {
-      const clusterImage = clusterImages.filter(
+      const clusterImage = clusterImages.find(
         (clusterImageSet) => clusterImageSet.metadata?.name === versionName,
       );
-      const version = getVersionFromReleaseImage(clusterImage[0]?.spec?.releaseImage);
+      const version =
+        getVersionFromReleaseImage(clusterImage?.spec?.releaseImage) ||
+        clusterImage?.metadata?.name ||
+        '';
       return getMajorMinorVersion(version);
     },
     [clusterImages],


### PR DESCRIPTION
- getNormalizedVersion function tries to get the version from releaseImage and if it fails it uses clusterImageSet name

Fixes MGMT-13054
Cherry-picked from fa97fa20