### PR TITLE
[release-4.21] OCPBUGS-81587: upgrade lodash/lodash-es to 4.17.23 (CVE-2025-13465)

### DIFF
--- a/apps/assisted-disconnected-ui/package.json
+++ b/apps/assisted-disconnected-ui/package.json
@@ -14,7 +14,7 @@
     "axios": ">=0.22.0 <2.0.0",
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
-    "lodash": "^4",
+    "lodash": "^4.17.23",
     "monaco-editor": "^0.44.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/apps/assisted-ui/package.json
+++ b/apps/assisted-ui/package.json
@@ -18,7 +18,7 @@
     "axios": ">=0.22.0 <2.0.0",
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
-    "lodash": "^4",
+    "lodash": "^4.17.23",
     "monaco-editor": "^0.44.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/libs/ui-lib/package.json
+++ b/libs/ui-lib/package.json
@@ -24,7 +24,7 @@
     "is-cidr": "^4.0.2",
     "is-in-subnet": "^4",
     "js-yaml": "^4.1.0",
-    "lodash-es": "^4.17.21",
+    "lodash-es": "^4.17.23",
     "parse-url": "^9.2.0",
     "prism-react-renderer": "^1.1.1",
     "react-error-boundary": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   "private": true,
   "resolutions": {
     "@types/react": "17.0.x",
-    "@patternfly/chatbot/@patternfly/react-icons": "6.3.1"
+    "@patternfly/chatbot/@patternfly/react-icons": "6.3.1",
+    "lodash": "^4.17.23",
+    "lodash-es": "^4.17.23"
   },
   "scripts": {
     "_build:lib": "yarn workspace @openshift-assisted/ui-lib build && yarn workspace @openshift-assisted/chatbot build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -612,7 +612,7 @@ __metadata:
     concurrently: ^8.2.2
     i18next: ^20.4.0
     i18next-browser-languagedetector: ^6.1.2
-    lodash: ^4
+    lodash: ^4.17.23
     monaco-editor: ^0.44.0
     nodemon: ^3.0.3
     react: ^18.2.0
@@ -656,7 +656,7 @@ __metadata:
     axios: ">=0.22.0 <2.0.0"
     i18next: ^20.4.0
     i18next-browser-languagedetector: ^6.1.2
-    lodash: ^4
+    lodash: ^4.17.23
     monaco-editor: ^0.44.0
     react: ^18.2.0
     react-dom: ^18.2.0
@@ -819,7 +819,7 @@ __metadata:
     is-cidr: ^4.0.2
     is-in-subnet: ^4
     js-yaml: ^4.1.0
-    lodash-es: ^4.17.21
+    lodash-es: ^4.17.23
     parse-url: ^9.2.0
     prism-react-renderer: ^1.1.1
     react-error-boundary: ^3.1.4
@@ -7040,10 +7040,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash-es@npm:^4.17.14, lodash-es@npm:^4.17.21":
-  version: 4.17.21
-  resolution: "lodash-es@npm:4.17.21"
-  checksum: 05cbffad6e2adbb331a4e16fbd826e7faee403a1a04873b82b42c0f22090f280839f85b95393f487c1303c8a3d2a010048bf06151a6cbe03eee4d388fb0a12d2
+"lodash-es@npm:^4.17.23":
+  version: 4.17.23
+  resolution: "lodash-es@npm:4.17.23"
+  checksum: b1bd1d141bbde8ffc72978e34b364065675806b0ca42ab99477d247fb2ae795faeed81db9283bf18ae1f096c2b6611ec0589e0503fa9724bf82e3dce947bad69
   languageName: node
   linkType: hard
 
@@ -7061,10 +7061,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.21, lodash@npm:^4, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.21":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
+"lodash@npm:^4.17.23":
+  version: 4.17.23
+  resolution: "lodash@npm:4.17.23"
+  checksum: 7daad39758a72872e94651630fbb54ba76868f904211089721a64516ce865506a759d9ad3d8ff22a2a49a50a09db5d27c36f22762d21766e47e3ba918d6d7bab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Upgrades `lodash` from 4.17.21 → 4.17.23 in `apps/assisted-ui` and `apps/assisted-disconnected-ui`
- Upgrades `lodash-es` from 4.17.21 → 4.17.23 in `libs/ui-lib`
- Adds workspace `resolutions` in root `package.json` to enforce the fixed version for all transitive dependencies

## CVE Details

| Field | Value |
|---|---|
| **CVE** | CVE-2025-13465 / [GHSA-xxjr-mmjv-4gpg](https://github.com/lodash/lodash/security/advisories/GHSA-xxjr-mmjv-4gpg) |
| **Severity** | MEDIUM (CVSS v4.0: 6.9) |
| **CWE** | CWE-1321 — Prototype Pollution |
| **Affected** | lodash / lodash-es 4.0.0 – 4.17.22 |
| **Fixed in** | 4.17.23 |
| **Impact** | `_.unset` and `_.omit` allow crafted paths to delete methods from global prototypes |
| **Symbol used in repo** | `omit` from `lodash-es/omit.js` (3 files) |

## Files Changed

- `apps/assisted-disconnected-ui/package.json` — `lodash ^4` → `^4.17.23`
- `apps/assisted-ui/package.json` — `lodash ^4` → `^4.17.23`
- `libs/ui-lib/package.json` — `lodash-es ^4.17.21` → `^4.17.23`
- `package.json` — added `resolutions` for `lodash` and `lodash-es` to `^4.17.23`
- `yarn.lock` — regenerated; all lodash/lodash-es entries now resolve to 4.17.23

## Test plan

- [x] `vitest run` in `libs/ui-lib` — 79 tests passed
- [ ] Full CI pipeline

🤖 Generated with [Claude Code](https://claude.ai/claude-code)