### PR TITLE
OCPBUGS-84040: Hide internally generated custom manifests on the Cluster Review page

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewSummary.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewSummary.tsx
@@ -19,9 +19,16 @@ import { ReviewCustomManifestsTable } from './ReviewCustomManifestsTable';
 import PlatformIntegrationNote from '../platformIntegration/PlatformIntegrationNote';
 import useClusterCustomManifests from '../../../hooks/useClusterCustomManifests';
 import { Cluster } from '@openshift-assisted/types/assisted-installer-service';
+import { ListManifestsExtended } from '../manifestsConfiguration/data/dataTypes';
+
+const userProvidedManifests = (manifests: ListManifestsExtended | undefined) =>
+  (manifests ?? []).filter((m) => m.manifestSource !== 'system');
 
 export const ReviewSummaryContent = ({ cluster }: { cluster: Cluster }) => {
   const { customManifests } = useClusterCustomManifests(cluster.id, false);
+  const manifestsForReview = userProvidedManifests(customManifests);
+  const showCustomManifests = manifestsForReview.length > 0;
+
   return (
     <>
       <TableSummaryExpandable title={'Cluster details'} id={'cluster-details-expandable'}>
@@ -57,9 +64,9 @@ export const ReviewSummaryContent = ({ cluster }: { cluster: Cluster }) => {
         <ReviewNetworkingTable cluster={cluster} />
       </TableSummaryExpandable>
 
-      {customManifests && customManifests.length > 0 && (
+      {showCustomManifests && (
         <TableSummaryExpandable title={'Custom manifests'} id={'custom-manifests-expandable'}>
-          <ReviewCustomManifestsTable manifests={customManifests} />
+          <ReviewCustomManifestsTable manifests={manifestsForReview} />
         </TableSummaryExpandable>
       )}
     </>

--- a/libs/ui-lib/lib/ocm/hooks/useClusterCustomManifests.ts
+++ b/libs/ui-lib/lib/ocm/hooks/useClusterCustomManifests.ts
@@ -34,12 +34,14 @@ const getManifestsInfo = async (customManifests: ListManifests, clusterId: strin
       );
       const yamlString = await convertBlobToString(yamlContent);
       manifestsExtended.push({
+        ...manifest,
         folder: manifest.folder || 'manifests',
         fileName: manifest.fileName || '',
         yamlContent: yamlString,
       });
     } catch (e) {
       manifestsExtended.push({
+        ...manifest,
         folder: manifest.folder || 'manifests',
         fileName: manifest.fileName || '',
         yamlContent: '',
@@ -65,6 +67,7 @@ const useClusterCustomManifests = (clusterId: Cluster['id'], extendedVersion: bo
           });
         } else {
           const manifestsExtended = data.map((manifest: Manifest) => ({
+            ...manifest,
             folder: manifest.folder || 'manifests',
             fileName: manifest.fileName || '',
             yamlContent: '',

--- a/libs/ui-lib/lib/ocm/hooks/useUISettings.ts
+++ b/libs/ui-lib/lib/ocm/hooks/useUISettings.ts
@@ -31,7 +31,9 @@ const useUISettings = (clusterId?: Cluster['id']) => {
           const { data: customManifests } = await ClustersAPI.getManifests(clusterId);
 
           const mockUISettings: UISettingsValues = {
-            customManifestsAdded: !!customManifests.length,
+            customManifestsAdded: customManifests.some(
+              (manifest) => manifest.manifestSource === 'user',
+            ),
           };
 
           setUISettings(mockUISettings);


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-84040

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Custom manifests section in the cluster review summary now displays only user-provided manifests, filtering out system-generated entries.
  * Section visibility is correctly gated by whether the user has added manifests.
  * Manifest entries now preserve their full metadata and content for accurate display and review.
  * UI settings now correctly detect and reflect presence of user-added manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->