### PR TITLE
Make new info optional in common FeatureSupportLevelData

### DIFF
--- a/src/common/components/featureSupportLevels/FeatureSupportLevelContext.tsx
+++ b/src/common/components/featureSupportLevels/FeatureSupportLevelContext.tsx
@@ -19,7 +19,7 @@ export type FeatureSupportLevelData = {
     t?: TFunction,
   ): string | undefined;
   isFeatureSupported(version: string, featureId: FeatureId): boolean;
-  activeFeatureConfiguration: ActiveFeatureConfiguration;
+  activeFeatureConfiguration?: ActiveFeatureConfiguration;
 };
 
 const FeatureSupportLevelContext = React.createContext<FeatureSupportLevelData | null>(null);

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
@@ -4,19 +4,19 @@ import { useSelector } from 'react-redux';
 import { Alert, AlertVariant, Grid, Tooltip } from '@patternfly/react-core';
 import { VirtualIPControlGroup, VirtualIPControlGroupProps } from './VirtualIPControlGroup';
 import {
-  CpuArchitecture,
-  HostSubnets,
-  NetworkConfigurationValues,
-  Cluster,
-  ClusterDefaultConfig,
-  FeatureSupportLevelData,
-  useFeatureSupportLevel,
-  isSNO,
   canBeDualStack,
   canSelectNetworkTypeSDN,
+  Cluster,
+  ClusterDefaultConfig,
   clusterNetworksEqual,
+  CpuArchitecture,
   DUAL_STACK,
+  FeatureSupportLevelData,
+  HostSubnets,
+  isSNO,
+  NetworkConfigurationValues,
   serviceNetworksEqual,
+  useFeatureSupportLevel,
 } from '../../../../common';
 import { getLimitedFeatureSupportLevels } from '../../../../common/components/featureSupportLevels/utils';
 import {
@@ -153,7 +153,8 @@ const NetworkConfiguration = ({
         t,
       ),
       underlyingCpuArchitecture:
-        featureSupportLevelData.activeFeatureConfiguration.underlyingCpuArchitecture,
+        featureSupportLevelData.activeFeatureConfiguration?.underlyingCpuArchitecture ||
+        CpuArchitecture.x86,
     };
   }, [cluster, featureSupportLevelData, t]);
   const isSNOCluster = isSNO(cluster);

--- a/src/ocm/components/clusterConfiguration/review/ReviewClusterDetailTable.tsx
+++ b/src/ocm/components/clusterConfiguration/review/ReviewClusterDetailTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Table, IRow, TableVariant, TableBody } from '@patternfly/react-table';
-import { Cluster, useFeatureSupportLevel } from '../../../../common';
+import { IRow, Table, TableBody, TableVariant } from '@patternfly/react-table';
+import { Cluster, CpuArchitecture, useFeatureSupportLevel } from '../../../../common';
 import { getDiskEncryptionEnabledOnStatus } from '../../clusterDetail/ClusterProperties';
 import OpenShiftVersionDetail from '../../clusterDetail/OpenShiftVersionDetail';
 
@@ -8,6 +8,9 @@ export const ReviewClusterDetailTable = ({ cluster }: { cluster: Cluster }) => {
   const { activeFeatureConfiguration } = useFeatureSupportLevel();
 
   const rows = React.useMemo(() => {
+    const cpuArchitecture =
+      activeFeatureConfiguration?.underlyingCpuArchitecture || CpuArchitecture.x86;
+    const hasStaticIp = activeFeatureConfiguration?.hasStaticIpNetworking || false;
     return [
       {
         cells: [
@@ -37,7 +40,7 @@ export const ReviewClusterDetailTable = ({ cluster }: { cluster: Cluster }) => {
         cells: [
           { title: 'CPU architecture' },
           {
-            title: <>{activeFeatureConfiguration.underlyingCpuArchitecture}</>,
+            title: <>{cpuArchitecture}</>,
             props: { 'data-testid': 'cpu-architecture' },
           },
         ],
@@ -46,7 +49,7 @@ export const ReviewClusterDetailTable = ({ cluster }: { cluster: Cluster }) => {
         cells: [
           { title: "Hosts' network configuration" },
           {
-            title: <>{activeFeatureConfiguration.hasStaticIpNetworking ? 'Static IP' : 'DHCP'}</>,
+            title: <>{hasStaticIp ? 'Static IP' : 'DHCP'}</>,
             props: { 'data-testid': 'network-configuration' },
           },
         ],

--- a/src/ocm/components/clusterDetail/ClusterProperties.tsx
+++ b/src/ocm/components/clusterDetail/ClusterProperties.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
-import { GridItem, TextContent, Text } from '@patternfly/react-core';
+import { GridItem, Text, TextContent } from '@patternfly/react-core';
 import {
   Cluster,
-  DetailList,
+  CpuArchitecture,
   DetailItem,
+  DetailList,
   DiskEncryption,
-  PopoverIcon,
-  NETWORK_TYPE_SDN,
   isDualStack,
+  NETWORK_TYPE_SDN,
+  PopoverIcon,
   selectIpv4Cidr,
-  selectIpv6Cidr,
   selectIpv4HostPrefix,
+  selectIpv6Cidr,
   selectIpv6HostPrefix,
   useFeatureSupportLevel,
-  CpuArchitecture,
 } from '../../../common';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
 import { ClusterFeatureSupportLevelsDetailItem } from '../featureSupportLevels';
@@ -84,7 +84,9 @@ const ClusterProperties = ({ cluster, externalMode = false }: ClusterPropertiesP
   const isDualStackType = isDualStack(cluster);
   const featureSupportLevelContext = useFeatureSupportLevel();
 
-  const { underlyingCpuArchitecture } = featureSupportLevelContext.activeFeatureConfiguration;
+  const activeFeatureConfiguration = featureSupportLevelContext.activeFeatureConfiguration;
+  const underlyingCpuArchitecture =
+    activeFeatureConfiguration?.underlyingCpuArchitecture || CpuArchitecture.x86;
   const hasMultiCpuArchitecture = cluster.cpuArchitecture === CpuArchitecture.MULTI;
 
   const isMultiArchSupported = Boolean(

--- a/src/ocm/components/featureSupportLevels/featureStateUtils.ts
+++ b/src/ocm/components/featureSupportLevels/featureStateUtils.ts
@@ -75,14 +75,14 @@ const getArmDisabledReason = (
 
 const getOdfDisabledReason = (
   cluster: Cluster | undefined,
-  activeFeatureConfiguration: ActiveFeatureConfiguration,
+  activeFeatureConfiguration: ActiveFeatureConfiguration | undefined,
   isSupported: boolean,
 ) => {
   if (!cluster) {
     return undefined;
   }
 
-  const isArm = activeFeatureConfiguration.underlyingCpuArchitecture === CpuArchitecture.ARM;
+  const isArm = activeFeatureConfiguration?.underlyingCpuArchitecture === CpuArchitecture.ARM;
   if (isArm && isSNO(cluster)) {
     return `${ODF_OPERATOR_LABEL} is not available when using Single Node OpenShift or ARM CPU architecture.`;
   }


### PR DESCRIPTION
Make the new `activeFeatureConfiguration` optional in FeatureSupportLevelData as it is being used in ACM.

Fixes Typescript 4 errors.