### PR TITLE
Remove back button from first page

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterWizard/disconnected/BasicStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/disconnected/BasicStep.tsx
@@ -27,8 +27,7 @@ import { WithErrorBoundary } from '../../../../common/components/ErrorHandling/W
 
 const BasicStep = () => {
   const { t } = useTranslation();
-  const { installDisconnected, setInstallDisconnected, moveNext, moveBack } =
-    useClusterWizardContext();
+  const { installDisconnected, setInstallDisconnected, moveNext } = useClusterWizardContext();
 
   return (
     <Formik
@@ -39,7 +38,7 @@ const BasicStep = () => {
     >
       <ClusterWizardStep
         navigation={<ClusterWizardNavigation />}
-        footer={<ClusterWizardFooter onNext={moveNext} onBack={moveBack} />}
+        footer={<ClusterWizardFooter onNext={moveNext} />}
       >
         <WithErrorBoundary title="Failed to load Basic step">
           <Grid hasGutter>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified navigation in the Cluster Wizard’s Disconnected Basic step: the Back action has been removed.
  * The footer now only presents a Next action for forward progression on this step.
  * Users can no longer navigate backward from this specific step, resulting in a more streamlined flow.
  * No other steps are affected; standard navigation remains elsewhere in the wizard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->