### PR TITLE
MGMT-13788: Show API error message in actions

### DIFF
--- a/src/ocm/components/clusterWizard/Operators.tsx
+++ b/src/ocm/components/clusterWizard/Operators.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
+import { useHistory, useLocation } from 'react-router-dom';
 import { Formik, FormikConfig, useFormikContext } from 'formik';
 import {
   Cluster,
@@ -20,10 +21,8 @@ import ClusterWizardNavigation from '../clusterWizard/ClusterWizardNavigation';
 import { OperatorsStep } from './OperatorsStep';
 import { ClustersService, OperatorsService } from '../../services';
 import { setServerUpdateError, updateCluster } from '../../reducers/clusters';
-import { handleApiError, isUnknownServerError } from '../../api';
+import { getApiErrorMessage, handleApiError, isUnknownServerError } from '../../api';
 import { canNextOperators } from './wizardTransition';
-import { getErrorMessage } from '../../../common/utils';
-import { useHistory, useLocation } from 'react-router-dom';
 
 export const getOperatorsInitialValues = (
   monitoredOperators: MonitoredOperator[],
@@ -113,7 +112,7 @@ const Operators = ({ cluster }: { cluster: Cluster }) => {
       dispatch(updateCluster(updatedCluster));
     } catch (e) {
       handleApiError(e, () =>
-        addAlert({ title: 'Failed to update the cluster', message: getErrorMessage(e) }),
+        addAlert({ title: 'Failed to update the cluster', message: getApiErrorMessage(e) }),
       );
       if (isUnknownServerError(e as Error)) {
         dispatch(setServerUpdateError());

--- a/src/ocm/components/hosts/use-hosts-table.tsx
+++ b/src/ocm/components/hosts/use-hosts-table.tsx
@@ -52,7 +52,6 @@ import UpdateDay2ApiVipModal from './UpdateDay2ApiVipModal';
 import { UpdateDay2ApiVipFormProps } from './UpdateDay2ApiVipForm';
 import { usePagination } from '../../../common/components/hosts/usePagination';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
-import { getErrorMessage } from '../../../common/utils';
 import { selectCurrentClusterPermissionsState, selectCurrentClusterState } from '../../selectors';
 import { hardwareStatusColumn } from './HardwareStatus';
 
@@ -169,7 +168,7 @@ export const useHostsTable = (cluster: Cluster) => {
         resetCluster ? await resetCluster() : dispatch(updateHost(data));
       } catch (e) {
         handleApiError(e, () =>
-          addAlert({ title: 'Failed to update ODF status', message: getErrorMessage(e) }),
+          addAlert({ title: 'Failed to update ODF status', message: getApiErrorMessage(e) }),
         );
         if (isUnknownServerError(e as Error)) {
           dispatch(setServerUpdateError());
@@ -510,9 +509,8 @@ export const HostsTableModals = ({
             }
           }}
           getEditErrorMessage={(e: Error) => {
-            let message = '';
-            handleApiError(e, () => (message = getApiErrorMessage(e)));
-            return message;
+            handleApiError(e);
+            return getApiErrorMessage(e);
           }}
         />
       )}


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-13788

- In Operators page, if the cluster fails to update, we must show the detailed API error message.
- Fixed in `use-hosts-table` too.