### PR TITLE
NO-ISSUE: Add renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":semanticCommits"],
+  "schedule": ["* 0-2 * * 1"],
+  "rangeStrategy": "bump",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["* 0-2 1 * *"]
+  },
+  "automerge": false,
+  "packageRules": [
+    {
+      "description": "Group all TypeScript type definitions",
+      "matchPackagePrefixes": ["@types/"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "TypeScript type definitions (non-major)"
+    },
+    {
+      "description": "Group TypeScript type definitions major updates separately",
+      "matchPackagePrefixes": ["@types/"],
+      "matchUpdateTypes": ["major"],
+      "groupName": "TypeScript type definitions (major)"
+    },
+    {
+      "description": "Group React and React-related packages",
+      "matchPackagePatterns": ["^react", "^@types/react"],
+      "groupName": "React and React ecosystem"
+    },
+    {
+      "description": "Group all PatternFly packages together",
+      "matchPackagePrefixes": ["@patternfly/"],
+      "groupName": "PatternFly packages"
+    },
+    {
+      "description": "Group all linting/formatting tools",
+      "matchPackageNames": ["eslint", "prettier"],
+      "matchPackagePrefixes": ["eslint-", "@typescript-eslint/"],
+      "groupName": "Linting and formatting tools"
+    },
+    {
+      "description": "Group testing-related packages",
+      "matchPackageNames": ["vitest", "happy-dom", "msw", "cypress"],
+      "matchPackagePrefixes": ["@vitest/", "@cypress/"],
+      "groupName": "Testing packages"
+    },
+    {
+      "description": "Group minor and patch updates for production dependencies",
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "excludePackagePrefixes": ["@patternfly/", "@types/"],
+      "excludePackagePatterns": ["^react"],
+      "groupName": "Production dependencies (non-major)"
+    },
+    {
+      "description": "Group minor and patch updates for dev dependencies",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "excludePackagePrefixes": ["@types/", "eslint-", "@typescript-eslint/", "@vitest/"],
+      "excludePackageNames": ["eslint", "prettier", "vitest", "happy-dom", "msw"],
+      "groupName": "Dev dependencies (non-major)"
+    },
+    {
+      "description": "Group TypeScript compiler updates",
+      "matchPackageNames": ["typescript"],
+      "matchPackagePrefixes": ["@tsconfig/"],
+      "groupName": "TypeScript"
+    }
+  ]
+}


### PR DESCRIPTION
https://docs.renovatebot.com/

With this config, package update PRs (not from Dependabot) should be limited to Mondays and group related packages (e.g. 1 PR for PatternFly instead of 6).

Let's see if this setup works for us before we disable the bot completely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added dependency-management configuration to schedule weekly update runs and lockfile maintenance, with non-automerge and semantic-commit support.
  * Updates will use a range-bump strategy and group packages into labeled batches (type declarations, React/ecosystem, UI libraries, linters/formatters, testing tools, TypeScript, and production vs dev dependencies) for clearer review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->