### PR TITLE
MGMT-14270: We need to show 'Add hosts' tab to cluster with  'installed' status

### DIFF
--- a/src/ocm/components/HostsClusterDetailTab/utils.ts
+++ b/src/ocm/components/HostsClusterDetailTab/utils.ts
@@ -29,7 +29,9 @@ const disabledTabResult = (tooltipMessage: string) => ({
 });
 
 export const getAddHostTabDetails = ({ cluster }: { cluster: OcmClusterType }) => {
-  const isHiddenTab = cluster.state !== 'ready' || cluster.product?.id !== 'OCP-AssistedInstall';
+  const isHiddenTab =
+    (cluster.state !== 'ready' && cluster.state !== 'installed') ||
+    cluster.product?.id !== 'OCP-AssistedInstall';
   if (isHiddenTab) {
     return hiddenTabResult;
   }


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-14270

When cluster is in status 'installed' we need to show the 'Add hosts' tab.

Before the change:
![installed_cluster_without_tab](https://user-images.githubusercontent.com/11390125/231731582-64ee121b-45da-4d80-811c-bb1b2ad9dbd9.png)


After the change:
![installed_cluster_with_tab](https://user-images.githubusercontent.com/11390125/231731557-73e16097-1130-414d-8c8c-0d23e959526b.png)
