### PR TITLE
MGMT-20898: In disconnected Standalone cluster installation ClusterImageSet is not getting populated in AgentClusterInstall

### DIFF
--- a/libs/locales/lib/en/translation.json
+++ b/libs/locales/lib/en/translation.json
@@ -741,6 +741,7 @@
   "ai:Service networks": "Service networks",
   "ai:Set <bold>{{agent_location_label_key}}</bold> label in Agent resource to specify its location.": "Set <bold>{{agent_location_label_key}}</bold> label in Agent resource to specify its location.",
   "ai:Set all the hosts to boot using iPXE script file": "Set all the hosts to boot using iPXE script file",
+  "ai:Show all available versions": "Show all available versions",
   "ai:Show proxy settings": "Show proxy settings",
   "ai:Single node cluster cannot contain more than 1 host.": "Single node cluster cannot contain more than 1 host.",
   "ai:Single Node OpenShift disclaimer": "Single Node OpenShift disclaimer",

--- a/libs/ui-lib/lib/cim/components/ClusterDeployment/ClusterDetailsFormFields.tsx
+++ b/libs/ui-lib/lib/cim/components/ClusterDeployment/ClusterDetailsFormFields.tsx
@@ -55,7 +55,7 @@ export const ClusterDetailsFormFields: React.FC<ClusterDetailsFormFieldsProps> =
   cpuArchitectures,
   allowHighlyAvailable,
 }) => {
-  const { values } = useFormikContext<ClusterDetailsValues>();
+  const { values, setFieldValue } = useFormikContext<ClusterDetailsValues>();
   const { name, baseDnsDomain } = values;
   const [openshiftVersionModalOpen, setOpenshiftVersionModalOpen] = React.useState(false);
 
@@ -67,6 +67,15 @@ export const ClusterDetailsFormFields: React.FC<ClusterDetailsFormFieldsProps> =
       })),
     [versions],
   );
+
+  React.useEffect(() => {
+    if (!versions.length && !values.openshiftVersion) {
+      const fallbackOpenShiftVersion = allVersions.find((version) => version.default);
+      setFieldValue('customOpenshiftSelect', fallbackOpenShiftVersion);
+      setFieldValue('openshiftVersion', fallbackOpenShiftVersion?.value);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const additionalSelectOptions = React.useMemo(() => {
     if (

--- a/libs/ui-lib/lib/common/components/ui/OpenShiftVersionDropdown.tsx
+++ b/libs/ui-lib/lib/common/components/ui/OpenShiftVersionDropdown.tsx
@@ -55,7 +55,6 @@ export const OpenShiftVersionDropdown = ({
   const [isOpen, setOpen] = React.useState(false);
   const { t } = useTranslation();
   const fieldId = getFieldId(name, 'input');
-  const isDisabled = versions.length === 0;
   const {
     values: { customOpenshiftSelect },
   } = useFormikContext<ClusterDetailsValues>();
@@ -107,28 +106,30 @@ export const OpenShiftVersionDropdown = ({
         {dropdownItems}
       </DropdownGroup>
     ),
-    <DropdownGroup label="Custom releases" key="custom-releases">
-      {customDropdownItems}
-    </DropdownGroup>,
+    customDropdownItems.length && (
+      <DropdownGroup label="Custom releases" key="custom-releases">
+        {customDropdownItems}
+      </DropdownGroup>
+    ),
     <DropdownGroup key="all-available-versions">
-      <DropdownItem key="all-versions" id="all-versions">
+      <DropdownItem key="all-versions" id="all-versions" onSelect={(e) => e.preventDefault()}>
         <Button
           variant="link"
           isInline
           onClick={() => showOpenshiftVersionModal()}
           id="show-all-versions"
         >
-          Show all available versions
+          {t('ai:Show all available versions')}
         </Button>
       </DropdownItem>
     </DropdownGroup>,
-  ];
+  ].filter(Boolean);
 
   const onSelect = React.useCallback(
     (event?: React.MouseEvent<Element, MouseEvent>, val?: string | number) => {
       const newLabel = event?.currentTarget.textContent;
       const newValue = (val as string) || '';
-      if (newLabel && newValue !== 'all-versions') {
+      if (newLabel && event.currentTarget.id !== 'all-versions') {
         setCurrent(newLabel);
         setValue(newValue);
         setOpen(false);
@@ -144,10 +145,9 @@ export const OpenShiftVersionDropdown = ({
       ref={toggleRef}
       isFullWidth
       onClick={() => setOpen(!isOpen)}
-      isDisabled={isDisabled}
       isExpanded={isOpen}
     >
-      {current}
+      {current || t('ai:OpenShift version')}
     </MenuToggle>
   );
 


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-20898

Let's always leave the dropdown enabled so that users can access the All versions modal even if the versions list is empty.

![image](https://github.com/user-attachments/assets/417ea350-98af-4a44-9b22-1cd71d04f101)

![image](https://github.com/user-attachments/assets/7fa72d2b-433e-412a-8501-b2d5d45207f5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Show all available versions" option to the version dropdown, now fully localized.

* **Bug Fixes**
  * Prevented empty "Custom releases" groups from appearing in the dropdown.
  * Improved dropdown behavior to avoid unintended selection changes when clicking "Show all available versions".
  * The dropdown toggle now displays a fallback label when no version is selected.

* **Enhancements**
  * Automatically selects a default OpenShift version when none is specified and no versions are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->