### PR TITLE
MGMT-24301: Third-Party CNI Support in Assisted Installer - stuck on Networking page in Validating status

### DIFF
--- a/libs/ui-lib/lib/cim/components/ClusterDeployment/wizardTransition.ts
+++ b/libs/ui-lib/lib/cim/components/ClusterDeployment/wizardTransition.ts
@@ -69,7 +69,11 @@ const networkingStepValidationsMap: WizardStepValidationMap = {
   // Alternatively we would have to whitelist network validations instead of using group
   // TODO(mlibra): remove that container-images-available from soft validations and let backend drive it via disabling it.
   //   Depends on: https://issues.redhat.com/browse/MGMT-5265
-  softValidationIds: ['ntp-synced', 'container-images-available'],
+  softValidationIds: [
+    'ntp-synced',
+    'container-images-available',
+    'custom-manifests-requirements-satisfied',
+  ],
   getPageURL: (host: Host, validationID: string) => {
     if (validationID === 'ntp-synced') {
       return {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/MGMT-24301
https://redhat.atlassian.net/browse/MGMT-24694


The validation was missing on our setup so the wizard wasn't blocked. The QE setup has the validation ID, so I'm adding it to the validations map for CIM as well.

<img width="833" height="322" alt="image" src="https://github.com/user-attachments/assets/a18d5b32-79ff-4751-8e05-883670cdead6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cluster deployment wizard validation logic to properly handle custom manifest requirements during the networking configuration step, improving the accuracy of validation checks and wizard progression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->