### PR TITLE
OCPBUGS-72598 | [OVE] Custom manifests are broken in local Assisted UI

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
@@ -160,10 +160,14 @@ const ClusterWizardContextProvider = ({
         isSingleClusterFeatureEnabled,
       );
 
-      // Only move step if there is still none, or the user is at a forbidden step
+      // Only move step if there is still none, or the user is at a forbidden step.
+      // Never force the user off the custom-manifests step when they are actively filling it
+      // (e.g. after pasting content triggers auto-save and uiSettings can update).
       if (
         !currentStepId ||
-        (customManifestsStepNeedsToBeFilled && isStepAfter(currentStepId, requiredStepId))
+        (currentStepId !== 'custom-manifests' &&
+          customManifestsStepNeedsToBeFilled &&
+          isStepAfter(currentStepId, requiredStepId))
       ) {
         setCurrentStepId(requiredStepId);
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined cluster wizard step navigation to prevent forced advancement away from the custom manifests step while it is actively being edited. This improves the user experience when configuring cluster settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->