### PR TITLE
MGMT-12952: LVMO operator is going to be renamed to LVMS  in 4.12

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -473,7 +473,7 @@
   "ai:OpenShift Cluster Version Operator": "OpenShift Cluster Version Operator",
   "ai:OpenShift Console": "OpenShift Console",
   "ai:OpenShift Data Foundation": "OpenShift Data Foundation",
-  "ai:OpenShift Data Foundation Logical Volume Manager": "OpenShift Data Foundation Logical Volume Manager",
+  "ai:OpenShift Data Foundation Logical Volume Manager Storage": "OpenShift Data Foundation Logical Volume Manager Storage",
   "ai:OpenShift in-place upgrades aren't expected to work with SNO. If an upgrade is needed, your system will need a redeployment.": "OpenShift in-place upgrades aren't expected to work with SNO. If an upgrade is needed, your system will need a redeployment.",
   "ai:OpenShift Local Storage": "OpenShift Local Storage",
   "ai:OpenShift version": "OpenShift version",

--- a/src/common/config/constants.ts
+++ b/src/common/config/constants.ts
@@ -297,7 +297,7 @@ export const operatorLabels = (t: TFunction): { [key in OperatorName]: string } 
   [OPERATOR_NAME_CVO]: t('ai:OpenShift Cluster Version Operator'),
   [OPERATOR_NAME_LSO]: t('ai:OpenShift Local Storage'),
   [OPERATOR_NAME_ODF]: t('ai:OpenShift Data Foundation'),
-  [OPERATOR_NAME_LVM]: t('ai:OpenShift Data Foundation Logical Volume Manager'),
+  [OPERATOR_NAME_LVM]: t('ai:OpenShift Data Foundation Logical Volume Manager Storage'),
   [OPERATOR_NAME_CNV]: t('ai:OpenShift Virtualization'),
 });
 

--- a/src/ocm/components/clusterConfiguration/operators/LvmCheckbox.tsx
+++ b/src/ocm/components/clusterConfiguration/operators/LvmCheckbox.tsx
@@ -17,7 +17,7 @@ const LVM_FIELD_NAME = 'useOdfLogicalVolumeManager';
 
 const LvmLabel = (props: ClusterOperatorProps) => (
   <>
-    Install OpenShift Data Foundation Logical Volume Manager{' '}
+    Install OpenShift Data Foundation Logical Volume Manager Storage{' '}
     <PopoverIcon
       component={'a'}
       headerContent="Additional Requirements"

--- a/src/ocm/components/featureSupportLevels/featureStateUtils.ts
+++ b/src/ocm/components/featureSupportLevels/featureStateUtils.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../common';
 
 const CNV_OPERATOR_LABEL = 'Virtualization';
-const LVM_OPERATOR_LABEL = 'OpenShift Data Foundation Logical Volume Manager';
+const LVM_OPERATOR_LABEL = 'OpenShift Data Foundation Logical Volume Manager Storage';
 
 const isArmSupported = (versionName: string, versionOptions: OpenshiftVersionOptionType[]) => {
   const versionOption = versionOptions.find((option) => option.value === versionName);
@@ -96,7 +96,7 @@ const getLvmDisabledReason = (cluster: Cluster | undefined, isSupported: boolean
     return undefined;
   }
   if (!isSupported) {
-    return 'OpenShift Data Foundation Logical Volume Manager is enabled only for OpenShift 4.11 and above.';
+    return 'OpenShift Data Foundation Logical Volume Manager Storage is enabled only for OpenShift 4.11 and above.';
   }
   return undefined;
 };


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-12952

Change LVMO operator's text to LVMS operator's text:

![Captura de pantalla de 2023-01-05 10-12-07](https://user-images.githubusercontent.com/11390125/210744365-f18326de-21e8-493b-b51b-7e2fe68a04af.png)
