### PR TITLE
MGMT-21350: Fix SSE parsing and set break-word for all chatbot messages

### DIFF
--- a/apps/assisted-ui/package.json
+++ b/apps/assisted-ui/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "@openshift-assisted/chatbot": "workspace:*",
     "@openshift-assisted/ui-lib": "workspace:*",
+    "@openshift-assisted/chatbot": "workspace:*",
     "@openshift-console/dynamic-plugin-sdk": "0.0.3",
     "@patternfly-6/chatbot": "npm:@patternfly/chatbot@2.2.1",
     "@patternfly-6/patternfly": "npm:@patternfly/patternfly@6.2.2",

--- a/libs/chatbot/lib/components/ChatBot/Chatbot.css
+++ b/libs/chatbot/lib/components/ChatBot/Chatbot.css
@@ -13,17 +13,6 @@
   inset-inline-end: 20px;
 }
 
-/*
-* Break long words in links, otherwise the horizontal scrollbar appears.
-*/
-.ai-chatbot .pf-chatbot__message-and-actions a.pf-m-link .pf-v6-c-button__text {
-  word-break: break-word;
-}
-
-/*
- * Break long words in inline code.
- * Workaround for links that are not formatted correctly by the service.
-*/
-.ai-chatbot .pf-chatbot__message-text .pf-chatbot__message-inline-code {
+.ai-chatbot .pf-chatbot__message-and-actions {
   word-break: break-word;
 }

--- a/libs/chatbot/tsconfig.json
+++ b/libs/chatbot/tsconfig.json
@@ -21,16 +21,5 @@
     "tsBuildInfoFile": "node_modules/.cache/tsc/tsconfig.tsbuildinfo"
   },
   "include": ["lib"],
-  "exclude": ["**/_*"],
-  "references": [
-    {
-      "path": "../types"
-    },
-    {
-      "path": "../sdks"
-    },
-    {
-      "path": "../locales"
-    }
-  ]
+  "exclude": ["**/_*"]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the handling of streaming responses in the chat window to ensure more reliable and accurate message updates.

* **Style**
  * Simplified CSS by consolidating word-break rules for chat messages, ensuring consistent text wrapping across message content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->