### PR TITLE
NO-ISSUE: Page header -> Page masthead

### DIFF
--- a/apps/assisted-ui/src/components/App.tsx
+++ b/apps/assisted-ui/src/components/App.tsx
@@ -13,7 +13,7 @@ window.__app__ = { OCM };
 export const App: React.FC = () => (
   <BrowserRouter basename={Config.routeBasePath}>
     <CompatRouter>
-      <Page header={<Header />} isManagedSidebar defaultManagedSidebarIsOpen={false}>
+      <Page masthead={<Header />} isManagedSidebar defaultManagedSidebarIsOpen={false}>
         <UILibRoutes
           allEnabledFeatures={Features.STANDALONE_DEPLOYMENT_ENABLED_FEATURES}
           additionalComponents={refreshToken ? <ChatBot /> : undefined}


### PR DESCRIPTION
Page `header` is not a prop anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing features added in this release.
- Refactor
  - Updated the top-level page layout to use a masthead configuration for the header area while preserving existing content and behavior.
  - All navigation, routes, and page properties remain unchanged.
  - No visual or functional differences expected for end users.
- Bug Fixes
  - None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->