### PR TITLE
MGMT-21261: keep link to pull secret visible

### DIFF
--- a/libs/ui-lib/lib/common/components/ui/formik/TextAreaField.tsx
+++ b/libs/ui-lib/lib/common/components/ui/formik/TextAreaField.tsx
@@ -60,13 +60,20 @@ const TextAreaField: React.FC<TextAreaFieldProps> = ({
       {(errorMessage || helperText) && (
         <FormHelperText>
           <HelperText>
-            <HelperTextItem
-              icon={errorMessage && <ExclamationCircleIcon />}
-              variant={errorMessage ? 'error' : 'default'}
-              id={errorMessage ? `${fieldId}-helper-error` : `${fieldId}-helper`}
-            >
-              {errorMessage ? errorMessage : helperText}
-            </HelperTextItem>
+            {errorMessage && (
+              <HelperTextItem
+                icon={<ExclamationCircleIcon />}
+                variant={'error'}
+                id={`${fieldId}-helper-error`}
+              >
+                {errorMessage}
+              </HelperTextItem>
+            )}
+            {helperText && (
+              <HelperTextItem variant={'default'} id={`${fieldId}-helper`}>
+                {helperText}
+              </HelperTextItem>
+            )}
           </HelperText>
         </FormHelperText>
       )}


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-21261

<img width="1631" height="821" alt="image" src="https://github.com/user-attachments/assets/7d0b5b2c-eafe-40e0-9dfc-55b6b39b91be" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * TextArea fields now display error messages more clearly with an error icon.
  * Helper text and error messages are shown separately for improved clarity and consistency.
  * More reliable rendering of helper/error states across forms.

* **Refactor**
  * Simplified internal rendering logic for helper and error messages to improve maintainability without changing public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->