### PR TITLE
Decouple release of chatbot from OCM/CIM

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,9 +14,10 @@ jobs:
     steps:
       - name: Check workflow runs in a release branch or is CIM release
         run: |
-          if [[ "${{ github.event.release.target_commitish }}" != *releases* && ! "$GITHUB_REF_NAME" =~ -cim$ ]]; then
+          if [[ "${{ github.event.release.target_commitish }}" != *releases* && ! "$GITHUB_REF_NAME" =~ -(cim|chatbot)$ ]]; then
             echo "OCM: Expecting to be in a release branch, but we are in: ${{ github.event.release.target_commitish }}"
             echo "CIM: Not a CIM release, since tag does not end with '-cim'. Tag is: $GITHUB_REF_NAME"
+            echo "Chatbot: Not a Chatbot release, since tag does not end with '-chatbot'. Tag is: $GITHUB_REF_NAME"
             exit 1
           fi
 
@@ -28,11 +29,16 @@ jobs:
       - name: Lookup for workspaces to be published
         run: |
           declare -a LIBS=()
-          for pkg in libs/*/package.json; do
-            if [[ "$(jq '.publishConfig.access == "public"' "${pkg}")" = "true" ]]; then
-              LIBS+=("${pkg:5:-13}")
-            fi
-          done
+          if [[ "$GITHUB_REF_NAME" =~ -chatbot$ ]]; then
+            LIBS+=("chatbot")
+          else
+            for pkg in libs/*/package.json; do
+              lib_name="${pkg:5:-13}"
+              if [[ "$lib_name" != "chatbot" && "$(jq '.publishConfig.access == "public"' "${pkg}")" = "true" ]]; then
+                LIBS+=("$lib_name")
+              fi
+            done
+          fi
           echo "LIBS=${LIBS[@]}" >> $GITHUB_ENV
           (IFS=,; printf 'The following workspaces will be published: [%s]\n' "${LIBS[*]}")
 

--- a/docs/RELEASE_WORKFLOW.md
+++ b/docs/RELEASE_WORKFLOW.md
@@ -18,16 +18,24 @@ The library's `package.json` must contain the following section in order to be s
 }
 ```
 
+There are 3 possible releases, driven by the suffix in the release name:
+
+- OCM - no suffix
+- CIM - suffix `-cim`
+- Chatbot - suffix `-chatbot`
+
 ## Instructions
 
 1. Make sure you have been granted the `maintaner` role in the project settings.
 2. Create a new branch from `master` and name it following this pattern:
-   `releases/v<some-semver-string>`.
+   `releases/v<some-semver-string>-<optionally_a_suffix>`.
 3. [Draft a new release through GitHub's interface](https://github.com/openshift-assisted/assisted-installer-ui/releases/new).
 4. Fill the form with the following details:
-   1. Tag: `v<some-semver-string>`
-   2. Target branch: `releases/v<some-semver-string>` (the same as in the previous step).
-   3. Title: `v<some-semver-string>` (again, the same as in the previous step).
+   1. Tag: `v<some-semver-string>-<optionally_a_suffix>`
+   2. Target branch: `releases/v<some-semver-string>-<optionally_a_suffix>` (the same as in the
+      previous step).
+   3. Title: `v<some-semver-string>-<optionally_a_suffix>` (again, the same as in the previous
+      step).
    4. Description: Generate the release notes automatically (recommended), or edit the field
       manually.
 
@@ -36,4 +44,5 @@ The library's `package.json` must contain the following section in order to be s
 - [@openshift-assisted/ui-lib](https://www.npmjs.com/package/@openshift-assisted/ui-lib)
 - [@openshift-assisted/types](https://www.npmjs.com/package/@openshift-assisted/types)
 - [@openshift-assisted/locales](https://www.npmjs.com/package/@openshift-assisted/locales)
+- [@openshift-assisted/chatbot](https://www.npmjs.com/package/@openshift-assisted/chatbot)
 - https://quay.io/repository/edge-infrastructure/assisted-installer-ui?tab=tags


### PR DESCRIPTION
Update release script to handle `-chatbot` releases.
Chatbot package is included only in `-chatbot` release, not in OCM or CIM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to support release tags ending with "-chatbot" in addition to "-cim".
  * Improved log output to clarify when a release is not for the chatbot.
  * Adjusted publishing logic so only the chatbot library is published for "-chatbot" releases; other releases exclude the chatbot library.
* **Documentation**
  * Clarified release types and naming conventions for tags with optional suffixes.
  * Updated instructions for drafting releases to include suffix requirements.
  * Expanded list of publicly available artifacts to include the chatbot package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->