### PR TITLE
MGMT-21625: Add Dual-Stack with Primary IPv6 Support

### DIFF
--- a/libs/ui-lib/lib/common/components/clusterConfiguration/utils.test.ts
+++ b/libs/ui-lib/lib/common/components/clusterConfiguration/utils.test.ts
@@ -1,0 +1,275 @@
+import { test, describe, expect } from 'vitest';
+import { isDualStack } from './utils';
+import {
+  MachineNetwork,
+  ClusterNetwork,
+  ServiceNetwork,
+} from '@openshift-assisted/types/assisted-installer-service';
+
+describe('isDualStack', () => {
+  const createMachineNetwork = (cidr: string): MachineNetwork => ({ cidr, clusterId: 'test' });
+  const createClusterNetwork = (cidr: string, hostPrefix: number): ClusterNetwork => ({
+    cidr,
+    hostPrefix,
+    clusterId: 'test',
+  });
+  const createServiceNetwork = (cidr: string): ServiceNetwork => ({ cidr, clusterId: 'test' });
+
+  describe('OCP < 4.12 (legacy behavior)', () => {
+    test('returns true for valid dual stack with IPv4 primary', () => {
+      const result = isDualStack({
+        machineNetworks: [
+          createMachineNetwork('192.168.1.0/24'),
+          createMachineNetwork('2001:db8::/64'),
+        ],
+        clusterNetworks: [
+          createClusterNetwork('10.128.0.0/14', 23),
+          createClusterNetwork('fd01::/48', 64),
+        ],
+        serviceNetworks: [
+          createServiceNetwork('172.30.0.0/16'),
+          createServiceNetwork('fd02::/112'),
+        ],
+        openshiftVersion: '4.11',
+      });
+
+      expect(result).toBe(true);
+    });
+
+    test('returns false for IPv6 primary in OCP < 4.12', () => {
+      const result = isDualStack({
+        machineNetworks: [
+          createMachineNetwork('2001:db8::/64'),
+          createMachineNetwork('192.168.1.0/24'),
+        ],
+        clusterNetworks: [
+          createClusterNetwork('fd01::/48', 64),
+          createClusterNetwork('10.128.0.0/14', 23),
+        ],
+        serviceNetworks: [
+          createServiceNetwork('fd02::/112'),
+          createServiceNetwork('172.30.0.0/16'),
+        ],
+        openshiftVersion: '4.11',
+      });
+
+      expect(result).toBe(false);
+    });
+
+    test('returns false for single stack', () => {
+      const result = isDualStack({
+        machineNetworks: [createMachineNetwork('192.168.1.0/24')],
+        clusterNetworks: [createClusterNetwork('10.128.0.0/14', 23)],
+        serviceNetworks: [createServiceNetwork('172.30.0.0/16')],
+        openshiftVersion: '4.11',
+      });
+
+      expect(result).toBe(false);
+    });
+
+    test('returns false for empty networks', () => {
+      const result = isDualStack({
+        machineNetworks: [],
+        clusterNetworks: [],
+        serviceNetworks: [],
+        openshiftVersion: '4.11',
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('OCP >= 4.12 (new behavior)', () => {
+    test('returns true for IPv4 primary and IPv6 secondary', () => {
+      const result = isDualStack({
+        machineNetworks: [
+          createMachineNetwork('192.168.1.0/24'),
+          createMachineNetwork('2001:db8::/64'),
+        ],
+        clusterNetworks: [
+          createClusterNetwork('10.128.0.0/14', 23),
+          createClusterNetwork('fd01::/48', 64),
+        ],
+        serviceNetworks: [
+          createServiceNetwork('172.30.0.0/16'),
+          createServiceNetwork('fd02::/112'),
+        ],
+        openshiftVersion: '4.12',
+      });
+
+      expect(result).toBe(true);
+    });
+
+    test('returns true for IPv6 primary and IPv4 secondary', () => {
+      const result = isDualStack({
+        machineNetworks: [
+          createMachineNetwork('2001:db8::/64'),
+          createMachineNetwork('192.168.1.0/24'),
+        ],
+        clusterNetworks: [
+          createClusterNetwork('fd01::/48', 64),
+          createClusterNetwork('10.128.0.0/14', 23),
+        ],
+        serviceNetworks: [
+          createServiceNetwork('fd02::/112'),
+          createServiceNetwork('172.30.0.0/16'),
+        ],
+        openshiftVersion: '4.12',
+      });
+
+      expect(result).toBe(true);
+    });
+
+    test('returns false for IPv6 primary and IPv6 secondary (not dual-stack)', () => {
+      const result = isDualStack({
+        machineNetworks: [
+          createMachineNetwork('2001:db8::/64'),
+          createMachineNetwork('2001:db9::/64'),
+        ],
+        clusterNetworks: [
+          createClusterNetwork('fd01::/48', 64),
+          createClusterNetwork('fd02::/48', 64),
+        ],
+        serviceNetworks: [createServiceNetwork('fd03::/112'), createServiceNetwork('fd04::/112')],
+        openshiftVersion: '4.12',
+      });
+
+      expect(result).toBe(false);
+    });
+
+    test('returns false for IPv4 primary and IPv4 secondary (not dual-stack)', () => {
+      const result = isDualStack({
+        machineNetworks: [
+          createMachineNetwork('192.168.1.0/24'),
+          createMachineNetwork('10.0.0.0/24'),
+        ],
+        clusterNetworks: [
+          createClusterNetwork('10.128.0.0/14', 23),
+          createClusterNetwork('172.16.0.0/14', 23),
+        ],
+        serviceNetworks: [
+          createServiceNetwork('172.30.0.0/16'),
+          createServiceNetwork('172.31.0.0/16'),
+        ],
+        openshiftVersion: '4.12',
+      });
+
+      expect(result).toBe(false);
+    });
+
+    test('returns false for single stack', () => {
+      const result = isDualStack({
+        machineNetworks: [createMachineNetwork('192.168.1.0/24')],
+        clusterNetworks: [createClusterNetwork('10.128.0.0/14', 23)],
+        serviceNetworks: [createServiceNetwork('172.30.0.0/16')],
+        openshiftVersion: '4.12',
+      });
+
+      expect(result).toBe(false);
+    });
+
+    test('returns false if any network type is not dual stack', () => {
+      const result = isDualStack({
+        machineNetworks: [
+          createMachineNetwork('192.168.1.0/24'),
+          createMachineNetwork('2001:db8::/64'),
+        ],
+        clusterNetworks: [createClusterNetwork('10.128.0.0/14', 23)], // Single stack
+        serviceNetworks: [
+          createServiceNetwork('172.30.0.0/16'),
+          createServiceNetwork('fd02::/112'),
+        ],
+        openshiftVersion: '4.12',
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('no version specified (defaults to legacy behavior)', () => {
+    test('returns true for IPv4 primary and IPv6 secondary', () => {
+      const result = isDualStack({
+        machineNetworks: [
+          createMachineNetwork('192.168.1.0/24'),
+          createMachineNetwork('2001:db8::/64'),
+        ],
+        clusterNetworks: [
+          createClusterNetwork('10.128.0.0/14', 23),
+          createClusterNetwork('fd01::/48', 64),
+        ],
+        serviceNetworks: [
+          createServiceNetwork('172.30.0.0/16'),
+          createServiceNetwork('fd02::/112'),
+        ],
+      });
+
+      expect(result).toBe(true);
+    });
+
+    test('returns false for IPv6 primary when no version specified', () => {
+      const result = isDualStack({
+        machineNetworks: [
+          createMachineNetwork('2001:db8::/64'),
+          createMachineNetwork('192.168.1.0/24'),
+        ],
+        clusterNetworks: [
+          createClusterNetwork('fd01::/48', 64),
+          createClusterNetwork('10.128.0.0/14', 23),
+        ],
+        serviceNetworks: [
+          createServiceNetwork('fd02::/112'),
+          createServiceNetwork('172.30.0.0/16'),
+        ],
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('edge cases', () => {
+    test('handles undefined networks', () => {
+      const result = isDualStack({
+        machineNetworks: undefined,
+        clusterNetworks: undefined,
+        serviceNetworks: undefined,
+        openshiftVersion: '4.12',
+      });
+
+      expect(result).toBe(false);
+    });
+
+    test('handles networks with empty CIDRs', () => {
+      const result = isDualStack({
+        machineNetworks: [
+          { cidr: '', clusterId: 'test' },
+          { cidr: '', clusterId: 'test' },
+        ],
+        clusterNetworks: [
+          { cidr: '', hostPrefix: 23, clusterId: 'test' },
+          { cidr: '', hostPrefix: 64, clusterId: 'test' },
+        ],
+        serviceNetworks: [
+          { cidr: '', clusterId: 'test' },
+          { cidr: '', clusterId: 'test' },
+        ],
+        openshiftVersion: '4.12',
+      });
+
+      expect(result).toBe(false);
+    });
+
+    test('handles invalid CIDRs', () => {
+      const result = isDualStack({
+        machineNetworks: [createMachineNetwork('invalid'), createMachineNetwork('also-invalid')],
+        clusterNetworks: [
+          createClusterNetwork('invalid', 23),
+          createClusterNetwork('also-invalid', 64),
+        ],
+        serviceNetworks: [createServiceNetwork('invalid'), createServiceNetwork('also-invalid')],
+        openshiftVersion: '4.12',
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/libs/ui-lib/lib/common/components/clusterConfiguration/utils.ts
+++ b/libs/ui-lib/lib/common/components/clusterConfiguration/utils.ts
@@ -10,6 +10,7 @@ import {
   ServiceNetwork,
 } from '@openshift-assisted/types/assisted-installer-service';
 import { NO_SUBNET_SET } from '../../config';
+import { isMajorMinorVersionEqualOrGreater } from '../../utils';
 import {
   selectClusterNetworkCIDR,
   selectClusterNetworkHostPrefix,
@@ -179,20 +180,38 @@ export const canBeDualStack = (subnets: HostSubnets) =>
 
 const areNetworksDualStack = (
   networks: (MachineNetwork | ClusterNetwork | ServiceNetwork)[] | undefined,
-) =>
-  networks &&
-  networks.length > 1 &&
-  Address4.isValid(networks[0].cidr || '') &&
-  Address6.isValid(networks[1].cidr || '');
+  openshiftVersion?: string,
+) => {
+  if (!networks || networks.length < 2) {
+    return false;
+  }
+
+  const firstCidr = networks[0].cidr || '';
+  const secondCidr = networks[1].cidr || '';
+
+  // For OCP >= 4.12, allow either IPv4 or IPv6 as primary, with opposite as secondary
+  if (openshiftVersion && isMajorMinorVersionEqualOrGreater(openshiftVersion, '4.12')) {
+    return (
+      (Address4.isValid(firstCidr) && Address6.isValid(secondCidr)) ||
+      (Address6.isValid(firstCidr) && Address4.isValid(secondCidr))
+    );
+  }
+
+  // For older versions, require IPv4 as primary and IPv6 as secondary
+  return Address4.isValid(firstCidr) && Address6.isValid(secondCidr);
+};
 
 export const isDualStack = ({
   machineNetworks,
   clusterNetworks,
   serviceNetworks,
-}: Pick<Cluster, 'machineNetworks' | 'clusterNetworks' | 'serviceNetworks'>) =>
-  areNetworksDualStack(machineNetworks) &&
-  areNetworksDualStack(clusterNetworks) &&
-  areNetworksDualStack(serviceNetworks);
+  openshiftVersion,
+}: Pick<Cluster, 'machineNetworks' | 'clusterNetworks' | 'serviceNetworks'> & {
+  openshiftVersion?: string;
+}) =>
+  areNetworksDualStack(machineNetworks, openshiftVersion) &&
+  areNetworksDualStack(clusterNetworks, openshiftVersion) &&
+  areNetworksDualStack(serviceNetworks, openshiftVersion);
 
 export const isSubnetInIPv6 = ({
   clusterNetworkCidr,

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/AvailableSubnetsControl.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/AvailableSubnetsControl.tsx
@@ -9,6 +9,7 @@ import {
   NetworkConfigurationValues,
   DUAL_STACK,
   NO_SUBNET_SET,
+  isMajorMinorVersionEqualOrGreater,
 } from '../../../../common';
 import { selectCurrentClusterPermissionsState } from '../../../store/slices/current-cluster/selectors';
 import { SubnetsDropdown } from './SubnetsDropdown';
@@ -35,6 +36,7 @@ export interface AvailableSubnetsControlProps {
   hostSubnets: HostSubnet[];
   isRequired: boolean;
   isDisabled: boolean;
+  openshiftVersion?: string;
 }
 
 export const AvailableSubnetsControl = ({
@@ -42,10 +44,15 @@ export const AvailableSubnetsControl = ({
   hostSubnets,
   isRequired = false,
   isDisabled,
+  openshiftVersion,
 }: AvailableSubnetsControlProps) => {
   const { values, errors, setFieldValue } = useFormikContext<NetworkConfigurationValues>();
   const isDualStack = values.stackType === DUAL_STACK;
   const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
+
+  // Check if OCP version supports IPv6 as primary network
+  const supportsIPv6Primary =
+    openshiftVersion && isMajorMinorVersionEqualOrGreater(openshiftVersion, '4.12');
 
   const IPv4Subnets = hostSubnets
     .filter((subnet) => Address4.isValid(subnet.subnet))
@@ -54,53 +61,106 @@ export const AvailableSubnetsControl = ({
     .filter((subnet) => Address6.isValid(subnet.subnet))
     .sort(subnetSort);
 
+  // For OCP >= 4.12, both networks can use either IPv4 or IPv6
+  const allSubnets = supportsIPv6Primary
+    ? [...IPv4Subnets, ...IPv6Subnets].sort(subnetSort)
+    : IPv4Subnets;
+
+  // For auto-selection, always use IPv4 subnets for single-stack
   const cidr = IPv4Subnets.length >= 1 ? IPv4Subnets[0].subnet : NO_SUBNET_SET;
   const hasEmptySelection = (values.machineNetworks ?? []).length === 0;
   const autoSelectNetwork = !isViewerMode && hasEmptySelection;
   useAutoSelectSingleAvailableSubnet(autoSelectNetwork, setFieldValue, cidr, clusterId);
 
   return (
-    <FormGroup
-      label="Machine network"
-      labelInfo={isDualStack && 'Primary'}
-      fieldId="machine-networks"
-      isRequired={isRequired}
-    >
-      <FieldArray name="machineNetworks">
-        {() => (
-          <Stack>
-            {isDualStack ? (
-              values.machineNetworks?.map((_machineNetwork, index) => {
-                const machineSubnets = index === 1 ? IPv6Subnets : IPv4Subnets;
+    <>
+      <FormGroup
+        label="Machine network"
+        labelInfo={isDualStack && 'Primary'}
+        fieldId="machine-networks"
+        isRequired={isRequired}
+      >
+        <FieldArray name="machineNetworks">
+          {() => (
+            <Stack>
+              {isDualStack ? (
+                values.machineNetworks?.map((machineNetwork, index) => {
+                  if (index > 0) return null;
 
-                return (
-                  <StackItem key={index}>
-                    <SubnetsDropdown
-                      name={`machineNetworks.${index}.cidr`}
-                      machineSubnets={machineSubnets}
-                      isDisabled={isDisabled}
-                      data-testid={`subnets-dropdown-toggle-${index ? 'ipv6' : 'ipv4'}`}
-                    />
-                  </StackItem>
-                );
-              })
-            ) : (
-              <StackItem>
-                <SubnetsDropdown
-                  name={`machineNetworks.0.cidr`}
-                  machineSubnets={IPv4Subnets}
-                  isDisabled={isDisabled}
-                  data-testid={'subnets-dropdown-toggle-ipv4'}
-                />
-              </StackItem>
-            )}
-          </Stack>
+                  const machineSubnets = supportsIPv6Primary ? allSubnets : IPv4Subnets;
+
+                  return (
+                    <StackItem key={index}>
+                      <SubnetsDropdown
+                        name={`machineNetworks.${index}.cidr`}
+                        machineSubnets={machineSubnets}
+                        isDisabled={isDisabled}
+                        data-testid={`subnets-dropdown-toggle-${index ? 'ipv6' : 'ipv4'}`}
+                      />
+                    </StackItem>
+                  );
+                })
+              ) : (
+                <StackItem>
+                  <SubnetsDropdown
+                    name={`machineNetworks.0.cidr`}
+                    machineSubnets={IPv4Subnets}
+                    isDisabled={isDisabled}
+                    data-testid={'subnets-dropdown-toggle-primary'}
+                  />
+                </StackItem>
+              )}
+            </Stack>
+          )}
+        </FieldArray>
+
+        {typeof errors.machineNetworks === 'string' && (
+          <Alert variant={AlertVariant.warning} title={errors.machineNetworks} isInline />
         )}
-      </FieldArray>
+      </FormGroup>
 
-      {typeof errors.machineNetworks === 'string' && (
-        <Alert variant={AlertVariant.warning} title={errors.machineNetworks} isInline />
+      {isDualStack && values.machineNetworks && values.machineNetworks.length > 1 && (
+        <FormGroup
+          label="Machine network"
+          labelInfo="Secondary"
+          fieldId="machine-networks-secondary"
+          isRequired={isRequired}
+        >
+          <FieldArray name="machineNetworks">
+            {() => {
+              const index = 1;
+              let machineSubnets;
+
+              if (supportsIPv6Primary) {
+                // For OCP >= 4.12, smart filtering based on the other network's selection
+                const firstNetworkCidr = values.machineNetworks?.[0]?.cidr;
+                if (firstNetworkCidr && Address6.isValid(firstNetworkCidr)) {
+                  // If first is IPv6, second should be IPv4
+                  machineSubnets = IPv4Subnets;
+                } else if (firstNetworkCidr && Address4.isValid(firstNetworkCidr)) {
+                  // If first is IPv4, second should be IPv6
+                  machineSubnets = IPv6Subnets;
+                } else {
+                  // If first is not selected yet, show all subnets
+                  machineSubnets = allSubnets;
+                }
+              } else {
+                // For older versions, second network is IPv6
+                machineSubnets = IPv6Subnets;
+              }
+
+              return (
+                <SubnetsDropdown
+                  name={`machineNetworks.${index}.cidr`}
+                  machineSubnets={machineSubnets}
+                  isDisabled={isDisabled}
+                  data-testid={`subnets-dropdown-toggle-${index ? 'ipv6' : 'ipv4'}`}
+                />
+              );
+            }}
+          </FieldArray>
+        </FormGroup>
       )}
-    </FormGroup>
+    </>
   );
 };

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
@@ -224,10 +224,10 @@ const NetworkConfiguration = ({
   );
 
   React.useEffect(() => {
-    if (!isViewerMode && isDualStack && !isUserManagedNetworking) {
+    if (!isViewerMode && isDualStack) {
       toggleAdvConfiguration(true);
     }
-  }, [isDualStack, isUserManagedNetworking, isViewerMode, toggleAdvConfiguration]);
+  }, [isDualStack, isViewerMode, toggleAdvConfiguration]);
 
   const managedNetworkingState = React.useMemo(
     () =>
@@ -292,6 +292,7 @@ const NetworkConfiguration = ({
               hostSubnets.length === 0 ||
               false
             }
+            openshiftVersion={cluster.openshiftVersion}
           />
         </StackItem>
       )}

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
@@ -200,8 +200,9 @@ const NetworkConfigurationPage = ({ cluster }: { cluster: Cluster }) => {
   );
 
   const memoizedValidationSchema = React.useMemo(
-    () => getNetworkConfigurationValidationSchema(initialValues, hostSubnets),
-    [hostSubnets, initialValues],
+    () =>
+      getNetworkConfigurationValidationSchema(initialValues, hostSubnets, cluster.openshiftVersion),
+    [hostSubnets, initialValues, cluster.openshiftVersion],
   );
 
   React.useEffect(() => {

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/VirtualIPControlGroup.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/VirtualIPControlGroup.tsx
@@ -16,7 +16,6 @@ import {
   NETWORK_TYPE_SDN,
   selectMachineNetworkCIDR,
   getVipValidationsById,
-  DUAL_STACK,
   PopoverIcon,
   selectApiVip,
   selectIngressVip,
@@ -117,7 +116,6 @@ export const VirtualIPControlGroup = ({
     setFieldValue(field, [{ ip: e.target.value, clusterId: cluster.id }], true);
   };
 
-  const ipFieldsSuffix = values.stackType === DUAL_STACK ? ' (IPv4)' : '';
   return (
     <>
       {!isVipDhcpAllocationDisabled && (
@@ -145,7 +143,7 @@ export const VirtualIPControlGroup = ({
           <FormikStaticField
             label={
               <>
-                <span>API IP{ipFieldsSuffix}</span> <PopoverIcon bodyContent={ipPopoverContent} />
+                <span>API IP</span> <PopoverIcon bodyContent={ipPopoverContent} />
               </>
             }
             name="apiVip"
@@ -164,8 +162,7 @@ export const VirtualIPControlGroup = ({
           <FormikStaticField
             label={
               <>
-                <span>Ingress IP{ipFieldsSuffix}</span>{' '}
-                <PopoverIcon bodyContent={ipPopoverContent} />
+                <span>Ingress IP</span> <PopoverIcon bodyContent={ipPopoverContent} />
               </>
             }
             name="ingressVip"
@@ -191,8 +188,7 @@ export const VirtualIPControlGroup = ({
                   <OcmInputField
                     label={
                       <>
-                        <span>API IP{ipFieldsSuffix}</span>{' '}
-                        <PopoverIcon bodyContent={ipPopoverContent} />
+                        <span>API IP</span> <PopoverIcon bodyContent={ipPopoverContent} />
                       </>
                     }
                     name="apiVips.0.ip"
@@ -208,8 +204,7 @@ export const VirtualIPControlGroup = ({
                     name="ingressVips.0.ip"
                     label={
                       <>
-                        <span>Ingress IP{ipFieldsSuffix}</span>{' '}
-                        <PopoverIcon bodyContent={ipPopoverContent} />
+                        <span>Ingress IP</span> <PopoverIcon bodyContent={ipPopoverContent} />
                       </>
                     }
                     helperText={ipHelperText}

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewNetworkingTable.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewNetworkingTable.tsx
@@ -58,7 +58,16 @@ export const ReviewNetworkingTable = ({ cluster }: { cluster: Cluster }) => {
             )),
             props: { 'data-testid': 'machine-networks' },
           },
-          isDualStack(cluster) ? { title: 'Primary' } : { title: '' },
+          isDualStack({ ...cluster, openshiftVersion: cluster.openshiftVersion })
+            ? {
+                title: cluster.machineNetworks?.map((network, index) => (
+                  <span key={network.cidr}>
+                    {index === 0 ? 'Primary' : 'Secondary'}
+                    <br />
+                  </span>
+                )),
+              }
+            : { title: '' },
         ],
       });
 
@@ -106,7 +115,14 @@ export const ReviewNetworkingTable = ({ cluster }: { cluster: Cluster }) => {
             )),
             props: { 'data-testid': 'cluster-network-cidr' },
           },
-          isDualStack(cluster) && { title: 'Primary' },
+          isDualStack({ ...cluster, openshiftVersion: cluster.openshiftVersion }) && {
+            title: cluster.clusterNetworks?.map((network, index) => (
+              <span key={network.cidr}>
+                {index === 0 ? 'Primary' : 'Secondary'}
+                <br />
+              </span>
+            )),
+          },
         ].filter(Boolean),
       },
       {
@@ -122,7 +138,14 @@ export const ReviewNetworkingTable = ({ cluster }: { cluster: Cluster }) => {
             )),
             props: { 'data-testid': 'cluster-network-prefix' },
           },
-          isDualStack(cluster) && { title: 'Primary' },
+          isDualStack({ ...cluster, openshiftVersion: cluster.openshiftVersion }) && {
+            title: cluster.clusterNetworks?.map((network, index) => (
+              <span key={network.hostPrefix}>
+                {index === 0 ? 'Primary' : 'Secondary'}
+                <br />
+              </span>
+            )),
+          },
         ].filter(Boolean),
       },
       {
@@ -138,7 +161,14 @@ export const ReviewNetworkingTable = ({ cluster }: { cluster: Cluster }) => {
             )),
             props: { 'data-testid': 'service-network-cidr' },
           },
-          isDualStack(cluster) && { title: 'Primary' },
+          isDualStack({ ...cluster, openshiftVersion: cluster.openshiftVersion }) && {
+            title: cluster.serviceNetworks?.map((network, index) => (
+              <span key={network.cidr}>
+                {index === 0 ? 'Primary' : 'Secondary'}
+                <br />
+              </span>
+            )),
+          },
         ].filter(Boolean),
       },
       {

--- a/libs/ui-lib/lib/ocm/components/clusterDetail/ClusterProperties.test.ts
+++ b/libs/ui-lib/lib/ocm/components/clusterDetail/ClusterProperties.test.ts
@@ -1,0 +1,215 @@
+import { test, describe, expect } from 'vitest';
+import { getStackTypeLabel } from './ClusterProperties';
+import { Cluster } from '@openshift-assisted/types/assisted-installer-service';
+
+const createCluster = (overrides: Partial<Cluster> = {}): Cluster =>
+  ({
+    id: 'test-cluster',
+    name: 'test-cluster',
+    kind: 'Cluster',
+    href: '/api/assisted-install/v2/clusters/test-cluster',
+    openshiftVersion: '4.11',
+    status: 'ready',
+    statusInfo: 'Cluster is ready',
+    machineNetworks: [],
+    clusterNetworks: [],
+    serviceNetworks: [],
+    ...overrides,
+  } as Cluster);
+
+const createMachineNetwork = (cidr: string) => ({ cidr, clusterId: 'test' });
+const createClusterNetwork = (cidr: string, hostPrefix: number) => ({
+  cidr,
+  hostPrefix,
+  clusterId: 'test',
+});
+const createServiceNetwork = (cidr: string) => ({ cidr, clusterId: 'test' });
+
+describe('getStackTypeLabel', () => {
+  describe('OCP < 4.12 (legacy behavior)', () => {
+    test('returns "Dual-stack" for valid dual stack with IPv4 primary', () => {
+      const cluster = createCluster({
+        openshiftVersion: '4.11',
+        machineNetworks: [
+          createMachineNetwork('192.168.1.0/24'),
+          createMachineNetwork('2001:db8::/64'),
+        ],
+        clusterNetworks: [
+          createClusterNetwork('10.128.0.0/14', 23),
+          createClusterNetwork('fd01::/48', 64),
+        ],
+        serviceNetworks: [
+          createServiceNetwork('172.30.0.0/16'),
+          createServiceNetwork('fd02::/112'),
+        ],
+      });
+
+      expect(getStackTypeLabel(cluster)).toBe('Dual-stack');
+    });
+
+    test('returns "IPv4" for single stack', () => {
+      const cluster = createCluster({
+        openshiftVersion: '4.11',
+        machineNetworks: [createMachineNetwork('192.168.1.0/24')],
+        clusterNetworks: [createClusterNetwork('10.128.0.0/14', 23)],
+        serviceNetworks: [createServiceNetwork('172.30.0.0/16')],
+      });
+
+      expect(getStackTypeLabel(cluster)).toBe('IPv4');
+    });
+
+    test('returns "IPv4" for IPv6 primary (invalid for OCP < 4.12)', () => {
+      const cluster = createCluster({
+        openshiftVersion: '4.11',
+        machineNetworks: [
+          createMachineNetwork('2001:db8::/64'),
+          createMachineNetwork('192.168.1.0/24'),
+        ],
+        clusterNetworks: [
+          createClusterNetwork('fd01::/48', 64),
+          createClusterNetwork('10.128.0.0/14', 23),
+        ],
+        serviceNetworks: [
+          createServiceNetwork('fd02::/112'),
+          createServiceNetwork('172.30.0.0/16'),
+        ],
+      });
+
+      expect(getStackTypeLabel(cluster)).toBe('IPv4');
+    });
+  });
+
+  describe('OCP >= 4.12 (new behavior)', () => {
+    test('returns "Dual-stack" for IPv4 primary and IPv6 secondary', () => {
+      const cluster = createCluster({
+        openshiftVersion: '4.12',
+        machineNetworks: [
+          createMachineNetwork('192.168.1.0/24'),
+          createMachineNetwork('2001:db8::/64'),
+        ],
+        clusterNetworks: [
+          createClusterNetwork('10.128.0.0/14', 23),
+          createClusterNetwork('fd01::/48', 64),
+        ],
+        serviceNetworks: [
+          createServiceNetwork('172.30.0.0/16'),
+          createServiceNetwork('fd02::/112'),
+        ],
+      });
+
+      expect(getStackTypeLabel(cluster)).toBe('Dual-stack');
+    });
+
+    test('returns "Dual-stack" for IPv6 primary and IPv4 secondary', () => {
+      const cluster = createCluster({
+        openshiftVersion: '4.12',
+        machineNetworks: [
+          createMachineNetwork('2001:db8::/64'),
+          createMachineNetwork('192.168.1.0/24'),
+        ],
+        clusterNetworks: [
+          createClusterNetwork('fd01::/48', 64),
+          createClusterNetwork('10.128.0.0/14', 23),
+        ],
+        serviceNetworks: [
+          createServiceNetwork('fd02::/112'),
+          createServiceNetwork('172.30.0.0/16'),
+        ],
+      });
+
+      expect(getStackTypeLabel(cluster)).toBe('Dual-stack');
+    });
+
+    test('returns "IPv4" for IPv6 primary and IPv6 secondary (not dual-stack)', () => {
+      const cluster = createCluster({
+        openshiftVersion: '4.12',
+        machineNetworks: [
+          createMachineNetwork('2001:db8::/64'),
+          createMachineNetwork('2001:db9::/64'),
+        ],
+        clusterNetworks: [
+          createClusterNetwork('fd01::/48', 64),
+          createClusterNetwork('fd02::/48', 64),
+        ],
+        serviceNetworks: [createServiceNetwork('fd03::/112'), createServiceNetwork('fd04::/112')],
+      });
+
+      expect(getStackTypeLabel(cluster)).toBe('IPv4');
+    });
+
+    test('returns "IPv4" for IPv4 primary and IPv4 secondary (not dual-stack)', () => {
+      const cluster = createCluster({
+        openshiftVersion: '4.12',
+        machineNetworks: [
+          createMachineNetwork('192.168.1.0/24'),
+          createMachineNetwork('10.0.0.0/24'),
+        ],
+        clusterNetworks: [
+          createClusterNetwork('10.128.0.0/14', 23),
+          createClusterNetwork('172.16.0.0/14', 23),
+        ],
+        serviceNetworks: [
+          createServiceNetwork('172.30.0.0/16'),
+          createServiceNetwork('172.31.0.0/16'),
+        ],
+      });
+
+      expect(getStackTypeLabel(cluster)).toBe('IPv4');
+    });
+
+    test('returns "IPv4" for single stack', () => {
+      const cluster = createCluster({
+        openshiftVersion: '4.12',
+        machineNetworks: [createMachineNetwork('192.168.1.0/24')],
+        clusterNetworks: [createClusterNetwork('10.128.0.0/14', 23)],
+        serviceNetworks: [createServiceNetwork('172.30.0.0/16')],
+      });
+
+      expect(getStackTypeLabel(cluster)).toBe('IPv4');
+    });
+  });
+
+  describe('edge cases', () => {
+    test('handles undefined openshiftVersion', () => {
+      const cluster = createCluster({
+        openshiftVersion: undefined,
+        machineNetworks: [
+          createMachineNetwork('192.168.1.0/24'),
+          createMachineNetwork('2001:db8::/64'),
+        ],
+        clusterNetworks: [
+          createClusterNetwork('10.128.0.0/14', 23),
+          createClusterNetwork('fd01::/48', 64),
+        ],
+        serviceNetworks: [
+          createServiceNetwork('172.30.0.0/16'),
+          createServiceNetwork('fd02::/112'),
+        ],
+      });
+
+      expect(getStackTypeLabel(cluster)).toBe('Dual-stack');
+    });
+
+    test('handles empty networks', () => {
+      const cluster = createCluster({
+        openshiftVersion: '4.12',
+        machineNetworks: [],
+        clusterNetworks: [],
+        serviceNetworks: [],
+      });
+
+      expect(getStackTypeLabel(cluster)).toBe('IPv4');
+    });
+
+    test('handles undefined networks', () => {
+      const cluster = createCluster({
+        openshiftVersion: '4.12',
+        machineNetworks: undefined,
+        clusterNetworks: undefined,
+        serviceNetworks: undefined,
+      });
+
+      expect(getStackTypeLabel(cluster)).toBe('IPv4');
+    });
+  });
+});

--- a/libs/ui-lib/lib/ocm/components/clusterDetail/ClusterProperties.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterDetail/ClusterProperties.tsx
@@ -41,7 +41,7 @@ export const getManagementType = ({ userManagedNetworking }: Cluster): string =>
 };
 
 export const getStackTypeLabel = (cluster: Cluster): string =>
-  isDualStack(cluster) ? 'Dual-stack' : 'IPv4';
+  isDualStack({ ...cluster, openshiftVersion: cluster.openshiftVersion }) ? 'Dual-stack' : 'IPv4';
 
 export const getDiskEncryptionEnabledOnStatus = (diskEncryption: DiskEncryption['enableOn']) => {
   let diskEncryptionType = null;
@@ -67,7 +67,7 @@ export const getDiskEncryptionEnabledOnStatus = (diskEncryption: DiskEncryption[
 
 const ClusterProperties = ({ cluster, externalMode = false }: ClusterPropertiesProps) => {
   const { t } = useTranslation();
-  const isDualStackType = isDualStack(cluster);
+  const isDualStackType = isDualStack({ ...cluster, openshiftVersion: cluster.openshiftVersion });
   const featureSupportLevelContext = useNewFeatureSupportLevel();
 
   const activeFeatureConfiguration = featureSupportLevelContext.activeFeatureConfiguration;


### PR DESCRIPTION
This PR adds support for IPv6-primary dual-stack clusters, enabling users to create dual-stack clusters where IPv6 is the primary IP stack (version-aware for OpenShift 4.12+).

**assisted-by:** cursor

**Screenshots:**
<img width="924" height="504" alt="image" src="https://github.com/user-attachments/assets/5b0a1453-3fd5-4971-964f-eae8aed2f581" />

<img width="922" height="449" alt="image" src="https://github.com/user-attachments/assets/030f7af1-9f8b-4bbb-8f3b-adf79cbf2d97" />

<img width="963" height="847" alt="image" src="https://github.com/user-attachments/assets/322af44b-3273-4199-b0e6-2a275ca1ae5c" />

<img width="892" height="823" alt="image" src="https://github.com/user-attachments/assets/603630bb-3e87-487f-8464-28569f9cd6e6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dual‑stack behavior is now version‑aware and propagates cluster OpenShift version to relevant controls, allowing IPv6‑primary on 4.12+.

* **Validation**
  * Dual‑stack validation schemas accept an optional OpenShift version and enforce version‑appropriate ordering and messages.

* **UI**
  * Subnet pickers group IPv4/IPv6, include a no‑subnet option, improved auto‑selection, automatic subnet reordering, and simplified VIP/network labels with primary/secondary indicators.

* **Tests**
  * Added comprehensive tests for versioned validation, dual‑stack detection, UI flows, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->