### PR TITLE
MGMT-13855: Base domain field validation causing the UI to get stuck

### DIFF
--- a/src/common/components/ui/formik/validationSchemas.ts
+++ b/src/common/components/ui/formik/validationSchemas.ts
@@ -30,7 +30,7 @@ const CLUSTER_NAME_VALID_CHARS_REGEX = /^[a-z0-9-]*$/;
 const SSH_PUBLIC_KEY_REGEX =
   /^(ssh-rsa|ssh-ed25519|ecdsa-[-a-z0-9]*) AAAA[0-9A-Za-z+/]+[=]{0,3}( .+)?$/;
 const DNS_NAME_REGEX = /^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$/;
-const BASE_DOMAIN_REGEX = /^([a-z0-9]+(-[a-z0-9]+)*)+$/;
+const BASE_DOMAIN_REGEX = /^([a-z0-9]+(-[a-z0-9]+)*)$/;
 const DNS_NAME_REGEX_OCM = /^([a-z0-9]+(-[a-z0-9]+)*[.])+[a-z]{2,}$/;
 
 const PROXY_DNS_REGEX =
@@ -360,10 +360,9 @@ export const dnsNameValidationSchema = Yup.string()
   });
 
 export const validateBaseDomainName = (baseDomainName: string) => {
-  return (
-    baseDomainName.match(BASE_DOMAIN_REGEX) !== null ||
-    baseDomainName.match(DNS_NAME_REGEX_OCM) !== null
-  );
+  if (baseDomainName.match(BASE_DOMAIN_REGEX)) return true;
+  else if (baseDomainName.match(DNS_NAME_REGEX_OCM)) return true;
+  else return false;
 };
 
 export const baseDomainValidationSchema = Yup.string()


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-13855

We change the validation of base domain field because causes problems in the UI.
The problem is related to https://javascript.info/regexp-catastrophic-backtracking

Changing the previous regex:
const BASE_DOMAIN_REGEX = /^([a-z0-9]+(-[a-z0-9]+)*)+$/;

To a new regex:
const BASE_DOMAIN_REGEX = /^([a-z0-9]+(-[a-z0-9]+)*)$/;

Solve this problem.

https://issues.redhat.com/secure/attachment/12921510/vokoscreenNG-2023-03-03_08-59-36.mp4
