### PR TITLE
Add missing title to OpenShift version

### DIFF
--- a/src/ocm/components/clusterDetail/ClusterProperties.tsx
+++ b/src/ocm/components/clusterDetail/ClusterProperties.tsx
@@ -102,7 +102,13 @@ const ClusterProperties = ({ cluster, externalMode = false }: ClusterPropertiesP
       )}
       <GridItem md={6} data-testid="cluster-details">
         <DetailList>
-          {externalMode ? undefined : <OpenShiftVersionDetail cluster={cluster} />}
+          {externalMode ? undefined : (
+            <DetailItem
+              title={t('ai:OpenShift version')}
+              value={<OpenShiftVersionDetail cluster={cluster} />}
+              testId="openshift-version"
+            />
+          )}
           <DetailItem title="Base domain" value={cluster.baseDnsDomain} testId="base-dns-domain" />
           <DetailItem
             title={<CpuArchTitle isMultiArchSupported={isMultiArchSupported} />}


### PR DESCRIPTION
I noticed that in the ClusterDetails page, the OpenShift version had lost its title

Before:
![missing-label](https://user-images.githubusercontent.com/829045/213688987-51e319f8-bf99-4cff-882f-421ead59bd3e.png)

After:
![added-label](https://user-images.githubusercontent.com/829045/213688996-0c6dbce1-152d-46fc-85eb-8b63f6072178.png)
