### PR TITLE
MGMT-13677: Fix non-production warning only for appropriate versions

### DIFF
--- a/src/ocm/components/clusterConfiguration/OcmOpenShiftVersionSelect.tsx
+++ b/src/ocm/components/clusterConfiguration/OcmOpenShiftVersionSelect.tsx
@@ -37,7 +37,7 @@ const getOpenshiftVersionHelperText = (
     );
   }
 
-  const selectedVersion = versions.find((version) => version.label === selectedVersionValue);
+  const selectedVersion = versions.find((version) => version.value === selectedVersionValue);
   if (!selectedVersionValue || !selectedVersion) {
     return null;
   }
@@ -74,14 +74,11 @@ const OcmOpenShiftVersionSelect = ({ versions }: OcmOpenShiftVersionSelectProps)
         })),
     [versions, t],
   );
-  const defaultVersion = versions.find((v) => v.default)?.label || versions[0]?.label || '';
 
   return (
     <OpenShiftVersionDropdown
       name="openshiftVersion"
-      defaultValue={defaultVersion}
       items={selectOptions}
-      isDisabled={versions.length === 0}
       versions={versions}
       getHelperText={getOpenshiftVersionHelperText}
       showReleasesLink={ocmClient !== undefined}


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-13677

The warning about the version not being production-ready has stopped being displayed.

The previous code relied on the matching of the labels, but for Beta version, it wasn't finding a version that matched, because the label had some extra text ("Developer Preview release"). 

What finally broke it is this change https://github.com/openshift-assisted/assisted-ui-lib/pull/1877/files#diff-e9b056fd8eab90b0a2096e8e64661a8cb4106723abb935e099cb9faa23b18117R43
but IMO if we don't find the match, we should not show the warning. There should always be a match, as the selected version must be on of the dropdown values.

Now we are matching on the value which is always the same, no matter if we append some text to the rendered item.

