### PR TITLE
MGMT-13856: LVMS should be enabled for SNO+ARM clusters - 2.16

### DIFF
--- a/src/ocm/components/featureSupportLevels/featureStateUtils.ts
+++ b/src/ocm/components/featureSupportLevels/featureStateUtils.ts
@@ -121,9 +121,6 @@ const getLvmDisabledReason = (
   if (!isSupported) {
     return `${operatorLabel} is not supported in this OpenShift version.`;
   }
-  if (activeFeatureConfiguration.underlyingCpuArchitecture === CpuArchitecture.ARM) {
-    return `${operatorLabel} is not available when ARM CPU architecture is selected.`;
-  }
   return undefined;
 };
 


### PR DESCRIPTION
Backport of https://github.com/openshift-assisted/assisted-ui-lib/pull/1963