### PR TITLE
MGMT-13062: Change alert in odf installations about formatting installation disks

### DIFF
--- a/src/ocm/components/hosts/OdfDisksManualFormattingHint.tsx
+++ b/src/ocm/components/hosts/OdfDisksManualFormattingHint.tsx
@@ -1,34 +1,24 @@
 import React from 'react';
-import {
-  Button,
-  ButtonVariant,
-  Popover,
-  Text,
-  TextContent,
-  TextVariants,
-} from '@patternfly/react-core';
-import { ExclamationTriangleIcon } from '@patternfly/react-icons';
-import { global_warning_color_100 as warningColor } from '@patternfly/react-tokens/dist/js/global_warning_color_100';
+import { Alert, AlertVariant, Text, TextContent, TextVariants } from '@patternfly/react-core';
 
 const Hint = () => (
   <TextContent>
     <Text component={TextVariants.p}>
-      All non-installation disks will be used for local storage. To view available disks, expand
-      each host row in the table
+      All non-installation disks will be used for local storage and must be formatted before the
+      storage operator's installation. To view available disks, expand each host row in the table
     </Text>
   </TextContent>
 );
 
 const OdfDisksManualFormattingHint = () => {
   return (
-    <Text component="p">
-      <Popover bodyContent={<Hint />} minWidth="30rem">
-        <Button variant={ButtonVariant.link} isInline>
-          <ExclamationTriangleIcon className="status-icon" color={warningColor.value} size="sm" />
-          &nbsp;Format all non-installation disks
-        </Button>
-      </Popover>
-    </Text>
+    <Alert
+      variant={AlertVariant.warning}
+      isInline
+      title="Make sure you format all non-installation disks"
+    >
+      <Hint />
+    </Alert>
   );
 };
 

--- a/src/ocm/components/hosts/OdfDisksManualFormattingHint.tsx
+++ b/src/ocm/components/hosts/OdfDisksManualFormattingHint.tsx
@@ -6,7 +6,7 @@ const Hint = () => (
     <Text component={TextVariants.p}>
       All non-installation disks will be used for local storage and must be formatted before the
       storage operator's installation. To view and format available disks, expand each host row in
-      the table
+      the table.
     </Text>
   </TextContent>
 );


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-13062

Change the inline alert in odf installations to tell the user that disks needs to be formatted:
![image](https://user-images.githubusercontent.com/11390125/210577168-2fdf60d5-2b4e-435f-b6b4-16edac6ab432.png)

