### PR TITLE
MGMT-21858: Missing Border Between Column Headers and Values

### DIFF
--- a/libs/ui-lib/lib/common/components/hosts/AITableMemo.tsx
+++ b/libs/ui-lib/lib/common/components/hosts/AITableMemo.tsx
@@ -73,6 +73,7 @@ export const AITableMemo = React.memo(
                 </Th>
               ))}
             </Tr>
+            <Tr isBorderRow />
           </Thead>
           <Tbody>
             {rows.map((row, i) => (


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-21858

**Before:**

<img width="1415" height="342" alt="image" src="https://github.com/user-attachments/assets/f2c4d232-36ea-4150-85a2-0d4f539eb29c" />

**After:**

<img width="1415" height="342" alt="image" src="https://github.com/user-attachments/assets/7701ade6-0780-42a9-83a2-57c1ffa11ff5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Introduced a subtle border row beneath the Hosts table header to clearly separate column labels from table content.
  * Improves readability and scanability of the header area.
  * No changes to data rendering, sorting, collapsing, or interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->