### PR TITLE
MGMT-14320: Power Z clusters will be only homogeneous clusters

### DIFF
--- a/src/common/types/cpuArchitecture.ts
+++ b/src/common/types/cpuArchitecture.ts
@@ -46,23 +46,41 @@ export const getAllCpuArchitectures = (): SupportedCpuArchitecture[] => [
 export const getSupportedCpuArchitectures = (
   canSelectCpuArch: boolean,
   cpuArchitectures: CpuArchitecture[],
+  day1CpuArchitecture?: SupportedCpuArchitecture,
 ): SupportedCpuArchitecture[] => {
   const newSupportedCpuArchs: SupportedCpuArchitecture[] = [];
-  if (cpuArchitectures) {
-    cpuArchitectures.forEach((cpuArch) => {
-      if (
-        (cpuArch === CpuArchitecture.ppc64le || cpuArch === CpuArchitecture.s390x) &&
-        canSelectCpuArch
-      ) {
-        newSupportedCpuArchs.push(cpuArch);
-      } else if (
-        cpuArch !== CpuArchitecture.MULTI &&
-        cpuArch !== CpuArchitecture.USE_DAY1_ARCHITECTURE
-      ) {
-        newSupportedCpuArchs.push(cpuArch);
-      }
-    });
+  if (day1CpuArchitecture) {
+    if (day1CpuArchitecture === CpuArchitecture.ppc64le && canSelectCpuArch) {
+      newSupportedCpuArchs.push(CpuArchitecture.ppc64le);
+    } else if (canSelectCpuArch) {
+      cpuArchitectures.forEach((cpuArch) => {
+        if (
+          cpuArch !== CpuArchitecture.MULTI &&
+          cpuArch !== CpuArchitecture.USE_DAY1_ARCHITECTURE &&
+          cpuArch !== CpuArchitecture.ppc64le
+        ) {
+          newSupportedCpuArchs.push(cpuArch);
+        }
+      });
+    }
+  } else {
+    if (cpuArchitectures) {
+      cpuArchitectures.forEach((cpuArch) => {
+        if (
+          (cpuArch === CpuArchitecture.ppc64le || cpuArch === CpuArchitecture.s390x) &&
+          canSelectCpuArch
+        ) {
+          newSupportedCpuArchs.push(cpuArch);
+        } else if (
+          cpuArch !== CpuArchitecture.MULTI &&
+          cpuArch !== CpuArchitecture.USE_DAY1_ARCHITECTURE
+        ) {
+          newSupportedCpuArchs.push(cpuArch);
+        }
+      });
+    }
   }
+
   return newSupportedCpuArchs;
 };
 

--- a/src/ocm/components/AddHosts/day2Wizard/Day2ClusterDetails.tsx
+++ b/src/ocm/components/AddHosts/day2Wizard/Day2ClusterDetails.tsx
@@ -58,11 +58,16 @@ const Day2ClusterDetails = () => {
   const canSelectCpuArch = useFeature('ASSISTED_INSTALLER_MULTIARCH_SUPPORTED');
   const { getCpuArchitectures } = useOpenshiftVersions();
   const cpuArchitecturesByVersionImage = getCpuArchitectures(day2Cluster.openshiftVersion);
-  const cpuArchitectures = React.useMemo(
-    () => getSupportedCpuArchitectures(canSelectCpuArch, cpuArchitecturesByVersionImage),
-    [canSelectCpuArch, cpuArchitecturesByVersionImage],
-  );
   const day1CpuArchitecture = mapClusterCpuArchToInfraEnvCpuArch(day2Cluster.cpuArchitecture);
+  const cpuArchitectures = React.useMemo(
+    () =>
+      getSupportedCpuArchitectures(
+        canSelectCpuArch,
+        cpuArchitecturesByVersionImage,
+        day1CpuArchitecture,
+      ),
+    [canSelectCpuArch, cpuArchitecturesByVersionImage, day1CpuArchitecture],
+  );
   React.useEffect(() => {
     const fetchAndSetInitialValues = async () => {
       const initialValues = await getDay2ClusterDetailInitialValues(

--- a/src/ocm/components/clusterDetail/ClusterProperties.tsx
+++ b/src/ocm/components/clusterDetail/ClusterProperties.tsx
@@ -2,14 +2,12 @@ import React from 'react';
 import { GridItem, Text, TextContent } from '@patternfly/react-core';
 import {
   Cluster,
-  CpuArchitecture,
   DetailItem,
   DetailList,
   DiskEncryption,
   getDefaultCpuArchitecture,
   isDualStack,
   NETWORK_TYPE_SDN,
-  PopoverIcon,
   selectIpv4Cidr,
   selectIpv4HostPrefix,
   selectIpv6Cidr,
@@ -19,20 +17,6 @@ import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
 import { ClusterFeatureSupportLevelsDetailItem } from '../featureSupportLevels';
 import OpenShiftVersionDetail from './OpenShiftVersionDetail';
 import { useNewFeatureSupportLevel } from '../../../common/components/newFeatureSupportLevels';
-
-const CpuArchTitle = ({ isMultiArchSupported }: { isMultiArchSupported: boolean }) => {
-  let stringCpuArch: string;
-  isMultiArchSupported
-    ? (stringCpuArch =
-        'The original cluster hosts CPU architecture. You can add hosts that are using either x86 or arm64 CPU architecture to this cluster.')
-    : (stringCpuArch = 'The original cluster hosts CPU architecture.');
-  return (
-    <>
-      {'CPU architecture '}
-      <PopoverIcon bodyContent={<p>{stringCpuArch}</p>} />
-    </>
-  );
-};
 
 type ClusterPropertiesProps = {
   cluster: Cluster;
@@ -88,12 +72,7 @@ const ClusterProperties = ({ cluster, externalMode = false }: ClusterPropertiesP
   const activeFeatureConfiguration = featureSupportLevelContext.activeFeatureConfiguration;
   const underlyingCpuArchitecture =
     activeFeatureConfiguration?.underlyingCpuArchitecture || getDefaultCpuArchitecture();
-  const hasMultiCpuArchitecture = cluster.cpuArchitecture === CpuArchitecture.MULTI;
 
-  const isMultiArchSupported = Boolean(
-    hasMultiCpuArchitecture ||
-      featureSupportLevelContext.getFeatureSupportLevel('MULTIARCH_RELEASE_IMAGE') === 'supported',
-  );
   return (
     <>
       {!externalMode && (
@@ -114,7 +93,7 @@ const ClusterProperties = ({ cluster, externalMode = false }: ClusterPropertiesP
           )}
           <DetailItem title="Base domain" value={cluster.baseDnsDomain} testId="base-dns-domain" />
           <DetailItem
-            title={<CpuArchTitle isMultiArchSupported={isMultiArchSupported} />}
+            title={'CPU architecture '}
             value={underlyingCpuArchitecture}
             testId="cpu-architecture"
           />


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-14320

P/Z clusters should be homogeneous - P/Z day1 cluster should only have same cpu arch possibility in day2 and other day1 cpu archs should not support day2 P/Z.

For example, this cluster that is P/Z day1 cluster,
![image](https://user-images.githubusercontent.com/11390125/232791010-0cc5417c-5e5d-426d-b987-a6267d00b6fa.png)

 in 'Add hosts' modal for day2 only shows P/Z architecture in dropdown:
![image](https://user-images.githubusercontent.com/11390125/232790886-4b77186e-f9b6-4e21-a3b9-91d74a97c5a0.png)


