### PR TITLE
Fix useInfraEnv() for missing clusterId (new cluster flow)

### DIFF
--- a/src/ocm/hooks/useInfraEnv.ts
+++ b/src/ocm/hooks/useInfraEnv.ts
@@ -4,7 +4,15 @@ import { Cluster, CpuArchitecture, InfraEnv, InfraEnvUpdateParams } from '../../
 import { getErrorMessage } from '../../common/utils';
 import { InfraEnvsAPI } from '../services/apis';
 
-export default function useInfraEnv(clusterId: Cluster['id'], cpuArchitecture: CpuArchitecture) {
+export default function useInfraEnv(
+  clusterId: Cluster['id'],
+  cpuArchitecture: CpuArchitecture,
+): {
+  infraEnv?: InfraEnv;
+  error?: string;
+  isLoading: boolean;
+  updateInfraEnv?: (infraEnvUpdateParams: InfraEnvUpdateParams) => Promise<InfraEnv>;
+} {
   const [infraEnv, setInfraEnv] = React.useState<InfraEnv>();
   const [error, setError] = React.useState('');
   const { infraEnvId, error: infraEnvIdError } = useInfraEnvId(clusterId, cpuArchitecture);

--- a/src/ocm/hooks/useInfraEnvId.ts
+++ b/src/ocm/hooks/useInfraEnvId.ts
@@ -17,7 +17,9 @@ export default function useInfraEnvId(clusterId: Cluster['id'], cpuArchitecture:
   }, [clusterId, cpuArchitecture]);
 
   React.useEffect(() => {
-    if (clusterId && !infraEnvId) {
+    if (!clusterId) {
+      setError('Missing clusterId to load infrastructure environment');
+    } else if (!infraEnvId) {
       void findInfraEnvId();
     }
   }, [clusterId, findInfraEnvId, infraEnvId]);


### PR DESCRIPTION
In the new cluster flow, the clusterId does not exist. Called from `FeatureSupportLevelProvider`.