### PR TITLE
NO_ISSSUE: Ignore everything inside apps dir but assisted-ui

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 package-lock.json
+
+apps/*
+!apps/assisted-ui


### PR DESCRIPTION
the monorepo introduce this new folder called `apps`. Content in there is ignored by default in the monorepo dev branch but not in master. I'm adding this rule to the .gitignore in order to allow switching between branches faster.