### PR TITLE
MGMT-21056: Deployment of Standalone cluster in disconnected ipv6 environment failing with error "Openshift version 4.19.3 is not supported for OpenShiftSDN" - OVN is not supported for ipv6

### DIFF
--- a/libs/ui-lib/lib/cim/components/ClusterDeployment/ClusterDetailsFormFields.tsx
+++ b/libs/ui-lib/lib/cim/components/ClusterDeployment/ClusterDetailsFormFields.tsx
@@ -15,6 +15,7 @@ import { ClusterDetailsValues } from '../../../common/components/clusterWizard/t
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
 import CpuArchitectureDropdown from '../common/CpuArchitectureDropdown';
 import ControlPlaneNodesDropdown from '../../../common/components/clusterConfiguration/ControlPlaneNodesDropdown';
+import { getNetworkType } from '../helpers';
 
 export type ClusterDetailsFormFieldsProps = {
   isEditFlow: boolean;
@@ -55,9 +56,25 @@ export const ClusterDetailsFormFields: React.FC<ClusterDetailsFormFieldsProps> =
   cpuArchitectures,
   allowHighlyAvailable,
 }) => {
+  const { t } = useTranslation();
+  const nameInputRef = React.useRef<HTMLInputElement>();
+  const [openshiftVersionModalOpen, setOpenshiftVersionModalOpen] = React.useState(false);
   const { values, setFieldValue } = useFormikContext<ClusterDetailsValues>();
   const { name, baseDnsDomain } = values;
-  const [openshiftVersionModalOpen, setOpenshiftVersionModalOpen] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!versions.length && !values.openshiftVersion) {
+      const fallbackOpenShiftVersion = allVersions.find((version) => version.default);
+      setFieldValue('customOpenshiftSelect', fallbackOpenShiftVersion);
+      setFieldValue('openshiftVersion', fallbackOpenShiftVersion?.value);
+      setFieldValue('networkType', getNetworkType(fallbackOpenShiftVersion));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  React.useEffect(() => {
+    nameInputRef.current?.focus();
+  }, []);
 
   const selectOptions = React.useMemo(
     () =>
@@ -67,15 +84,6 @@ export const ClusterDetailsFormFields: React.FC<ClusterDetailsFormFieldsProps> =
       })),
     [versions],
   );
-
-  React.useEffect(() => {
-    if (!versions.length && !values.openshiftVersion) {
-      const fallbackOpenShiftVersion = allVersions.find((version) => version.default);
-      setFieldValue('customOpenshiftSelect', fallbackOpenShiftVersion);
-      setFieldValue('openshiftVersion', fallbackOpenShiftVersion?.value);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const additionalSelectOptions = React.useMemo(() => {
     if (
@@ -92,14 +100,9 @@ export const ClusterDetailsFormFields: React.FC<ClusterDetailsFormFieldsProps> =
     return [];
   }, [selectOptions, values.customOpenshiftSelect]);
 
-  const nameInputRef = React.useRef<HTMLInputElement>();
-  React.useEffect(() => {
-    nameInputRef.current?.focus();
-  }, []);
-  const atListOneDiskEncryptionEnableOn =
+  const isDiskEncryptionEnabled =
     values.enableDiskEncryptionOnMasters || values.enableDiskEncryptionOnWorkers;
 
-  const { t } = useTranslation();
   return (
     <Form id="wizard-cluster-details__form">
       {isEditFlow ? (
@@ -172,7 +175,7 @@ export const ClusterDetailsFormFields: React.FC<ClusterDetailsFormFieldsProps> =
         isDisabled={isPullSecretSet}
         isSNO={isSNO({ controlPlaneCount })}
       /> */}
-      {atListOneDiskEncryptionEnableOn && values.diskEncryptionMode === 'tpmv2' && (
+      {isDiskEncryptionEnabled && values.diskEncryptionMode === 'tpmv2' && (
         <Alert
           variant={AlertVariant.warning}
           isInline
@@ -185,7 +188,7 @@ export const ClusterDetailsFormFields: React.FC<ClusterDetailsFormFieldsProps> =
           }
         />
       )}
-      {atListOneDiskEncryptionEnableOn && values.diskEncryptionMode === 'tang' && (
+      {isDiskEncryptionEnabled && values.diskEncryptionMode === 'tang' && (
         <Alert
           variant={AlertVariant.warning}
           isInline


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-21056

If no OpenShift version has the label `visible` set to `"true"`, the `openshiftVersion` value is initially empty which results in `OpenShiftSDN` being used as the `networkType`. 

When we select a fallback OpenShift version from those with `visible` set to `"false"`, we need to reset `networkType` to a compatible value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved clarity and organization of the cluster details form fields, including more logical ordering of hooks and variables.
  * Enhanced naming for disk encryption indicators for easier understanding.
  * Internal updates to how network type is set when using a default OpenShift version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->