### PR TITLE
MGMT-14290: Filling CpuArchitectureDropdown from release image architectures

### DIFF
--- a/src/common/types/cpuArchitecture.ts
+++ b/src/common/types/cpuArchitecture.ts
@@ -1,4 +1,4 @@
-import { ArchitectureSupportLevelId, SupportLevel } from '../api';
+import { ArchitectureSupportLevelId } from '../api';
 
 export type ClusterCpuArchitecture = 'x86_64' | 'aarch64' | 'arm64' | 'ppc64le' | 's390x' | 'multi';
 
@@ -45,26 +45,23 @@ export const getAllCpuArchitectures = (): SupportedCpuArchitecture[] => [
 
 export const getSupportedCpuArchitectures = (
   canSelectCpuArch: boolean,
-  cpuArchitectures: Record<ArchitectureSupportLevelId, SupportLevel> | null,
-  isFeatureSupportedAndAvailable: (supportLevel: SupportLevel | undefined) => boolean,
+  cpuArchitectures: CpuArchitecture[],
 ): SupportedCpuArchitecture[] => {
   const newSupportedCpuArchs: SupportedCpuArchitecture[] = [];
   if (cpuArchitectures) {
-    for (const [architectureId, supportLevel] of Object.entries(cpuArchitectures) as unknown as [
-      ArchitectureSupportLevelId,
-      SupportLevel,
-    ][]) {
-      if (isFeatureSupportedAndAvailable(supportLevel)) {
-        if (
-          (architectureId === 'S390X_ARCHITECTURE' || architectureId === 'PPC64LE_ARCHITECTURE') &&
-          canSelectCpuArch
-        ) {
-          newSupportedCpuArchs.push(featureIdToCpuArchitecture[architectureId]);
-        } else if (architectureId !== 'MULTIARCH_RELEASE_IMAGE') {
-          newSupportedCpuArchs.push(featureIdToCpuArchitecture[architectureId]);
-        }
+    cpuArchitectures.forEach((cpuArch) => {
+      if (
+        (cpuArch === CpuArchitecture.ppc64le || cpuArch === CpuArchitecture.s390x) &&
+        canSelectCpuArch
+      ) {
+        newSupportedCpuArchs.push(cpuArch);
+      } else if (
+        cpuArch !== CpuArchitecture.MULTI &&
+        cpuArch !== CpuArchitecture.USE_DAY1_ARCHITECTURE
+      ) {
+        newSupportedCpuArchs.push(cpuArch);
       }
-    }
+    });
   }
   return newSupportedCpuArchs;
 };

--- a/src/ocm/components/AddHosts/day2Wizard/Day2ClusterDetails.tsx
+++ b/src/ocm/components/AddHosts/day2Wizard/Day2ClusterDetails.tsx
@@ -22,8 +22,7 @@ import Day2WizardFooter from './Day2WizardFooter';
 import Day2HostStaticIpConfigurations from './Day2StaticIpHostConfigurations';
 import { mapClusterCpuArchToInfraEnvCpuArch } from '../../../services/CpuArchitectureService';
 import CpuArchitectureDropdown from '../../clusterConfiguration/CpuArchitectureDropdown';
-import useSupportLevelsAPI from '../../../hooks/useSupportLevelsAPI';
-import { isFeatureSupportedAndAvailable } from '../../newFeatureSupportLevels/newFeatureStateUtils';
+import { useOpenshiftVersions } from '../../../hooks';
 
 const getDay2ClusterDetailInitialValues = async (
   clusterId: Cluster['id'],
@@ -55,19 +54,13 @@ const Day2ClusterDetails = () => {
     Day2ClusterDetailValues | Error | null
   >();
   const [isSubmitting, setSubmitting] = React.useState(false);
-  const cpuArchitectureSupportLevelIdToSupportLevelMap = useSupportLevelsAPI(
-    'architectures',
-    day2Cluster.openshiftVersion,
-  );
+
   const canSelectCpuArch = useFeature('ASSISTED_INSTALLER_MULTIARCH_SUPPORTED');
+  const { getCpuArchitectures } = useOpenshiftVersions();
+  const cpuArchitecturesByVersionImage = getCpuArchitectures(day2Cluster.openshiftVersion);
   const cpuArchitectures = React.useMemo(
-    () =>
-      getSupportedCpuArchitectures(
-        canSelectCpuArch,
-        cpuArchitectureSupportLevelIdToSupportLevelMap,
-        isFeatureSupportedAndAvailable,
-      ),
-    [canSelectCpuArch, cpuArchitectureSupportLevelIdToSupportLevelMap],
+    () => getSupportedCpuArchitectures(canSelectCpuArch, cpuArchitecturesByVersionImage),
+    [canSelectCpuArch, cpuArchitecturesByVersionImage],
   );
   const day1CpuArchitecture = mapClusterCpuArchToInfraEnvCpuArch(day2Cluster.cpuArchitecture);
   React.useEffect(() => {

--- a/src/ocm/components/HostsClusterDetailTab/HostsClusterDetailTabContent.tsx
+++ b/src/ocm/components/HostsClusterDetailTab/HostsClusterDetailTabContent.tsx
@@ -16,7 +16,6 @@ import { handleApiError } from '../../api';
 import { isApiError } from '../../api/types';
 import { AddHosts } from '../AddHosts';
 import { HostsClusterDetailTabProps } from './types';
-import useSupportLevelsAPI from '../../hooks/useSupportLevelsAPI';
 import { NewFeatureSupportLevelProvider } from '../newFeatureSupportLevels';
 import useInfraEnv from '../../hooks/useInfraEnv';
 
@@ -28,7 +27,8 @@ export const HostsClusterDetailTabContent = ({
   const [day2Cluster, setDay2Cluster] = useStateSafely<Cluster | null>(null);
   const pullSecret = usePullSecret();
   const { normalizeClusterVersion } = useOpenshiftVersions();
-  const cpuArchitectures = useSupportLevelsAPI('architectures', ocmCluster.openshift_version);
+  const { getCpuArchitectures } = useOpenshiftVersions();
+  const cpuArchitecturesByVersionImage = getCpuArchitectures(ocmCluster.openshift_version);
   const canSelectCpuArch = useFeature('ASSISTED_INSTALLER_MULTIARCH_SUPPORTED');
   const handleClickTryAgainLink = React.useCallback(() => {
     setError(undefined);
@@ -106,7 +106,7 @@ export const HostsClusterDetailTabContent = ({
             ocmCluster,
             pullSecret,
             normalizedVersion,
-            cpuArchitectures,
+            cpuArchitecturesByVersionImage,
             canSelectCpuArch,
           );
           const aiCluster = Day2ClusterService.completeAiClusterWithOcmCluster(
@@ -146,7 +146,7 @@ export const HostsClusterDetailTabContent = ({
     isVisible,
     normalizeClusterVersion,
     handleClickTryAgainLink,
-    cpuArchitectures,
+    cpuArchitecturesByVersionImage,
     canSelectCpuArch,
   ]);
 

--- a/src/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
+++ b/src/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
@@ -34,7 +34,7 @@ import CpuArchitectureDropdown, {
 } from './CpuArchitectureDropdown';
 import OcmSNOControlGroup from './OcmSNOControlGroup';
 import useSupportLevelsAPI from '../../hooks/useSupportLevelsAPI';
-import { isFeatureSupportedAndAvailable } from '../newFeatureSupportLevels/newFeatureStateUtils';
+import { useOpenshiftVersions } from '../../hooks';
 
 export type OcmClusterDetailsFormFieldsProps = {
   forceOpenshiftVersion?: string;
@@ -84,23 +84,17 @@ export const OcmClusterDetailsFormFields = ({
     values: { openshiftVersion },
   } = useFormikContext<ClusterCreateParams>();
   const isMultiArchSupported = useFeature('ASSISTED_INSTALLER_MULTIARCH_SUPPORTED');
-  const cpuArchitectureSupportLevelIdToSupportLevelMap = useSupportLevelsAPI(
-    'architectures',
-    openshiftVersion,
-  );
+  const { getCpuArchitectures } = useOpenshiftVersions();
+  const cpuArchitecturesByVersionImage = getCpuArchitectures(openshiftVersion);
+
   const featureSupportLevelData = useSupportLevelsAPI(
     'features',
     values.openshiftVersion,
     values.cpuArchitecture,
   );
   const cpuArchitectures = React.useMemo(
-    () =>
-      getSupportedCpuArchitectures(
-        isMultiArchSupported,
-        cpuArchitectureSupportLevelIdToSupportLevelMap,
-        isFeatureSupportedAndAvailable,
-      ),
-    [cpuArchitectureSupportLevelIdToSupportLevelMap, isMultiArchSupported],
+    () => getSupportedCpuArchitectures(isMultiArchSupported, cpuArchitecturesByVersionImage),
+    [cpuArchitecturesByVersionImage, isMultiArchSupported],
   );
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/ocm/services/Day2ClusterService.ts
+++ b/src/ocm/services/Day2ClusterService.ts
@@ -1,17 +1,15 @@
 import { InfraEnvsService } from '.';
 import { ClustersAPI } from './apis';
 import {
-  ArchitectureSupportLevelId,
   Cluster,
   ClusterCpuArchitecture,
+  CpuArchitecture,
   getSupportedCpuArchitectures,
   OcmCpuArchitecture,
   SupportedCpuArchitecture,
-  SupportLevel,
 } from '../../common';
 import { OcmClusterType } from '../components/AddHosts/types';
 import { mapOcmArchToCpuArchitecture } from './CpuArchitectureService';
-import { isFeatureSupportedAndAvailable } from '../components/newFeatureSupportLevels/newFeatureStateUtils';
 
 export const getApiVipDnsName = (ocmCluster: OcmClusterType) => {
   let apiVipDnsname = '';
@@ -47,7 +45,7 @@ const Day2ClusterService = {
     ocmCluster: OcmClusterType,
     pullSecret: string,
     openshiftVersion: string,
-    supportedCpuArchitectures: Record<ArchitectureSupportLevelId, SupportLevel> | null,
+    cpuArchitecturesByVersionImage: CpuArchitecture[],
     canSelectCpuArch?: boolean,
   ) {
     const openshiftClusterId = Day2ClusterService.getOpenshiftClusterId(ocmCluster);
@@ -68,8 +66,7 @@ const Day2ClusterService = {
     const cpuArchitectures = createMultipleInfraEnvs
       ? getSupportedCpuArchitectures(
           canSelectCpuArch ? canSelectCpuArch : false,
-          supportedCpuArchitectures,
-          isFeatureSupportedAndAvailable,
+          cpuArchitecturesByVersionImage,
         )
       : ([mapOcmArchToCpuArchitecture(ocmCluster.cpu_architecture)] as SupportedCpuArchitecture[]);
 


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-14290

The CPU arhcitectures drop down list should be created by the release image architecture and not by the support-level supported architectures. With this change we avoid some errors that happens in day2 clusters.

Before the change:

![image](https://user-images.githubusercontent.com/11390125/232753555-3c5a0e0b-1591-47af-8527-5480f4f2bba7.png)


After the change:

![image](https://user-images.githubusercontent.com/11390125/232753296-5c0809f0-4325-4176-a407-0273ad8a721b.png)
