### PR TITLE
MGMT-13266: Show missing feature support levels error in R&C

### DIFF
--- a/src/common/components/featureSupportLevels/utils.ts
+++ b/src/common/components/featureSupportLevels/utils.ts
@@ -14,7 +14,6 @@ export const getLimitedFeatureSupportLevels = (
   if (!cluster.featureUsage) {
     throw t("ai:cluster doesn't contain the feature_usage field");
   }
-  const ret: FeatureIdToSupportLevel = {};
   const featureUsage = stringToJSON<ClusterFeatureUsage>(cluster.featureUsage);
   if (featureUsage === undefined) {
     throw t('ai:Error parsing cluster feature_usage field');
@@ -28,6 +27,8 @@ export const getLimitedFeatureSupportLevels = (
       openshiftVersion: cluster.openshiftVersion,
     });
   }
+
+  const ret: FeatureIdToSupportLevel = {};
   for (const featureId of usedFeatureIds) {
     if (featureId in versionSupportLevelsMap) {
       const supportLevel = versionSupportLevelsMap[featureId];

--- a/src/common/components/featureSupportLevels/utils.ts
+++ b/src/common/components/featureSupportLevels/utils.ts
@@ -1,7 +1,7 @@
+import { TFunction } from 'i18next';
 import { Cluster, stringToJSON } from '../../api';
 import { ClusterFeatureUsage, FeatureId, FeatureIdToSupportLevel } from '../../types';
 import { FeatureSupportLevelData } from './FeatureSupportLevelContext';
-import { TFunction } from 'i18next';
 
 export const getLimitedFeatureSupportLevels = (
   cluster: Cluster,
@@ -9,32 +9,24 @@ export const getLimitedFeatureSupportLevels = (
   t: TFunction,
 ): FeatureIdToSupportLevel => {
   if (!cluster.openshiftVersion) {
-    throw t
-      ? t("ai:cluster doesn't contain the openshift_version field")
-      : "cluster doesn't contain the openshift_version field";
+    throw t("ai:cluster doesn't contain the openshift_version field");
   }
   if (!cluster.featureUsage) {
-    throw t
-      ? t("ai:cluster doesn't contain the feature_usage field")
-      : "ai:cluster doesn't contain the feature_usage field";
+    throw t("ai:cluster doesn't contain the feature_usage field");
   }
   const ret: FeatureIdToSupportLevel = {};
   const featureUsage = stringToJSON<ClusterFeatureUsage>(cluster.featureUsage);
   if (featureUsage === undefined) {
-    throw t
-      ? t('ai:Error parsing cluster feature_usage field')
-      : 'Error parsing cluster feature_usage field';
+    throw t('ai:Error parsing cluster feature_usage field');
   }
   const usedFeatureIds: FeatureId[] = Object.values(featureUsage).map((item) => item.id);
   const versionSupportLevelsMap = featureSupportLevelData.getVersionSupportLevelsMap(
     cluster.openshiftVersion,
   );
   if (!versionSupportLevelsMap) {
-    throw t
-      ? t('ai:No support level data for version {{openshiftVersion}}', {
-          openshiftVersion: cluster.openshiftVersion,
-        })
-      : `No support level data for version ${cluster.openshiftVersion}`;
+    throw t('ai:No support level data for version {{openshiftVersion}}', {
+      openshiftVersion: cluster.openshiftVersion,
+    });
   }
   for (const featureId of usedFeatureIds) {
     if (featureId in versionSupportLevelsMap) {

--- a/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
+++ b/src/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
@@ -20,7 +20,6 @@ import {
   serviceNetworksEqual,
   useFeatureSupportLevel,
 } from '../../../../common';
-import { getLimitedFeatureSupportLevels } from '../../../../common/components/featureSupportLevels/utils';
 import {
   ManagedNetworkingControlGroup,
   UserManagedNetworkingTextContent,
@@ -146,18 +145,12 @@ const NetworkConfiguration = ({
   const featureSupportLevelData = useFeatureSupportLevel();
   const { setFieldValue, values, validateField } = useFormikContext<NetworkConfigurationValues>();
 
-  const { clusterFeatureSupportLevels, underlyingCpuArchitecture } = React.useMemo(() => {
-    return {
-      clusterFeatureSupportLevels: getLimitedFeatureSupportLevels(
-        cluster,
-        featureSupportLevelData,
-        t,
-      ),
-      underlyingCpuArchitecture:
-        featureSupportLevelData.activeFeatureConfiguration?.underlyingCpuArchitecture ||
-        getDefaultCpuArchitecture(),
-    };
-  }, [cluster, featureSupportLevelData, t]);
+  const underlyingCpuArchitecture = React.useMemo(
+    () =>
+      featureSupportLevelData.activeFeatureConfiguration?.underlyingCpuArchitecture ||
+      getDefaultCpuArchitecture(),
+    [featureSupportLevelData],
+  );
   const isSNOCluster = isSNO(cluster);
   const isMultiNodeCluster = !isSNOCluster;
   const isUserManagedNetworking = values.managedNetworkingType === 'userManaged';
@@ -263,8 +256,10 @@ const NetworkConfiguration = ({
       )}
 
       {!isUserManagedNetworking &&
-        !!clusterFeatureSupportLevels &&
-        clusterFeatureSupportLevels['CLUSTER_MANAGED_NETWORKING_WITH_VMS'] === 'unsupported' &&
+        featureSupportLevelData.getFeatureSupportLevel(
+          cluster.openshiftVersion || '',
+          'CLUSTER_MANAGED_NETWORKING_WITH_VMS',
+        ) === 'unsupported' &&
         vmsAlert}
 
       {(isSNOCluster || !isUserManagedNetworking) && (

--- a/src/ocm/components/clusterConfiguration/review/ReviewStep.tsx
+++ b/src/ocm/components/clusterConfiguration/review/ReviewStep.tsx
@@ -34,12 +34,13 @@ const ReviewStep = ({ cluster }: { cluster: Cluster }) => {
   const dispatch = useDispatch();
 
   const hasSupportLevel = React.useMemo<boolean>(() => {
+    let hasSupportLevels = false;
     try {
-      getLimitedFeatureSupportLevels(cluster, featureSupportLevelData, t);
-      return true;
+      hasSupportLevels = !!getLimitedFeatureSupportLevels(cluster, featureSupportLevelData, t);
     } catch (e) {
-      return false;
+      // Missing support levels
     }
+    return hasSupportLevels;
   }, [cluster, featureSupportLevelData, t]);
 
   const handleClusterInstall = async () => {


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-13334

For clusters using an OpenShift version which does not include feature-support-level details, the wizard would thrown an error in two places: Networking page or Review & Create. The error was not clear, since this error is a misconfiguration of the OpenShift version in the environment.

- The error is now clearer
- Now the error page will only be shown in the Review & Create page, to prevent the user from installing a cluster with an unknown set of unsupported features. In the Networking page, it was only used to display the warning about "only using VMs".


![review-error](https://user-images.githubusercontent.com/829045/218432519-20616906-5d1c-4959-b057-01552388856e.png)
