### PR TITLE
MGMT-19755: Create infrastructure environment shows old OCP versions

### DIFF
--- a/libs/ui-lib/lib/cim/components/InfraEnv/InfraEnvOpenShiftVersionDropdown.tsx
+++ b/libs/ui-lib/lib/cim/components/InfraEnv/InfraEnvOpenShiftVersionDropdown.tsx
@@ -65,15 +65,17 @@ const InfraEnvOpenShiftVersionDropdown = ({ osImages }: { osImages: OsImage[] })
           onOpenChange={() => setOsImageOpen(!osImageOpen)}
         >
           <DropdownList>
-            {filteredImages.map((image) => (
-              <DropdownItem
-                key={image.openshiftVersion}
-                id={image.openshiftVersion}
-                value={image.openshiftVersion}
-              >
-                {`OpenShift ${image.openshiftVersion}`}
-              </DropdownItem>
-            ))}
+            {filteredImages
+              .sort((a, b) => b.openshiftVersion.localeCompare(a.openshiftVersion))
+              .map((image) => (
+                <DropdownItem
+                  key={image.openshiftVersion}
+                  id={image.openshiftVersion}
+                  value={image.openshiftVersion}
+                >
+                  {`OpenShift ${image.openshiftVersion}`}
+                </DropdownItem>
+              ))}
           </DropdownList>
         </Dropdown>
       </Tooltip>


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-19755

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Infra Environment: OpenShift Version dropdown options are now consistently sorted by version, providing a predictable order.
  * Improves usability by making it easier and faster to locate and select the desired version.
  * No visual design changes — only the ordering of dropdown items is affected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->