### PR TITLE
MGMT-13244 - Add host ssh keys does not allow space or \n for next key

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -564,6 +564,7 @@
   "ai:Provide an endpoint for users, both human and machine, to interact with and configure the platform. If needed, contact your IT manager for more information. {{vipHelperSufix}}": "Provide an endpoint for users, both human and machine, to interact with and configure the platform. If needed, contact your IT manager for more information. {{vipHelperSufix}}",
   "ai:Provide an SSH key to be able to connect to the hosts for debugging purposes during the discovery process": "Provide an SSH key to be able to connect to the hosts for debugging purposes during the discovery process",
   "ai:Provide as many labels as you can to narrow the list to relevant hosts only.": "Provide as many labels as you can to narrow the list to relevant hosts only.",
+  "ai:Provide SSH keys separated by newlines to be able to connect to the hosts for debugging purposes during the discovery process": "Provide SSH keys separated by newlines to be able to connect to the hosts for debugging purposes during the discovery process",
   "ai:Provided cluster configuration is not valid": "Provided cluster configuration is not valid",
   "ai:Pull secret": "Pull secret",
   "ai:Pull secret is a required field.": "Pull secret is a required field.",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "prepare": "install-peers",
     "test": "run-s test:circular lint format:check",
     "test:circular": "dpdm --warning false --tree false --exit-code circular:1 ./src/index.ts",
-    "lint": "eslint . --max-warnings=98 --color",
+    "lint": "eslint . --max-warnings=95 --color",
     "lint:fix": "yarn run lint --fix",
     "format": "prettier --write '**/*.{json,md,scss,yaml,yml}'",
     "format:check": "prettier --check '**/*.{json,md,scss,yaml,yml}'",

--- a/src/common/components/clusterConfiguration/UploadSSH.tsx
+++ b/src/common/components/clusterConfiguration/UploadSSH.tsx
@@ -7,21 +7,21 @@ import { useTranslation } from '../../hooks/use-translation-wrapper';
 
 type UploadSSHProps = {
   isRequired?: boolean;
+  labelText?: string;
 };
 
-const UploadSSH: React.FC<UploadSSHProps> = ({ isRequired }) => {
-  const [{ name, value }, , { setValue }] = useField('sshPublicKey');
+const UploadSSH: React.FC<UploadSSHProps> = ({ isRequired, labelText }) => {
+  const [{ name, value }, , { setValue }] = useField<string>('sshPublicKey');
   const { t } = useTranslation();
+  const defaultLabelText = t(
+    'ai:Provide an SSH key to be able to connect to the hosts for debugging purposes during the discovery process',
+  );
+
   return (
     <UploadField
       label={
         <>
-          {t('ai:SSH public key')}{' '}
-          <PopoverIcon
-            bodyContent={t(
-              'ai:Provide an SSH key to be able to connect to the hosts for debugging purposes during the discovery process',
-            )}
-          />
+          {t('ai:SSH public key')} <PopoverIcon bodyContent={labelText || defaultLabelText} />
         </>
       }
       name={name}
@@ -36,7 +36,6 @@ const UploadSSH: React.FC<UploadSSHProps> = ({ isRequired }) => {
           () =>
             setError(t('ai:File not supported.')),
       }}
-      transformValue={trimSshPublicKey}
       isRequired={isRequired}
     />
   );

--- a/src/common/components/ui/formik/validationSchemas.ts
+++ b/src/common/components/ui/formik/validationSchemas.ts
@@ -102,15 +102,28 @@ export const sshPublicKeyValidationSchema = Yup.string().test(
     }
 
     return !!trimSshPublicKey(value).match(SSH_PUBLIC_KEY_REGEX);
-    /* TODO(mlibra): disabled till muliple ssh-keys are supported: https://issues.redhat.com/browse/MGMT-3560
-    return (
-      trimSshPublicKey(value)
-        .split('\n')
-        .find((line: string) => !line.match(SSH_PUBLIC_KEY_REGEX)) === undefined
-    );
-    */
   },
 );
+
+export const sshPublicKeyListValidationSchema = Yup.string()
+  .test(
+    'ssh-public-keys',
+    'SSH public keys separated by newlines must consist of "[TYPE] key [[EMAIL]]", supported types are: ssh-rsa, ssh-ed25519, ecdsa-[VARIANT].',
+    (value: string) => {
+      if (!value) {
+        return true;
+      }
+      return (
+        trimSshPublicKey(value)
+          .split('\n')
+          .find((line: string) => !line.match(SSH_PUBLIC_KEY_REGEX)) === undefined
+      );
+    },
+  )
+  .test('ssh-public-keys-unique', 'SSH public keys must be unique.', (value: string) => {
+    const keyList = trimSshPublicKey(value).split('\n');
+    return new Set(keyList).size === keyList.length;
+  });
 
 export const pullSecretValidationSchema = Yup.string().test(
   'is-well-formed-json',

--- a/src/ocm/components/clusterConfiguration/OcmDiscoveryImageConfigForm.tsx
+++ b/src/ocm/components/clusterConfiguration/OcmDiscoveryImageConfigForm.tsx
@@ -16,7 +16,7 @@ import {
   AlertFormikError,
   httpProxyValidationSchema,
   noProxyValidationSchema,
-  sshPublicKeyValidationSchema,
+  sshPublicKeyListValidationSchema,
 } from '../../../common/components/ui';
 import {
   DiscoveryImageType,
@@ -48,7 +48,7 @@ export type OcmDiscoveryImageFormValues = OcmImageCreateParams &
 
 const validationSchema = Yup.lazy<OcmDiscoveryImageFormValues>((values) =>
   Yup.object<OcmDiscoveryImageFormValues>().shape({
-    sshPublicKey: sshPublicKeyValidationSchema,
+    sshPublicKey: sshPublicKeyListValidationSchema,
     httpProxy: httpProxyValidationSchema(values, 'httpProxy'),
     httpsProxy: httpProxyValidationSchema(values, 'httpsProxy'), // share the schema, httpS is currently not supported
     noProxy: noProxyValidationSchema,
@@ -145,7 +145,11 @@ export const OcmDiscoveryImageConfigForm = ({
                       }
                       onChange={updateDiscoveryButtonAndAlertText}
                     />
-                    <UploadSSH />
+                    <UploadSSH
+                      labelText={t(
+                        'ai:Provide SSH keys separated by newlines to be able to connect to the hosts for debugging purposes during the discovery process',
+                      )}
+                    />
                     <ProxyFields />
                     <CertificateFields />
                   </Form>
@@ -153,7 +157,13 @@ export const OcmDiscoveryImageConfigForm = ({
               </Stack>
             </ModalBoxBody>
             <ModalBoxFooter>
-              <Button onClick={submitForm} isDisabled={isSubmitting} isLoading={isSubmitting}>
+              <Button
+                onClick={() => {
+                  void submitForm();
+                }}
+                isDisabled={isSubmitting}
+                isLoading={isSubmitting}
+              >
                 {isSubmitting ? t('ai:Generating') : buttonText}
               </Button>
               <Button key="cancel" variant="link" onClick={onCancel}>


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-13244

- SSH upload field now allows spaces and \n
- Spaces and empty lines get trimmed on blur
- Newlines are used as separators between SSH keys
- SSH public keys must be unique

These changes shouldn't affect uses of the UploadSSH component outside `/ocm`.