### PR TITLE
MGMT-12825 Use new Github actions updated to Node16

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           cache: yarn
-          node-version: '12'
+          node-version: 16
 
       - name: Install dependencies
         # --frozen-lockfile: doesn't generate a yarn.lock file, fails if an update is needed.

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -94,7 +94,7 @@ jobs:
           context: ./assisted-ui
 
       - name: Push the assisted-ui image to Quay.io
-        uses: redhat-actions/push-to-registry@v2.6
+        uses: redhat-actions/push-to-registry@v2.7
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '12'
+          node-version: 16
           cache: yarn
           cache-dependency-path: |
             ./assisted-ui-lib/yarn.lock

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           cache: yarn
-          node-version: '12'
+          node-version: 16
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-12825

Updated Github actions to remove deprecation warnings for Node 12.
New versions have been migrated to Node 16.

See:
https://github.com/redhat-actions/push-to-registry/releases/tag/v2.7
https://github.com/redhat-actions/buildah-build/releases/tag/v2.11