### PR TITLE
MGMT-12952: LVMO operator is going to be renamed to LVMS in 4.12 - followup

### DIFF
--- a/src/ocm/components/featureSupportLevels/featureStateUtils.ts
+++ b/src/ocm/components/featureSupportLevels/featureStateUtils.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../common';
 
 const CNV_OPERATOR_LABEL = 'Virtualization';
-const LVM_OPERATOR_LABEL = 'OpenShift Data Foundation Logical Volume Manager';
+const LVM_OPERATOR_LABEL = 'OpenShift Data Foundation Logical Volume Manager Storage';
 
 const isArmSupported = (versionName: string, versionOptions: OpenshiftVersionOptionType[]) => {
   const versionOption = versionOptions.find((option) => option.value === versionName);


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-12952
Followup of #1846 

Change LVMO operator's text to LVMS operator's text:

![image](https://user-images.githubusercontent.com/11390125/211306348-96cfcb5a-dd95-4a7a-89e1-c06716d30aae.png)