### PR TITLE
OCPBUGS-84147 | [Below the sea UI] Leaky Abstraction: Transient 500 errors exposed during host binding process

### DIFF
--- a/libs/ui-lib/lib/ocm/hooks/useLateBinding.ts
+++ b/libs/ui-lib/lib/ocm/hooks/useLateBinding.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Cluster } from '@openshift-assisted/types/assisted-installer-service';
 import { CpuArchitecture, useAlerts } from '../../common';
 import useInfraEnvHosts from './useInfraEnvHosts';
@@ -6,10 +6,13 @@ import HostsService from '../services/HostsService';
 import { getErrorMessage } from '../../common/utils';
 import { useFeature } from './use-feature';
 
+const MAX_BIND_RETRY_ATTEMPTS = 3;
+
 const useLateBinding = (cluster: Cluster): boolean => {
   const [isBinding, setIsBinding] = useState(false);
   const { addAlert, removeAlert, alerts } = useAlerts();
   const isSingleClusterFeatureEnabled = useFeature('ASSISTED_INSTALLER_SINGLE_CLUSTER_FEATURE');
+  const bindFailureCounts = useRef<Map<string, number>>(new Map());
 
   const {
     hosts: infraEnvHosts,
@@ -25,27 +28,46 @@ const useLateBinding = (cluster: Cluster): boolean => {
     cluster.openshiftVersion,
   );
 
-  const bindHosts = useCallback(async () => {
-    if (infraEnvHosts && !infraEnvError && !infraEnvLoading && isSingleClusterFeatureEnabled) {
-      for (const host of infraEnvHosts) {
-        if (host.clusterId !== cluster.id) {
-          setIsBinding(true);
-          try {
-            const alertKey = alerts.find((alert) => alert.key === host.id)?.key;
-            if (alertKey) {
-              removeAlert(alertKey);
-            }
-            await HostsService.bind(host, cluster.id);
-          } catch (error) {
-            addAlert({
-              title: `Failed to bind host ${host.requestedHostname || ''}`,
-              message: getErrorMessage(error),
-              key: host.id,
-            });
-          } finally {
-            setIsBinding(false);
-          }
+  const bindSingleHost = useCallback(
+    async (host: NonNullable<typeof infraEnvHosts>[number]) => {
+      setIsBinding(true);
+      try {
+        await HostsService.bind(host, cluster.id);
+        // Binding succeeded: reset the failure counter and clear any alert that
+        // was shown after previous exhausted retries.
+        bindFailureCounts.current.delete(host.id);
+        const alertKey = alerts.find((alert) => alert.key === host.id)?.key;
+        if (alertKey) {
+          removeAlert(alertKey);
         }
+      } catch (error) {
+        const failureCount = (bindFailureCounts.current.get(host.id) ?? 0) + 1;
+        bindFailureCounts.current.set(host.id, failureCount);
+
+        // Suppress transient errors (e.g. 5xx during self-healing) and only
+        // surface the alert once silent retries have been exhausted.
+        if (failureCount >= MAX_BIND_RETRY_ATTEMPTS) {
+          addAlert({
+            title: `Failed to bind host ${host.requestedHostname || ''}`,
+            message: getErrorMessage(error),
+            key: host.id,
+          });
+        }
+      } finally {
+        setIsBinding(false);
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [cluster.id, addAlert, removeAlert],
+  );
+
+  const bindHosts = useCallback(async () => {
+    if (!infraEnvHosts || infraEnvError || infraEnvLoading || !isSingleClusterFeatureEnabled) {
+      return;
+    }
+    for (const host of infraEnvHosts) {
+      if (host.clusterId !== cluster.id) {
+        await bindSingleHost(host);
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -55,8 +77,7 @@ const useLateBinding = (cluster: Cluster): boolean => {
     infraEnvLoading,
     isSingleClusterFeatureEnabled,
     cluster.id,
-    addAlert,
-    removeAlert,
+    bindSingleHost,
   ]);
 
   useEffect(() => {

--- a/libs/ui-lib/lib/ocm/hooks/useLateBinding.ts
+++ b/libs/ui-lib/lib/ocm/hooks/useLateBinding.ts
@@ -13,6 +13,8 @@ const useLateBinding = (cluster: Cluster): boolean => {
   const { addAlert, removeAlert, alerts } = useAlerts();
   const isSingleClusterFeatureEnabled = useFeature('ASSISTED_INSTALLER_SINGLE_CLUSTER_FEATURE');
   const bindFailureCounts = useRef<Map<string, number>>(new Map());
+  const alertsRef = useRef(alerts);
+  alertsRef.current = alerts;
 
   const {
     hosts: infraEnvHosts,
@@ -36,7 +38,7 @@ const useLateBinding = (cluster: Cluster): boolean => {
         // Binding succeeded: reset the failure counter and clear any alert that
         // was shown after previous exhausted retries.
         bindFailureCounts.current.delete(host.id);
-        const alertKey = alerts.find((alert) => alert.key === host.id)?.key;
+        const alertKey = alertsRef.current.find((alert) => alert.key === host.id)?.key;
         if (alertKey) {
           removeAlert(alertKey);
         }
@@ -57,7 +59,6 @@ const useLateBinding = (cluster: Cluster): boolean => {
         setIsBinding(false);
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [cluster.id, addAlert, removeAlert],
   );
 
@@ -70,7 +71,6 @@ const useLateBinding = (cluster: Cluster): boolean => {
         await bindSingleHost(host);
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     infraEnvHosts,
     infraEnvError,


### PR DESCRIPTION
OCPBUGS-84147 | [Below the sea UI] Leaky Abstraction: Transient 500 errors exposed during host binding process


<h2 class="mt-6 [mb-2](https://redhat.atlassian.net/browse/mb-2) font-semibold text-2xl" data-streamdown="heading-2" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin-bottom: 10px; --tw-font-weight: 600; font-weight: 600; color: rgb(171, 178, 191); line-height: 1.25; font-size: 1.3em; margin-top: 20px; font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(35, 39, 46); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">What changed —<span> </span><code class="md-clickable-code md-inline-path-filename-like" role="button" tabindex="0" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.08); color: rgb(74, 165, 240); font-family: &quot;PT Mono&quot;, &quot;Cascadia Code&quot;, &quot;Fira Code&quot;, Consolas, monospace, &quot;Droid Sans Mono&quot;, &quot;monospace&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all; cursor: pointer;"><span class="md-inline-path-filename">useLateBinding.ts</span></code></h2><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(171, 178, 191); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(35, 39, 46); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Added</span><span> </span>a<span> </span><code class="md-inline-variable-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.08); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: &quot;PT Mono&quot;, &quot;Cascadia Code&quot;, &quot;Fira Code&quot;, Consolas, monospace, &quot;Droid Sans Mono&quot;, &quot;monospace&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">bindFailureCounts</code><span> </span>ref — a<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.08); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: &quot;PT Mono&quot;, &quot;Cascadia Code&quot;, &quot;Fira Code&quot;, Consolas, monospace, &quot;Droid Sans Mono&quot;, &quot;monospace&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">Map&lt;hostId, failureCount&gt;</code><span> </span>that tracks consecutive failures per host without triggering re-renders.</p><p style="--tw-space-y-reverse: 0; margin-block: 0px 16px; margin: 6px 0px; word-break: break-word; color: rgb(171, 178, 191); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(35, 39, 46); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><span class="font-semibold" data-streamdown="strong" style="--tw-font-weight: 600; font-weight: 600;">Refactored</span><span> </span>the per-host logic into<span> </span><code class="md-inline-variable-like" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.08); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: &quot;PT Mono&quot;, &quot;Cascadia Code&quot;, &quot;Fira Code&quot;, Consolas, monospace, &quot;Droid Sans Mono&quot;, &quot;monospace&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">bindSingleHost</code><span> </span>(reducing cognitive complexity) with this behavior:</p><div class="ui-scroll-area" data-visibility="hover" data-direction="horizontal" style="--tw-space-y-reverse: 0; margin-block: 0px 16px; --scrollbar-size: 6px; --scrollbar-inset: 0px; --scrollbar-thumb-top-offset: 6px; position: relative; overflow: hidden; display: grid; grid-template: 1fr / 1fr; margin: 1em 0px; border-color: color(srgb 0.8 0.8 0.8 / 0.08); border-style: solid; border-width: 1px; border-image: none 100% / 1 / 0 stretch; border-radius: 6px; color: rgb(171, 178, 191); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(35, 39, 46); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><div class="ui-scroll-area__viewport" style="grid-area: 1 / 1; min-height: 0px; max-height: 100%; border-radius: inherit; overflow: auto hidden; scroll-padding: 0px 4px; overscroll-behavior: contain; scrollbar-width: none;"><div class="ui-scroll-area__content" style="box-sizing: border-box; width: auto; min-width: 100%; max-width: 100%; min-height: 100%; display: flex; flex-direction: row; height: fit-content;">


| Event | Before | After |
|---|---|---|
| Bind fails (attempt 1 or 2) | Error alert shown immediately | Silent — counter incremented, no alert |
| Bind fails (attempt 3+, ≈ 30 s) | Already shown on attempt 1 | Error alert shown — user intervention needed |
| Bind succeeds | Alert cleared | Alert cleared + failure counter reset |
| Bind succeeds after prior failures | Alert removed | Alert removed + failure counter reset |

</div></div></div><p style="margin: 6px 0px 0px; word-break: break-word; color: rgb(171, 178, 191); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(35, 39, 46); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The constant<span> </span><code class="" style="padding: 1.5px 4px; border-radius: 5px; background-color: color(srgb 0.8 0.8 0.8 / 0.08); color: color(srgb 0.8 0.8 0.8 / 0.94); font-family: &quot;PT Mono&quot;, &quot;Cascadia Code&quot;, &quot;Fira Code&quot;, Consolas, monospace, &quot;Droid Sans Mono&quot;, &quot;monospace&quot;, monospace; font-size: 0.9em; line-height: 1.4; word-break: break-all;">MAX_BIND_RETRY_ATTEMPTS = 3</code><span> </span>can be adjusted — with the 10s polling interval that's ~30 seconds of silent retries before the user is notified of a persistent failure.</p>