### PR TITLE
Update setAuthInterceptor to be idempotent

### DIFF
--- a/libs/ui-lib/lib/common/api/axiosClient.ts
+++ b/libs/ui-lib/lib/common/api/axiosClient.ts
@@ -21,29 +21,37 @@ const withAssistedInstallerBasePath = (client: AxiosInstance): AxiosInstance => 
   return client;
 };
 
+function createClient() {
+  return applyCaseMiddleware(
+    withAssistedInstallerBasePath(axios.create()),
+    // Prevents the axios-case-converter from changing object keys from '4.7-fc2' to '4_7Fc2'
+    {
+      caseFunctions: {
+        camel: (input: string) =>
+          camelCase(input, {
+            stripRegexp: /[^A-Z0-9.-]+/gi,
+          }),
+      },
+    },
+  );
+}
+
+function createClientWithoutCaseConverter() {
+  return withAssistedInstallerBasePath(axios.create());
+}
+
 let isInOcm = false;
 let ocmClient: AxiosInstance | null;
-let client = applyCaseMiddleware(
-  withAssistedInstallerBasePath(axios.create()),
-  // Prevents the axios-case-converter from changing object keys from '4.7-fc2' to '4_7Fc2'
-  {
-    caseFunctions: {
-      camel: (input: string) =>
-        camelCase(input, {
-          stripRegexp: /[^A-Z0-9.-]+/gi,
-        }),
-    },
-  },
-);
-let clientWithoutCaseConverter = withAssistedInstallerBasePath(axios.create());
+let client = createClient();
+let clientWithoutCaseConverter = createClientWithoutCaseConverter();
 
 export const setAuthInterceptor = (authInterceptor: (client: AxiosInstance) => AxiosInstance) => {
   isInOcm = true;
   ocmClient = authInterceptor(axios.create());
 
   // Instances of Axios with URL intercepted using Assisted-installer's base-path
-  client = authInterceptor(client);
-  clientWithoutCaseConverter = authInterceptor(clientWithoutCaseConverter);
+  client = authInterceptor(createClient());
+  clientWithoutCaseConverter = authInterceptor(createClientWithoutCaseConverter());
 };
 
 export { client, ocmClient, isInOcm, clientWithoutCaseConverter };


### PR DESCRIPTION
Today if we call setAuthInterceptor multiple times, it's not working because we reuse previous client and clientWithoutCaseConverter. Config url in withAssistedInstallerBasePath for example is applied multiple times.

Normally we call setAuthInterceptor only one time. But with recent module federated code, we call setAuthInterceptor every time we load the component. We also remove the job template created earlier