### PR TITLE
[releases/v2.18-cim] MGMT-23747: Upgrade lodash to 4.18.0

### DIFF
--- a/apps/assisted-disconnected-ui/package.json
+++ b/apps/assisted-disconnected-ui/package.json
@@ -14,7 +14,7 @@
     "axios": "^1.15.0",
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.1",
     "monaco-editor": "^0.44.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/apps/assisted-ui/package.json
+++ b/apps/assisted-ui/package.json
@@ -14,7 +14,7 @@
     "axios": "^1.15.0",
     "i18next": "^20.4.0",
     "i18next-browser-languagedetector": "^6.1.2",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.1",
     "monaco-editor": "^0.44.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/libs/ui-lib-tests/package.json
+++ b/libs/ui-lib-tests/package.json
@@ -10,7 +10,7 @@
     "cypress": "13.6.2",
     "cypress-file-upload": "5.0.8",
     "cypress-fill-command": "^1.0.2",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.1",
     "start-server-and-test": "^2.0.0"
   },
   "scripts": {

--- a/tools/toolbox/package.json
+++ b/tools/toolbox/package.json
@@ -2,7 +2,7 @@
   "bin": "./build/main.js",
   "dependencies": {
     "chokidar": "^3.5.3",
-    "lodash": "^4.17.23",
+    "lodash": "^4.18.1",
     "zx": "^8.8.5"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -944,7 +944,7 @@ __metadata:
     concurrently: ^8.2.2
     i18next: ^20.4.0
     i18next-browser-languagedetector: ^6.1.2
-    lodash: ^4.17.23
+    lodash: ^4.18.1
     monaco-editor: ^0.44.0
     nodemon: ^3.0.3
     react: ^18.2.0
@@ -1019,7 +1019,7 @@ __metadata:
     axios: ^1.15.0
     i18next: ^20.4.0
     i18next-browser-languagedetector: ^6.1.2
-    lodash: ^4.17.23
+    lodash: ^4.18.1
     monaco-editor: ^0.44.0
     react: ^18.2.0
     react-dom: ^18.2.0
@@ -1101,7 +1101,7 @@ __metadata:
     "@tsconfig/recommended": ^1.0.2
     "@types/node": ^18.14.6
     chokidar: ^3.5.3
-    lodash: ^4.17.23
+    lodash: ^4.18.1
     zx: ^8.8.5
   bin:
     toolbox: ./build/main.js
@@ -1128,7 +1128,7 @@ __metadata:
     cypress: 13.6.2
     cypress-file-upload: 5.0.8
     cypress-fill-command: ^1.0.2
-    lodash: ^4.17.23
+    lodash: ^4.18.1
     start-server-and-test: ^2.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
https://redhat.atlassian.net/browse/MGMT-23747

