### PR TITLE
MGMT-23747: Upgrade lodash to 4.18.0

### DIFF
--- a/apps/assisted-disconnected-ui/package.json
+++ b/apps/assisted-disconnected-ui/package.json
@@ -14,7 +14,7 @@
     "axios": "^1.15.0",
     "i18next": "^20.4 || ^21",
     "i18next-browser-languagedetector": "^6.1.2",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.1",
     "monaco-editor": "^0.55.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/apps/assisted-ui/package.json
+++ b/apps/assisted-ui/package.json
@@ -14,7 +14,7 @@
     "axios": "^1.15.0",
     "i18next": "^20.4 || ^21",
     "i18next-browser-languagedetector": "^6.1.2",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.1",
     "monaco-editor": "^0.55.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/libs/ui-lib-tests/package.json
+++ b/libs/ui-lib-tests/package.json
@@ -10,7 +10,7 @@
     "cypress": "13.17.0",
     "cypress-file-upload": "5.0.8",
     "cypress-fill-command": "^1.0.2",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.1",
     "start-server-and-test": "^2.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
   },
   "type": "module",
   "resolutions": {
-    "lodash": "^4.17.23",
-    "lodash-es": "^4.17.23",
+    "lodash": "^4.18.1",
+    "lodash-es": "^4.18.1",
     "qs": "^6.14.1",
     "axios": "^1.15.0"
   },

--- a/tools/toolbox/package.json
+++ b/tools/toolbox/package.json
@@ -2,7 +2,7 @@
   "bin": "./build/main.js",
   "dependencies": {
     "chokidar": "^3.5.3",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.1",
     "zx": "^8.8.5"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1486,7 +1486,7 @@ __metadata:
     concurrently: ^9.0.0
     i18next: ^20.4 || ^21
     i18next-browser-languagedetector: ^6.1.2
-    lodash: ^4.17.23
+    lodash: ^4.18.1
     monaco-editor: ^0.55.0
     nodemon: ^3.0.3
     react: ^18.2.0
@@ -1561,7 +1561,7 @@ __metadata:
     axios: ^1.15.0
     i18next: ^20.4 || ^21
     i18next-browser-languagedetector: ^6.1.2
-    lodash: ^4.17.23
+    lodash: ^4.18.1
     monaco-editor: ^0.55.0
     react: ^18.2.0
     react-dom: ^18.2.0
@@ -1643,7 +1643,7 @@ __metadata:
     "@tsconfig/recommended": ^1.0.2
     "@types/node": ^24.0.0
     chokidar: ^3.5.3
-    lodash: ^4.17.23
+    lodash: ^4.18.1
     zx: ^8.8.5
   bin:
     toolbox: ./build/main.js
@@ -1670,7 +1670,7 @@ __metadata:
     cypress: 13.17.0
     cypress-file-upload: 5.0.8
     cypress-fill-command: ^1.0.2
-    lodash: ^4.17.23
+    lodash: ^4.18.1
     start-server-and-test: ^2.0.0
   languageName: unknown
   linkType: soft
@@ -12445,7 +12445,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash-es@npm:^4.17.23":
+"lodash-es@npm:^4.18.1":
   version: 4.18.1
   resolution: "lodash-es@npm:4.18.1"
   checksum: 578993943cfa779e784aeed96766484ec6ab15cd855e52c79631de6371ac49fadd6dd9f4719f8d1223ab2bcb0dfbece484f548191dd34d3dd8b39e1af712a343
@@ -12466,7 +12466,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.23":
+"lodash@npm:^4.18.1":
   version: 4.18.1
   resolution: "lodash@npm:4.18.1"
   checksum: bb5f5b49aad29614e709af02b64c56b0f8b78c6a81434a3c1ae527d2f0f78ca08f9d9fb22aa825a053876c9d2166e9c01f31c356014b5e2bdc0556c057433102


### PR DESCRIPTION
https://redhat.atlassian.net/browse/MGMT-23747
https://redhat.atlassian.net/browse/MGMT-23746

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated lodash and lodash-es to version 4.18.1 across the project — applied in multiple packages and pinned in the root dependency resolutions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->