### PR TITLE
MGMT-21216: Wrap inline code blocks

### DIFF
--- a/libs/chatbot/lib/components/ChatBot/Chatbot.css
+++ b/libs/chatbot/lib/components/ChatBot/Chatbot.css
@@ -19,3 +19,11 @@
 .ai-chatbot .pf-chatbot__message-and-actions a.pf-m-link .pf-v6-c-button__text {
   word-break: break-word;
 }
+
+/*
+ * Break long words in inline code.
+ * Workaround for links that are not formatted correctly by the service.
+*/
+.ai-chatbot .pf-chatbot__message-text .pf-chatbot__message-inline-code {
+  word-break: break-word;
+}


### PR DESCRIPTION
Sometimes, links are not formatted correctly in the API response, and the Patternfly Message component does not identify them as links, but as inline code blocks.

Added CSS rule to wrap inline code blocks as a workaround.

Correctly formatted link, wrapped:

<img width="200" height="300" alt="formatted-as-a-link" src="https://github.com/user-attachments/assets/04207da5-857e-4417-aabc-8f19113745a0" />

Incorrectly formatted link, wrapped:
<img width="200" height="300" alt="formatted-as-code-with-wrapping" src="https://github.com/user-attachments/assets/f77b76db-1308-47bb-8a2b-70c49f377e3f" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved display of inline code in chatbot messages by ensuring long words break appropriately, preventing horizontal scrollbars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->