### PR TITLE
MGMT-23951: Standalone flow: after Install cluster button is pressed, the deployment status page is never opened

### DIFF
--- a/libs/ui-lib/lib/cim/components/ClusterDeployment/review/ClusterDeploymentReviewStep.tsx
+++ b/libs/ui-lib/lib/cim/components/ClusterDeployment/review/ClusterDeploymentReviewStep.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import {
   Alert,
   AlertVariant,
@@ -7,7 +8,7 @@ import {
   useWizardFooter,
   WizardFooter,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import { PlatformType } from '@openshift-assisted/types/assisted-installer-service';
 import { canNextFromReviewStep } from '../wizardTransition';
 import {
   AgentClusterInstallK8sResource,
@@ -42,7 +43,6 @@ import { useTranslation } from '../../../../common/hooks/use-translation-wrapper
 import { ClusterDeploymentWizardContext } from '../ClusterDeploymentWizardContext';
 import { ReviewConfigMapsTable } from './ReviewConfigMapsTable';
 import { ValidationSection } from '../components/ValidationSection';
-import { PlatformType } from '@openshift-assisted/types/assisted-installer-service';
 
 type ClusterDeploymentReviewStepProps = {
   clusterDeployment: ClusterDeploymentK8sResource;
@@ -77,7 +77,8 @@ export const ClusterDeploymentReviewStep = ({
 
   const canContinue = canNextFromReviewStep(agentClusterInstall, clusterAgents);
   const { t } = useTranslation();
-  const onNext = async () => {
+
+  const onNext = React.useCallback(async () => {
     clearAlerts();
     setSubmitting(true);
     try {
@@ -88,18 +89,21 @@ export const ClusterDeploymentReviewStep = ({
     } finally {
       setSubmitting(false);
     }
-  };
+  }, [addAlert, clearAlerts, onFinish, t]);
 
-  const footer = (
-    <WizardFooter
-      activeStep={activeStep}
-      onNext={onNext}
-      isNextDisabled={isSubmitting || !canContinue || !!syncError}
-      nextButtonText={t('ai:Install cluster')}
-      nextButtonProps={{ isLoading: isSubmitting }}
-      onBack={goToPrevStep}
-      onClose={close}
-    />
+  const footer = React.useMemo(
+    () => (
+      <WizardFooter
+        activeStep={activeStep}
+        onNext={onNext}
+        isNextDisabled={isSubmitting || !canContinue || !!syncError}
+        nextButtonText={t('ai:Install cluster')}
+        nextButtonProps={{ isLoading: isSubmitting }}
+        onBack={goToPrevStep}
+        onClose={close}
+      />
+    ),
+    [activeStep, canContinue, close, goToPrevStep, isSubmitting, onNext, syncError, t],
   );
   useWizardFooter(footer);
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/MGMT-23951

The constant re-rendering and re-setting of the footer component likely messed with the navigation when running in OCP Console 4.22 which upgraded to React 18.

**Before:**

https://github.com/user-attachments/assets/e4c217fd-3938-4535-8870-c750fa3e3756

**After:**

https://github.com/user-attachments/assets/043ec153-6d7c-49e0-8a5d-c5ea585b5840






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced performance and reliability of the cluster deployment review process through component optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->