### PR TITLE
MGMT-14320: Problems in 'Add hosts' tab for Power/Z clusters 

### DIFF
--- a/src/ocm/services/Day2ClusterService.ts
+++ b/src/ocm/services/Day2ClusterService.ts
@@ -9,7 +9,10 @@ import {
   SupportedCpuArchitecture,
 } from '../../common';
 import { OcmClusterType } from '../components/AddHosts/types';
-import { mapOcmArchToCpuArchitecture } from './CpuArchitectureService';
+import {
+  mapOcmArchToCpuArchitecture,
+  mapClusterCpuArchToInfraEnvCpuArch,
+} from './CpuArchitectureService';
 
 export const getApiVipDnsName = (ocmCluster: OcmClusterType) => {
   let apiVipDnsname = '';
@@ -67,6 +70,7 @@ const Day2ClusterService = {
       ? getSupportedCpuArchitectures(
           canSelectCpuArch ? canSelectCpuArch : false,
           cpuArchitecturesByVersionImage,
+          mapClusterCpuArchToInfraEnvCpuArch(ocmCluster.cpu_architecture),
         )
       : ([mapOcmArchToCpuArchitecture(ocmCluster.cpu_architecture)] as SupportedCpuArchitecture[]);
 


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/MGMT-14320

For clusters wih Power/Z or s390 archs the  infraenvs are not created correctly because UI was not sending the day1 cpu architecture to get supported architectures. With this PR this bug will be fixed.