### PR TITLE
[releases/v2.15-cim] MGMT-23747: Upgrade lodash to 4.18.0

### DIFF
--- a/apps/assisted-disconnected-ui/package.json
+++ b/apps/assisted-disconnected-ui/package.json
@@ -14,7 +14,7 @@
     "axios": "^1.15.0",
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
-    "lodash": "^4",
+    "lodash": "^4.18.1",
     "monaco-editor": "^0.44.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/apps/assisted-ui/package.json
+++ b/apps/assisted-ui/package.json
@@ -14,7 +14,7 @@
     "axios": "^1.15.0",
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
-    "lodash": "^4",
+    "lodash": "^4.18.1",
     "monaco-editor": "^0.44.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/libs/ui-lib-tests/package.json
+++ b/libs/ui-lib-tests/package.json
@@ -10,7 +10,7 @@
     "cypress": "13.6.2",
     "cypress-file-upload": "5.0.8",
     "cypress-fill-command": "^1.0.2",
-    "lodash": "^4.17.15",
+    "lodash": "^4.18.1",
     "start-server-and-test": "^2.0.0"
   },
   "scripts": {

--- a/tools/toolbox/package.json
+++ b/tools/toolbox/package.json
@@ -2,7 +2,7 @@
   "bin": "./build/main.js",
   "dependencies": {
     "chokidar": "^3.5.3",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.1",
     "zx": "^7.2.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -757,7 +757,7 @@ __metadata:
     concurrently: ^8.2.2
     i18next: ^20.4.0
     i18next-browser-languagedetector: ^6.1.2
-    lodash: ^4
+    lodash: ^4.18.1
     monaco-editor: ^0.44.0
     nodemon: ^3.0.3
     react: ^18.2.0
@@ -797,7 +797,7 @@ __metadata:
     axios: ^1.15.0
     i18next: ^20.4.0
     i18next-browser-languagedetector: ^6.1.2
-    lodash: ^4
+    lodash: ^4.18.1
     monaco-editor: ^0.44.0
     react: ^18.2.0
     react-dom: ^18.2.0
@@ -855,7 +855,7 @@ __metadata:
     "@tsconfig/recommended": ^1.0.2
     "@types/node": ^18.14.6
     chokidar: ^3.5.3
-    lodash: ^4.17.21
+    lodash: ^4.18.1
     zx: ^7.2.0
   bin:
     toolbox: ./build/main.js
@@ -882,7 +882,7 @@ __metadata:
     cypress: 13.6.2
     cypress-file-upload: 5.0.8
     cypress-fill-command: ^1.0.2
-    lodash: ^4.17.15
+    lodash: ^4.18.1
     start-server-and-test: ^2.0.0
   languageName: unknown
   linkType: soft
@@ -6757,10 +6757,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.21, lodash@npm:^4, lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.19, lodash@npm:^4.17.21":
+"lodash@npm:4.17.21, lodash@npm:^4.17.14, lodash@npm:^4.17.19, lodash@npm:^4.17.21":
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
+  languageName: node
+  linkType: hard
+
+"lodash@npm:^4.18.1":
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: bb5f5b49aad29614e709af02b64c56b0f8b78c6a81434a3c1ae527d2f0f78ca08f9d9fb22aa825a053876c9d2166e9c01f31c356014b5e2bdc0556c057433102
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/MGMT-23747

