### PR TITLE
MGMT-13856: LVMS should be enabled for SNO+ARM clusters

### DIFF
--- a/src/ocm/components/featureSupportLevels/featureStateUtils.ts
+++ b/src/ocm/components/featureSupportLevels/featureStateUtils.ts
@@ -121,9 +121,6 @@ const getLvmDisabledReason = (
   if (!isSupported) {
     return `${operatorLabel} is not supported in this OpenShift version.`;
   }
-  if (activeFeatureConfiguration.underlyingCpuArchitecture === CpuArchitecture.ARM) {
-    return `${operatorLabel} is not available when ARM CPU architecture is selected.`;
-  }
   return undefined;
 };
 


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-13856

 LVMS should be enabled for SNO ARM cluster:
 
 https://user-images.githubusercontent.com/11390125/223037368-c21ee41f-1f5d-4564-bf4e-228a65e08b1c.mp4

