### PR TITLE
OCPBUGS-74421 | OVE UI: Fix rendezvousIP field name in error message

### DIFF
--- a/libs/locales/lib/en/translation.json
+++ b/libs/locales/lib/en/translation.json
@@ -748,6 +748,7 @@
   "ai:Removing from cluster": "Removing from cluster",
   "ai:Rename hostnames using the custom template:": "Rename hostnames using the custom template:",
   "ai:Rendezvous IP": "Rendezvous IP",
+  "ai:RendezvousIP": "RendezvousIP",
   "ai:Report a bug": "Report a bug",
   "ai:Required field": "Required field",
   "ai:Requirements for Two Node control plane OpenShift": "Requirements for Two Node control plane OpenShift",

--- a/libs/ui-lib/lib/common/config/constants.ts
+++ b/libs/ui-lib/lib/common/config/constants.ts
@@ -72,6 +72,7 @@ export const clusterFieldLabels = (t: TFunction): { [key in string]: string } =>
   machineNetworks: t('ai:Machine networks'),
   clusterNetworks: t('ai:Cluster networks'),
   serviceNetworks: t('ai:Service networks'),
+  rendezvousIp: t('ai:RendezvousIP'),
 });
 
 export const hostValidationGroupLabels = (

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
@@ -160,10 +160,14 @@ const ClusterWizardContextProvider = ({
         isSingleClusterFeatureEnabled,
       );
 
-      // Only move step if there is still none, or the user is at a forbidden step
+      // Only move step if there is still none, or the user is at a forbidden step.
+      // Never force the user off the custom-manifests step when they are actively filling it
+      // (e.g. after pasting content triggers auto-save and uiSettings can update).
       if (
         !currentStepId ||
-        (customManifestsStepNeedsToBeFilled && isStepAfter(currentStepId, requiredStepId))
+        (currentStepId !== 'custom-manifests' &&
+          customManifestsStepNeedsToBeFilled &&
+          isStepAfter(currentStepId, requiredStepId))
       ) {
         setCurrentStepId(requiredStepId);
       }


### PR DESCRIPTION
OVE UI: Fix rendezvousIP field name in error message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RendezvousIP field to cluster configuration labels.

* **Bug Fixes**
  * Fixed cluster wizard to prevent auto-advancing from the custom manifests step while actively filling it out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->