### PR TITLE
MGMT-20345 | Authorino Operator's 'Learn More' Link Should Point to Documentation or README Instead of Repo Root

### DIFF
--- a/libs/ui-lib/lib/common/config/docs_links.ts
+++ b/libs/ui-lib/lib/common/config/docs_links.ts
@@ -162,7 +162,8 @@ export const getMtuLink = (ocpVersion?: string) =>
     ocpVersion,
   )}/html/networking/changing-cluster-network-mtu#nw-cluster-mtu-change-about_changing-cluster-network-mtu`;
 
-export const AUTHORINO_OPERATOR_LINK = 'https://github.com/Kuadrant/authorino-operator';
+export const AUTHORINO_OPERATOR_LINK =
+  'https://github.com/Kuadrant/authorino-operator/blob/main/README.md';
 
 export const getLsoLink = (ocpVersion?: string) => {
   const version = getDocsOpenshiftVersion(ocpVersion);


### PR DESCRIPTION
[MGMT-20345](https://issues.redhat.com//browse/MGMT-20345) | Authorino Operator's 'Learn More' Link Should Point to Documentation or README Instead of Repo Root

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Authorino Operator link to point directly to the project README on the main branch for more accurate, up-to-date setup and usage information.
  * Improves navigation from the UI to relevant docs and reduces extra clicks.
  * No functional changes—only the documentation link used in the UI was updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->