### PR TITLE
MGMT-13789: Inline alert message in storage step about bootable disks should include info about read-only disks

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -59,7 +59,7 @@
   "ai:Address is the host/ip that the NodePort service is exposed over.": "Address is the host/ip that the NodePort service is exposed over.",
   "ai:Agent compatibility": "Agent compatibility",
   "ai:AgentClusterInstall conditions are missing.": "AgentClusterInstall conditions are missing.",
-  "ai:All bootable disks will be formatted during installation. Make sure to backup any sensitive data.": "All bootable disks will be formatted during installation. Make sure to backup any sensitive data.",
+  "ai:All bootable disks, except for read-only disks, will be formatted during installation. Make sure to back up any sensitive data before proceeding.": "All bootable disks, except for read-only disks, will be formatted during installation. Make sure to back up any sensitive data before proceeding.",
   "ai:All checks passed": "All checks passed",
   "ai:All discovered": "All discovered",
   "ai:All DNS records must be subdomains of this base and include the cluster name. This cannot be changed after cluster installation. The full cluster address will be:": "All DNS records must be subdomains of this base and include the cluster name. This cannot be changed after cluster installation. The full cluster address will be:",

--- a/src/common/components/clusterConfiguration/FormatDiskWarning.tsx
+++ b/src/common/components/clusterConfiguration/FormatDiskWarning.tsx
@@ -17,7 +17,7 @@ const FormatDiskWarning = ({ someDisksAreSkipFormatting }: FormatDiskWarningProp
         someDisksAreSkipFormatting
           ? t('ai:There may be issues with the boot order')
           : t(
-              'ai:All bootable disks will be formatted during installation. Make sure to backup any sensitive data.',
+              'ai:All bootable disks, except for read-only disks, will be formatted during installation. Make sure to back up any sensitive data before proceeding.',
             )
       }
     >


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-13789

Before the changes:
The inline alert message says" “All bootable disks will be formatted during installation. Make sure to backup any sensitive data."

After the changes:
![image](https://user-images.githubusercontent.com/11390125/220947182-cbbedb62-23fe-485e-939f-c8888e932b70.png)
