### PR TITLE
MGMT-11073: Block hostname field while action is in progress

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "prepare": "install-peers",
     "test": "run-s test:circular lint format:check",
     "test:circular": "dpdm --warning false --tree false --exit-code circular:1 ./src/index.ts",
-    "lint": "eslint . --max-warnings=102 --color",
+    "lint": "eslint . --max-warnings=98 --color",
     "lint:fix": "yarn run lint --fix",
     "format": "prettier --write '**/*.{json,md,scss,yaml,yml}'",
     "format:check": "prettier --check '**/*.{json,md,scss,yaml,yml}'",

--- a/src/common/components/hosts/EditHostForm.tsx
+++ b/src/common/components/hosts/EditHostForm.tsx
@@ -57,7 +57,7 @@ const EditHostForm = ({
   getEditErrorMessage,
 }: EditHostFormProps) => {
   const hostnameInputRef = React.useRef<HTMLInputElement>();
-  const [isEditInProgress, setIsEditInProgress] = React.useState<boolean>(false);
+  const [isSaveInProgress, setIsSaveInProgress] = React.useState<boolean>(false);
 
   React.useEffect(() => {
     hostnameInputRef.current?.focus();
@@ -85,10 +85,10 @@ const EditHostForm = ({
           return;
         }
         try {
-          setIsEditInProgress(true); // onSave ends closing the modal, so we can't update the status unless there is an error
+          setIsSaveInProgress(true); // onSave ends closing the modal, so we can't update the status unless there is an error
           await onSave(values);
         } catch (e) {
-          setIsEditInProgress(false);
+          setIsSaveInProgress(false);
           const error = e as Error;
           const message =
             (getEditErrorMessage && getEditErrorMessage(error)) || t('ai:Host update failed.');
@@ -123,7 +123,7 @@ const EditHostForm = ({
                 name="hostname"
                 ref={hostnameInputRef}
                 isRequired
-                isDisabled={isEditInProgress || !canHostnameBeChanged(host.status)}
+                isDisabled={isSaveInProgress || !canHostnameBeChanged(host.status)}
                 richValidationMessages={hostnameValidationMessages(t)}
               />
             </GridGap>

--- a/src/common/components/hosts/EditHostForm.tsx
+++ b/src/common/components/hosts/EditHostForm.tsx
@@ -9,7 +9,6 @@ import {
   ModalBoxFooter,
   AlertVariant,
   Alert,
-  AlertActionCloseButton,
 } from '@patternfly/react-core';
 
 import { Formik } from 'formik';
@@ -21,11 +20,13 @@ import {
   StaticTextField,
   hostnameValidationMessages,
   getRichTextValidation,
+  AlertFormikError,
 } from '../ui';
 import { canHostnameBeChanged } from './utils';
 import GridGap from '../ui/GridGap';
 import { EditHostFormValues } from './types';
 import { useTranslation } from '../../hooks/use-translation-wrapper';
+import { StatusErrorType } from '../../types';
 
 export type EditHostFormProps = {
   host: Host;
@@ -56,6 +57,7 @@ const EditHostForm = ({
   getEditErrorMessage,
 }: EditHostFormProps) => {
   const hostnameInputRef = React.useRef<HTMLInputElement>();
+  const [isEditInProgress, setIsEditInProgress] = React.useState<boolean>(false);
 
   React.useEffect(() => {
     hostnameInputRef.current?.focus();
@@ -83,9 +85,10 @@ const EditHostForm = ({
           return;
         }
         try {
+          setIsEditInProgress(true); // onSave ends closing the modal, so we can't update the status unless there is an error
           await onSave(values);
-          onCancel();
         } catch (e) {
+          setIsEditInProgress(false);
           const error = e as Error;
           const message =
             (getEditErrorMessage && getEditErrorMessage(error)) || t('ai:Host update failed.');
@@ -103,18 +106,10 @@ const EditHostForm = ({
         <Form onSubmit={handleSubmit}>
           <ModalBoxBody>
             <GridGap>
-              {status.error && (
-                <Alert
-                  variant={AlertVariant.danger}
-                  title={status.error.title}
-                  actionClose={
-                    <AlertActionCloseButton onClose={() => setStatus({ error: null })} />
-                  }
-                  isInline
-                >
-                  {status.error.message}
-                </Alert>
-              )}
+              <AlertFormikError
+                status={status as StatusErrorType}
+                onClose={() => setStatus({ error: null })}
+              />
               <Alert
                 variant={AlertVariant.info}
                 title={t('ai:This name will replace the original discovered hostname.')}
@@ -128,7 +123,7 @@ const EditHostForm = ({
                 name="hostname"
                 ref={hostnameInputRef}
                 isRequired
-                isDisabled={!canHostnameBeChanged(host.status)}
+                isDisabled={isEditInProgress || !canHostnameBeChanged(host.status)}
                 richValidationMessages={hostnameValidationMessages(t)}
               />
             </GridGap>


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-11073

After clicking on "change", the field for the host name was still editable, so users could keep typing on it even though it would have no effect.

We now disable the field while an action is in progress.

https://user-images.githubusercontent.com/829045/215818835-595ff6eb-e630-4e50-b414-bb8757f039e4.mp4

