### PR TITLE
OCPBUGS-83610 |  [Below the sea UI]  Ambiguous "Custom Manifest Conflict" warning on OVE review page

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewCustomManifestsTable.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewCustomManifestsTable.tsx
@@ -4,7 +4,13 @@ import { Alert } from '@patternfly/react-core';
 import { ListManifestsExtended } from '../manifestsConfiguration/data/dataTypes';
 import { genericTableRowKey } from '../../../../common';
 
-export const ReviewCustomManifestsTable = ({ manifests }: { manifests: ListManifestsExtended }) => {
+export const ReviewCustomManifestsTable = ({
+  manifests,
+  showWarning,
+}: {
+  manifests: ListManifestsExtended;
+  showWarning: boolean;
+}) => {
   const rows = manifests?.map((manifest) => ({
     rowId:
       manifest.folder && manifest.fileName
@@ -50,6 +56,7 @@ export const ReviewCustomManifestsTable = ({ manifests }: { manifests: ListManif
         title={
           'The custom manifests might contain configurations which are conflicting with the above configurations and might cause installation failure.'
         }
+        hidden={!showWarning}
       />
     </>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewSummary.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewSummary.tsx
@@ -58,9 +58,12 @@ export const ReviewSummaryContent = ({ cluster }: { cluster: Cluster }) => {
         <ReviewNetworkingTable cluster={cluster} />
       </TableSummaryExpandable>
 
-      {userManifests && userManifests.length > 0 && (
+      {customManifests && customManifests.length > 0 && (
         <TableSummaryExpandable title={'Custom manifests'} id={'custom-manifests-expandable'}>
-          <ReviewCustomManifestsTable manifests={userManifests} />
+          <ReviewCustomManifestsTable
+            manifests={customManifests}
+            showWarning={!!userManifests && userManifests.length > 0}
+          />
         </TableSummaryExpandable>
       )}
     </>

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewSummary.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewSummary.tsx
@@ -22,6 +22,7 @@ import { Cluster } from '@openshift-assisted/types/assisted-installer-service';
 
 export const ReviewSummaryContent = ({ cluster }: { cluster: Cluster }) => {
   const { customManifests } = useClusterCustomManifests(cluster.id, false);
+  const userManifests = customManifests?.filter((m) => m.manifestSource === 'user');
   return (
     <>
       <TableSummaryExpandable title={'Cluster details'} id={'cluster-details-expandable'}>
@@ -57,9 +58,9 @@ export const ReviewSummaryContent = ({ cluster }: { cluster: Cluster }) => {
         <ReviewNetworkingTable cluster={cluster} />
       </TableSummaryExpandable>
 
-      {customManifests && customManifests.length > 0 && (
+      {userManifests && userManifests.length > 0 && (
         <TableSummaryExpandable title={'Custom manifests'} id={'custom-manifests-expandable'}>
-          <ReviewCustomManifestsTable manifests={customManifests} />
+          <ReviewCustomManifestsTable manifests={userManifests} />
         </TableSummaryExpandable>
       )}
     </>

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewSummary.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewSummary.tsx
@@ -21,8 +21,9 @@ import useClusterCustomManifests from '../../../hooks/useClusterCustomManifests'
 import { Cluster } from '@openshift-assisted/types/assisted-installer-service';
 import { ListManifestsExtended } from '../manifestsConfiguration/data/dataTypes';
 
-const userProvidedManifests = (manifests: ListManifestsExtended | undefined): ListManifestsExtended =>
-  (manifests ?? []).filter((m) => m.manifestSource !== 'system');
+const userProvidedManifests = (
+  manifests: ListManifestsExtended | undefined,
+): ListManifestsExtended => (manifests ?? []).filter((m) => m.manifestSource !== 'system');
 
 export const ReviewSummaryContent = ({ cluster }: { cluster: Cluster }) => {
   const { customManifests } = useClusterCustomManifests(cluster.id, false);

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewSummary.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewSummary.tsx
@@ -21,7 +21,7 @@ import useClusterCustomManifests from '../../../hooks/useClusterCustomManifests'
 import { Cluster } from '@openshift-assisted/types/assisted-installer-service';
 import { ListManifestsExtended } from '../manifestsConfiguration/data/dataTypes';
 
-const userProvidedManifests = (manifests: ListManifestsExtended | undefined) =>
+const userProvidedManifests = (manifests: ListManifestsExtended | undefined): ListManifestsExtended =>
   (manifests ?? []).filter((m) => m.manifestSource !== 'system');
 
 export const ReviewSummaryContent = ({ cluster }: { cluster: Cluster }) => {
@@ -68,7 +68,7 @@ export const ReviewSummaryContent = ({ cluster }: { cluster: Cluster }) => {
       {showCustomManifests && (
         <TableSummaryExpandable title={'Custom manifests'} id={'custom-manifests-expandable'}>
           <ReviewCustomManifestsTable
-            manifests={customManifests}
+            manifests={manifestsForReview}
             showWarning={!!userManifests && userManifests.length > 0}
           />
         </TableSummaryExpandable>

--- a/libs/ui-lib/lib/ocm/hooks/useClusterCustomManifests.ts
+++ b/libs/ui-lib/lib/ocm/hooks/useClusterCustomManifests.ts
@@ -36,12 +36,14 @@ const getManifestsInfo = async (customManifests: ListManifests, clusterId: strin
       manifestsExtended.push({
         folder: manifest.folder || 'manifests',
         fileName: manifest.fileName || '',
+        manifestSource: manifest.manifestSource,
         yamlContent: yamlString,
       });
     } catch (e) {
       manifestsExtended.push({
         folder: manifest.folder || 'manifests',
         fileName: manifest.fileName || '',
+        manifestSource: manifest.manifestSource,
         yamlContent: '',
       });
     }
@@ -67,6 +69,7 @@ const useClusterCustomManifests = (clusterId: Cluster['id'], extendedVersion: bo
           const manifestsExtended = data.map((manifest: Manifest) => ({
             folder: manifest.folder || 'manifests',
             fileName: manifest.fileName || '',
+            manifestSource: manifest.manifestSource,
             yamlContent: '',
           }));
           setCustomManifests(manifestsExtended);


### PR DESCRIPTION
OCPBUGS-83610 |  [Below the sea UI]  Ambiguous "Custom Manifest Conflict" warning on OVE review page

### Logic of Warning Appearance

| Manifests present | Section visible | Warning shown |
|---|---|---|
| None | No | No |
| System only | Yes | No |
| User only | Yes | Yes |
| System + User | Yes | Yes |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom manifests warnings now display conditionally—shown only when user-created manifests are present in cluster configuration reviews
  * Enhanced tracking of manifest sources for improved visibility and control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->