### PR TITLE
OCPBUGS-83428: bump axios to ^1.15.0 for fixing CVE-2026-40175

### DIFF
--- a/apps/assisted-disconnected-ui/package.json
+++ b/apps/assisted-disconnected-ui/package.json
@@ -11,7 +11,7 @@
     "@patternfly/react-tokens": "6.4.0",
     "@reduxjs/toolkit": "^1.9.1",
     "@sentry/browser": "^7.119",
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "i18next": "^20.4 || ^21",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.23",

--- a/apps/assisted-ui/package.json
+++ b/apps/assisted-ui/package.json
@@ -11,7 +11,7 @@
     "@patternfly/react-tokens": "6.4.0",
     "@reduxjs/toolkit": "^1.9.1",
     "@sentry/browser": "^7.119",
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "i18next": "^20.4 || ^21",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.17.23",

--- a/libs/sdks/package.json
+++ b/libs/sdks/package.json
@@ -17,7 +17,7 @@
     }
   },
   "dependencies": {
-    "axios": "^1.13.5"
+    "axios": "^1.15.0"
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "^2.7.0",

--- a/libs/ui-lib/package.json
+++ b/libs/ui-lib/package.json
@@ -91,7 +91,7 @@
   "peerDependencies": {
     "@reduxjs/toolkit": "^1.9.1",
     "@sentry/browser": "^5.9 || ^6",
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "i18next": "^20.4 || ^21",
     "monaco-editor": "^0.44.0 || ^0.55.0",
     "react": "^18",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   "resolutions": {
     "lodash": "^4.17.23",
     "lodash-es": "^4.17.23",
-    "qs": "^6.14.1"
+    "qs": "^6.14.1",
+    "axios": "^1.15.0"
   },
   "workspaces": [
     "apps/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1475,7 +1475,7 @@ __metadata:
     "@types/react": 18.2.37
     "@types/react-dom": ^18.2.0
     "@vitejs/plugin-react-swc": ^3.0.1
-    axios: ^1.13.5
+    axios: ^1.15.0
     concurrently: ^9.0.0
     i18next: ^20.4 || ^21
     i18next-browser-languagedetector: ^6.1.2
@@ -1551,7 +1551,7 @@ __metadata:
     "@types/react-router": ^5.1.x
     "@types/react-router-dom": 5.3.x
     "@vitejs/plugin-react-swc": ^3.0.1
-    axios: ^1.13.5
+    axios: ^1.15.0
     i18next: ^20.4 || ^21
     i18next-browser-languagedetector: ^6.1.2
     lodash: ^4.17.23
@@ -1624,7 +1624,7 @@ __metadata:
   resolution: "@openshift-assisted/sdks@workspace:libs/sdks"
   dependencies:
     "@openapitools/openapi-generator-cli": ^2.7.0
-    axios: ^1.13.5
+    axios: ^1.15.0
     typescript: ^5.2.2
   languageName: unknown
   linkType: soft
@@ -1719,7 +1719,7 @@ __metadata:
   peerDependencies:
     "@reduxjs/toolkit": ^1.9.1
     "@sentry/browser": ^5.9 || ^6
-    axios: ^1.13.5
+    axios: ^1.15.0
     i18next: ^20.4 || ^21
     monaco-editor: ^0.44.0 || ^0.55.0
     react: ^18
@@ -5597,7 +5597,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.12.2, axios@npm:^1.13.5, axios@npm:^1.14.0, axios@npm:^1.6.1":
+"axios@npm:^1.15.0":
   version: 1.15.0
   resolution: "axios@npm:1.15.0"
   dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the HTTP client library to version 1.15.0 across all application modules, ensuring consistent dependency versions throughout the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->