### PR TITLE
MGMT-13103: Block UMN option in case we're in nutanix platform

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -728,6 +728,7 @@
   "ai:Used to describe hosts' physical location. Helps for quicker host selection during cluster creation.": "Used to describe hosts' physical location. Helps for quicker host selection during cluster creation.",
   "ai:useFeatureSupportLevel must be used within FeatureSupportLevelContextProvider.": "useFeatureSupportLevel must be used within FeatureSupportLevelContextProvider.",
   "ai:User-Managed Networking": "User-Managed Networking",
+  "ai:User-Managed Networking is not supported when using Nutanix": "User-Managed Networking is not supported when using Nutanix",
   "ai:Username": "Username",
   "ai:Valid hostname": "Valid hostname",
   "ai:Valid network prefix": "Valid network prefix",

--- a/src/common/components/clusterWizard/networkingSteps/ManagedNetworkingControlGroup.tsx
+++ b/src/common/components/clusterWizard/networkingSteps/ManagedNetworkingControlGroup.tsx
@@ -7,16 +7,25 @@ import { useTranslation } from '../../../hooks/use-translation-wrapper';
 export interface ManagedNetworkingControlGroupProps {
   disabled: boolean;
   tooltip?: string;
+  isUmnDisabled?: boolean;
 }
+
+const tooltipUmnDisabled = 'User-Managed Networking is not supported when using Nutanix';
 
 const GROUP_NAME = 'managedNetworkingType';
 export const ManagedNetworkingControlGroup = ({
   disabled = false,
   tooltip,
+  isUmnDisabled,
 }: ManagedNetworkingControlGroupProps) => {
   const tooltipProps: TooltipProps = {
     hidden: !tooltip || !disabled,
     content: tooltip,
+    position: 'top',
+  };
+  const tooltipPropsUmnDisabled: TooltipProps = {
+    hidden: !isUmnDisabled,
+    content: tooltipUmnDisabled,
     position: 'top',
   };
   const { t } = useTranslation();
@@ -34,9 +43,9 @@ export const ManagedNetworkingControlGroup = ({
         label={t('ai:Cluster-Managed Networking')}
       />
       <RadioFieldWithTooltip
-        tooltipProps={tooltipProps}
+        tooltipProps={isUmnDisabled ? tooltipPropsUmnDisabled : tooltipProps}
         name={GROUP_NAME}
-        isDisabled={disabled}
+        isDisabled={disabled || (isUmnDisabled ? isUmnDisabled : false)}
         value={'userManaged'}
         label={t('ai:User-Managed Networking')}
       />

--- a/src/common/components/clusterWizard/networkingSteps/ManagedNetworkingControlGroup.tsx
+++ b/src/common/components/clusterWizard/networkingSteps/ManagedNetworkingControlGroup.tsx
@@ -43,7 +43,7 @@ export const ManagedNetworkingControlGroup = ({
         label={t('ai:Cluster-Managed Networking')}
       />
       <RadioFieldWithTooltip
-        tooltipProps={tooltipUmnDisabled !== '' ? tooltipPropsUmnDisabled : tooltipProps}
+        tooltipProps={tooltipUmnDisabled ? tooltipPropsUmnDisabled : tooltipProps}
         name={GROUP_NAME}
         isDisabled={disabled}
         value={'userManaged'}

--- a/src/common/components/clusterWizard/networkingSteps/ManagedNetworkingControlGroup.tsx
+++ b/src/common/components/clusterWizard/networkingSteps/ManagedNetworkingControlGroup.tsx
@@ -14,21 +14,21 @@ const GROUP_NAME = 'managedNetworkingType';
 export const ManagedNetworkingControlGroup = ({
   disabled = false,
   tooltip,
-  isUmnDisabled,
+  isUmnDisabled = false,
 }: ManagedNetworkingControlGroupProps) => {
   const tooltipProps: TooltipProps = {
     hidden: !tooltip || !disabled,
     content: tooltip,
     position: 'top',
   };
+
+  const { t } = useTranslation();
+  const tooltipUmnDisabled = t('ai:User-Managed Networking is not supported when using Nutanix');
   const tooltipPropsUmnDisabled: TooltipProps = {
     hidden: !isUmnDisabled,
     content: tooltipUmnDisabled,
     position: 'top',
   };
-  const { t } = useTranslation();
-  const tooltipUmnDisabled = t('ai:User-Managed Networking is not supported when using Nutanix');
-
   return (
     <FormGroup
       label={t('ai:Network Management')}
@@ -45,7 +45,7 @@ export const ManagedNetworkingControlGroup = ({
       <RadioFieldWithTooltip
         tooltipProps={isUmnDisabled ? tooltipPropsUmnDisabled : tooltipProps}
         name={GROUP_NAME}
-        isDisabled={disabled || (isUmnDisabled ? isUmnDisabled : false)}
+        isDisabled={disabled || isUmnDisabled}
         value={'userManaged'}
         label={t('ai:User-Managed Networking')}
       />

--- a/src/common/components/clusterWizard/networkingSteps/ManagedNetworkingControlGroup.tsx
+++ b/src/common/components/clusterWizard/networkingSteps/ManagedNetworkingControlGroup.tsx
@@ -10,8 +10,6 @@ export interface ManagedNetworkingControlGroupProps {
   isUmnDisabled?: boolean;
 }
 
-const tooltipUmnDisabled = 'User-Managed Networking is not supported when using Nutanix';
-
 const GROUP_NAME = 'managedNetworkingType';
 export const ManagedNetworkingControlGroup = ({
   disabled = false,
@@ -29,6 +27,8 @@ export const ManagedNetworkingControlGroup = ({
     position: 'top',
   };
   const { t } = useTranslation();
+  const tooltipUmnDisabled = t('ai:User-Managed Networking is not supported when using Nutanix');
+
   return (
     <FormGroup
       label={t('ai:Network Management')}

--- a/src/common/components/clusterWizard/networkingSteps/ManagedNetworkingControlGroup.tsx
+++ b/src/common/components/clusterWizard/networkingSteps/ManagedNetworkingControlGroup.tsx
@@ -7,7 +7,6 @@ import { useTranslation } from '../../../hooks/use-translation-wrapper';
 export interface ManagedNetworkingControlGroupProps {
   disabled: boolean;
   tooltip?: string;
-  isUmnDisabled?: boolean;
   tooltipUmnDisabled?: string;
 }
 
@@ -15,7 +14,6 @@ const GROUP_NAME = 'managedNetworkingType';
 export const ManagedNetworkingControlGroup = ({
   disabled = false,
   tooltip,
-  isUmnDisabled = false,
   tooltipUmnDisabled,
 }: ManagedNetworkingControlGroupProps) => {
   const tooltipProps: TooltipProps = {
@@ -27,7 +25,7 @@ export const ManagedNetworkingControlGroup = ({
   const { t } = useTranslation();
 
   const tooltipPropsUmnDisabled: TooltipProps = {
-    hidden: !isUmnDisabled,
+    hidden: !tooltipUmnDisabled || !disabled,
     content: tooltipUmnDisabled,
     position: 'top',
   };
@@ -45,9 +43,9 @@ export const ManagedNetworkingControlGroup = ({
         label={t('ai:Cluster-Managed Networking')}
       />
       <RadioFieldWithTooltip
-        tooltipProps={isUmnDisabled ? tooltipPropsUmnDisabled : tooltipProps}
+        tooltipProps={tooltipUmnDisabled !== '' ? tooltipPropsUmnDisabled : tooltipProps}
         name={GROUP_NAME}
-        isDisabled={disabled || isUmnDisabled}
+        isDisabled={disabled}
         value={'userManaged'}
         label={t('ai:User-Managed Networking')}
       />

--- a/src/common/components/clusterWizard/networkingSteps/ManagedNetworkingControlGroup.tsx
+++ b/src/common/components/clusterWizard/networkingSteps/ManagedNetworkingControlGroup.tsx
@@ -8,6 +8,7 @@ export interface ManagedNetworkingControlGroupProps {
   disabled: boolean;
   tooltip?: string;
   isUmnDisabled?: boolean;
+  tooltipUmnDisabled?: string;
 }
 
 const GROUP_NAME = 'managedNetworkingType';
@@ -15,6 +16,7 @@ export const ManagedNetworkingControlGroup = ({
   disabled = false,
   tooltip,
   isUmnDisabled = false,
+  tooltipUmnDisabled,
 }: ManagedNetworkingControlGroupProps) => {
   const tooltipProps: TooltipProps = {
     hidden: !tooltip || !disabled,
@@ -23,7 +25,7 @@ export const ManagedNetworkingControlGroup = ({
   };
 
   const { t } = useTranslation();
-  const tooltipUmnDisabled = t('ai:User-Managed Networking is not supported when using Nutanix');
+
   const tooltipPropsUmnDisabled: TooltipProps = {
     hidden: !isUmnDisabled,
     content: tooltipUmnDisabled,

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
@@ -211,6 +211,8 @@ const NetworkConfiguration = ({
     [cluster.cpuArchitecture, cluster.openshiftVersion, featureSupportLevelData, isDualStack],
   );
 
+  const umnDisabledReason = t('ai:User-Managed Networking is not supported when using Nutanix');
+
   const { supportedPlatformIntegration } = useClusterSupportedPlatforms(cluster.id);
 
   return (
@@ -220,6 +222,7 @@ const NetworkConfiguration = ({
           disabled={isViewerMode || isNetworkManagementDisabled}
           tooltip={networkManagementDisabledReason}
           isUmnDisabled={supportedPlatformIntegration === 'nutanix'}
+          tooltipUmnDisabled={umnDisabledReason}
         />
       )}
 

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
@@ -31,6 +31,7 @@ import { selectCurrentClusterPermissionsState } from '../../../selectors';
 import { OcmCheckbox } from '../../ui/OcmFormFields';
 import { NetworkTypeControlGroup } from '../../../../common/components/clusterWizard/networkingSteps/NetworkTypeControlGroup';
 import { useClusterSupportedPlatforms } from '../../../hooks';
+import { TFunction } from 'i18next';
 
 export type NetworkConfigurationProps = VirtualIPControlGroupProps & {
   hostSubnets: HostSubnets;
@@ -111,6 +112,25 @@ const isManagedNetworkingDisabled = (
     };
   } else {
     return { isNetworkManagementDisabled: false, networkManagementDisabledReason: undefined };
+  }
+};
+
+const isUserManagedNetworkingDisabled = (
+  isSupportedPlatformIntegrationNutanix: boolean,
+  t: TFunction,
+) => {
+  if (isSupportedPlatformIntegrationNutanix) {
+    return {
+      isUserManagementDisabled: isSupportedPlatformIntegrationNutanix,
+      userManagementDisabledReason: t(
+        'ai:User-Managed Networking is not supported when using Nutanix',
+      ),
+    };
+  } else {
+    return {
+      isUserManagementDisabled: false,
+      userManagementDisabledReason: '',
+    };
   }
 };
 
@@ -200,6 +220,8 @@ const NetworkConfiguration = ({
     }
   }, [shouldUpdateAdvConf, toggleAdvConfiguration]);
 
+  const { supportedPlatformIntegration } = useClusterSupportedPlatforms(cluster.id);
+  const isSupportedPlatformIntegrationNutanix = supportedPlatformIntegration === 'nutanix';
   const { isNetworkManagementDisabled, networkManagementDisabledReason } = React.useMemo(
     () =>
       isManagedNetworkingDisabled(
@@ -211,18 +233,18 @@ const NetworkConfiguration = ({
     [cluster.cpuArchitecture, cluster.openshiftVersion, featureSupportLevelData, isDualStack],
   );
 
-  const umnDisabledReason = t('ai:User-Managed Networking is not supported when using Nutanix');
-
-  const { supportedPlatformIntegration } = useClusterSupportedPlatforms(cluster.id);
+  const { isUserManagementDisabled, userManagementDisabledReason } = React.useMemo(
+    () => isUserManagedNetworkingDisabled(isSupportedPlatformIntegrationNutanix, t),
+    [isSupportedPlatformIntegrationNutanix, t],
+  );
 
   return (
     <Grid hasGutter>
       {!hideManagedNetworking && (
         <ManagedNetworkingControlGroup
-          disabled={isViewerMode || isNetworkManagementDisabled}
+          disabled={isViewerMode || isNetworkManagementDisabled || isUserManagementDisabled}
           tooltip={networkManagementDisabledReason}
-          isUmnDisabled={supportedPlatformIntegration === 'nutanix'}
-          tooltipUmnDisabled={umnDisabledReason}
+          tooltipUmnDisabled={userManagementDisabledReason}
         />
       )}
 

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
@@ -30,6 +30,7 @@ import { useTranslation } from '../../../../common/hooks/use-translation-wrapper
 import { selectCurrentClusterPermissionsState } from '../../../selectors';
 import { OcmCheckbox } from '../../ui/OcmFormFields';
 import { NetworkTypeControlGroup } from '../../../../common/components/clusterWizard/networkingSteps/NetworkTypeControlGroup';
+import { useClusterSupportedPlatforms } from '../../../hooks';
 
 export type NetworkConfigurationProps = VirtualIPControlGroupProps & {
   hostSubnets: HostSubnets;
@@ -210,12 +211,15 @@ const NetworkConfiguration = ({
     [cluster.cpuArchitecture, cluster.openshiftVersion, featureSupportLevelData, isDualStack],
   );
 
+  const { supportedPlatformIntegration } = useClusterSupportedPlatforms(cluster.id);
+
   return (
     <Grid hasGutter>
       {!hideManagedNetworking && (
         <ManagedNetworkingControlGroup
           disabled={isViewerMode || isNetworkManagementDisabled}
           tooltip={networkManagementDisabledReason}
+          isUmnDisabled={supportedPlatformIntegration === 'nutanix'}
         />
       )}
 


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-13103

UI should block UMN in case of Nutanix platform:
![umn_disabled_nutanix_with_tooltip2](https://user-images.githubusercontent.com/11390125/212036869-7838a98e-2aa3-4169-8e4d-1525084ac4bb.png)

