### PR TITLE
MGMT-14214: Disable and uncheck SNO checkbox when choose IBM Power or IBM Z archs 

### DIFF
--- a/src/ocm/components/clusterConfiguration/OcmSingleNodeCheckbox.tsx
+++ b/src/ocm/components/clusterConfiguration/OcmSingleNodeCheckbox.tsx
@@ -34,6 +34,7 @@ const OcmSingleNodeCheckbox: React.FC<OcmCheckboxProps> = ({
   const [field, meta, helpers] = useField<'None' | 'Full'>({ name: props.name, validate });
   const featureSupportLevelContext = useNewFeatureSupportLevel();
   const prevVersionRef = React.useRef(openshiftVersion);
+  const prevIsDisabled = React.useRef(props.isDisabled);
   const fieldId = getFieldId(props.name, 'input', idPostfix);
   const { t } = useTranslation();
   const { value } = meta;
@@ -54,6 +55,13 @@ const OcmSingleNodeCheckbox: React.FC<OcmCheckboxProps> = ({
     }
     prevVersionRef.current = openshiftVersion;
   }, [openshiftVersion, onChanged, featureSupportLevelContext]);
+
+  React.useEffect(() => {
+    if (prevIsDisabled.current !== props.isDisabled) {
+      onChanged(false);
+    }
+    prevIsDisabled.current = props.isDisabled;
+  }, [props.isDisabled, setValue, onChanged]);
 
   if (isSingleNodeOpenshiftEnabled && isSupportedVersionAvailable) {
     return (


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-14214

Disable and uncheck SNO checkbox when IBM Power or IBM Z archs are selected in "Cluster details" page:
https://user-images.githubusercontent.com/11390125/229786801-588003b0-94d4-4ed9-8686-f2856f1211c8.mp4