### PR TITLE
MGMT-20271: CPU arch options on Create Cluster page are showing "This option is not available" also the option is available

### DIFF
--- a/libs/ui-lib/lib/cim/components/common/CpuArchitectureDropdown.tsx
+++ b/libs/ui-lib/lib/cim/components/common/CpuArchitectureDropdown.tsx
@@ -54,7 +54,7 @@ const CpuArchitectureDropdown = ({
             isAriaDisabled={!isItemEnabled}
             selected={arch === value}
             description={architectureData[arch].description}
-            tooltipProps={{ content: disabledReason, position: 'top' }}
+            tooltipProps={{ content: disabledReason, position: 'top', hidden: isItemEnabled }}
             onClick={(e: React.MouseEvent) => e.preventDefault()}
           >
             {architectureData[arch].label}


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-20271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Tooltips explaining disabled options in the CPU architecture dropdown now only appear for disabled items, preventing unnecessary tooltip display on enabled selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->