### PR TITLE
MGMT-13700: Add learn more link for LVMS operator

### DIFF
--- a/src/common/config/constants.ts
+++ b/src/common/config/constants.ts
@@ -37,6 +37,9 @@ export const CNV_LINK = 'https://cloud.redhat.com/learn/topics/virtualization/';
 
 export const ODF_LINK = 'https://www.redhat.com/en/resources/openshift-data-foundation-datasheet';
 
+export const LVMS_LINK =
+  'https://docs.openshift.com/container-platform/4.12/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.html';
+
 export const NMSTATE_EXAMPLES_LINK = 'https://nmstate.io/examples.html';
 
 export const APPROVE_NODES_IN_CL_LINK =

--- a/src/ocm/components/clusterConfiguration/operators/LvmCheckbox.tsx
+++ b/src/ocm/components/clusterConfiguration/operators/LvmCheckbox.tsx
@@ -7,7 +7,6 @@ import {
   PopoverIcon,
   useFeatureSupportLevel,
   operatorLabels,
-  ExternalLink,
   OperatorsValues,
   FeatureSupportLevelBadge,
   OPERATOR_NAME_LVM,

--- a/src/ocm/components/clusterConfiguration/operators/LvmCheckbox.tsx
+++ b/src/ocm/components/clusterConfiguration/operators/LvmCheckbox.tsx
@@ -7,6 +7,7 @@ import {
   PopoverIcon,
   useFeatureSupportLevel,
   operatorLabels,
+  ExternalLink,
   OperatorsValues,
   FeatureSupportLevelBadge,
   OPERATOR_NAME_LVM,


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-13700

For LVMS, starting in OpenShift 4.12 there is documentation about the operator configuration.
Added a link for the operator.

LVMS, link is shown
![lvms-with-link-4-12](https://user-images.githubusercontent.com/829045/220897319-9162ec4c-f20b-4d96-bda0-83e354b2b46c.png)

LVM, link not shown
![lvm-without-link-4-11](https://user-images.githubusercontent.com/829045/220897331-4c193499-18db-4e05-99f3-bb2fcc20967b.png)
