### PR TITLE
Correct deprecated translation exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "./index.css": "./dist/index.css",
     "./cim": "./dist/cim/index.js",
     "./ocm": "./dist/ocm/index.js",
-    "./locales/": "./dist/locales/"
+    "./locales/*": "./dist/locales/*"
   },
   "typesVersions": {
     "*": {


### PR DESCRIPTION
Solving issue with exports of translation files:

```
$ eslint src --ext js,jsx,ts,tsx && yarn  prettier
(node:318907) [DEP0148] DeprecationWarning: Use of deprecated folder mapping "./locales/" in the "exports" field module resolution of the package at /home/camadorg/dev/assisted-installer/uhc-portal/node_modules/openshift-assisted-ui-lib/package.json.
Update this package.json to use a subpath pattern like "./locales/*".
(Use `node --trace-deprecation ...` to show where the warning was created)
```

Depending on the node version, it can be an error
```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './locales/en/translation.json' is not defined by "exports" in /home/user/workspace/uhc-portal/node_modules/openshift-assisted-ui-lib/package.json
Occurred while linting /home/user/workspace/uhc-portal/src/chrome-main.tsx:17
    at new NodeError (node:internal/errors:393:5)
```