### PR TITLE
OCPBUGS-84038 | [Below the sea UI] Lack of visual feedback (spinner) on disabled "Next" button during background validation

### DIFF
--- a/libs/locales/lib/en/translation.json
+++ b/libs/locales/lib/en/translation.json
@@ -1013,6 +1013,7 @@
   "ai:Vsphere disk uuid enabled": "Vsphere disk uuid enabled",
   "ai:Waiting for host..._one": "Waiting for host...",
   "ai:Waiting for host..._other": "Waiting for hosts...",
+  "ai:Waiting for hosts to be ready...": "Waiting for hosts to be ready...",
   "ai:Waiting for hosts...": "Waiting for hosts...",
   "ai:Warning": "Warning",
   "ai:Web Console URL": "Web Console URL",

--- a/libs/ui-lib/lib/common/components/hosts/HostsTable.tsx
+++ b/libs/ui-lib/lib/common/components/hosts/HostsTable.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Spinner } from '@patternfly/react-core';
 import { ConnectedIcon } from '@patternfly/react-icons/dist/js/icons/connected-icon';
 import { HostsNotShowingLink, HostsNotShowingLinkProps } from '../clusterConfiguration';
 import { Host } from '@openshift-assisted/types/assisted-installer-service';
@@ -29,6 +30,7 @@ export const HostsTableEmptyState = ({
       icon={ConnectedIcon}
       title={t('ai:Waiting for host...', { count: +isSNO })}
       content={t('ai:Hosts may take a few minutes to appear here after booting.')}
+      primaryAction={<Spinner size="xl" />}
       secondaryActions={
         setDiscoveryHintModalOpen && [
           <HostsNotShowingLink

--- a/libs/ui-lib/lib/common/components/ui/WizardFooter.tsx
+++ b/libs/ui-lib/lib/common/components/ui/WizardFooter.tsx
@@ -27,6 +27,7 @@ export type WizardFooterGenericProps = {
   submittingText?: string;
   nextButtonText?: string;
   isNextButtonLoading?: boolean;
+  isWaitingForHosts?: boolean;
 };
 
 type WizardFooterProps = WizardFooterGenericProps & {
@@ -53,6 +54,7 @@ export const WizardFooter: React.FC<WizardFooterProps> = ({
   cluster,
   onFetchEvents,
   isNextButtonLoading,
+  isWaitingForHosts,
 }) => {
   const { t } = useTranslation();
   submittingText = submittingText || t('ai:Saving changes...');
@@ -116,6 +118,14 @@ export const WizardFooter: React.FC<WizardFooterProps> = ({
             <ActionListItem>
               <Content component={ContentVariants.small}>
                 <Spinner size="sm" data-testid="wizard-footer-spinner" /> {submittingText}
+              </Content>
+            </ActionListItem>
+          )}
+          {isWaitingForHosts && !isSubmitting && (
+            <ActionListItem>
+              <Content component={ContentVariants.small}>
+                <Spinner size="sm" data-testid="wizard-footer-hosts-spinner" />{' '}
+                {t('ai:Waiting for hosts to be ready...')}
               </Content>
             </ActionListItem>
           )}

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
@@ -113,18 +113,16 @@ const NetworkConfigurationForm: React.FC<{
     clusterWizardContext.moveNext();
   }, [addAlert, cluster.id, clusterWizardContext, dispatch, isSingleClusterFeatureEnabled]);
 
+  const isNextDisabled =
+    isSubmitting || isAutoSaveRunning || !!alerts.length || !isValid || !canNextNetwork({ cluster });
+
   const footer = (
     <ClusterWizardFooter
       cluster={cluster}
       errorFields={errorFields}
       isSubmitting={isSubmitting}
-      isNextDisabled={
-        isSubmitting ||
-        isAutoSaveRunning ||
-        !!alerts.length ||
-        !isValid ||
-        !canNextNetwork({ cluster })
-      }
+      isNextDisabled={isNextDisabled}
+      isWaitingForHosts={!canNextNetwork({ cluster })}
       onNext={() => void onNext()}
       onBack={() => clusterWizardContext.moveBack()}
       isBackDisabled={isSubmitting || isAutoSaveRunning}

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
@@ -114,7 +114,11 @@ const NetworkConfigurationForm: React.FC<{
   }, [addAlert, cluster.id, clusterWizardContext, dispatch, isSingleClusterFeatureEnabled]);
 
   const isNextDisabled =
-    isSubmitting || isAutoSaveRunning || !!alerts.length || !isValid || !canNextNetwork({ cluster });
+    isSubmitting ||
+    isAutoSaveRunning ||
+    !!alerts.length ||
+    !isValid ||
+    !canNextNetwork({ cluster });
 
   const footer = (
     <ClusterWizardFooter

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/HostDiscovery.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/HostDiscovery.tsx
@@ -32,6 +32,7 @@ const HostDiscoveryForm = ({ cluster }: { cluster: Cluster }) => {
   const errorFields = getFormikErrorFields(errors, touched);
   const isBinding = useLateBinding(cluster);
 
+  const hasHosts = (cluster.hosts?.length ?? 0) > 0;
   const isNextDisabled =
     !isValid ||
     !!alerts.length ||
@@ -40,12 +41,15 @@ const HostDiscoveryForm = ({ cluster }: { cluster: Cluster }) => {
     isBinding ||
     !canNextHostDiscovery({ cluster });
 
+  const isWaitingForHosts = hasHosts && (isBinding || !canNextHostDiscovery({ cluster }));
+
   const footer = (
     <ClusterWizardFooter
       cluster={cluster}
       errorFields={errorFields}
       isSubmitting={isSubmitting}
       isNextDisabled={isNextDisabled}
+      isWaitingForHosts={isWaitingForHosts}
       onNext={() => clusterWizardContext.moveNext()}
       onBack={() => clusterWizardContext.moveBack()}
       isBackDisabled={isSubmitting || isAutoSaveRunning}

--- a/libs/ui-lib/lib/ocm/components/hosts/HostsTableEmptyState.tsx
+++ b/libs/ui-lib/lib/ocm/components/hosts/HostsTableEmptyState.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Spinner } from '@patternfly/react-core';
 import { ConnectedIcon } from '@patternfly/react-icons/dist/js/icons/connected-icon';
 import EmptyState from '../../../common/components/ui/uiState/EmptyState';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
@@ -16,6 +17,7 @@ const HostsTableEmptyState = ({ isSingleNode = false }: HostsTableEmptyStateProp
       icon={ConnectedIcon}
       title={t('ai:Waiting for host...', { count: isSingleNode ? 1 : 2 })}
       content={t('ai:Hosts may take a few minutes to appear here after booting.')}
+      primaryAction={<Spinner size="xl" />}
       secondaryActions={[
         <HostsDiscoveryTroubleshootingInfoLinkWithModal key={'hosts-not-showing'} />,
       ]}


### PR DESCRIPTION
OCPBUGS-84038 | [Below the sea UI] Lack of visual feedback (spinner) on disabled "Next" button during background validation

## Hosts is shown but Waiting for Ready status

<img width="1538" height="116" alt="Screenshot From 2026-05-06 12-28-39" src="https://github.com/user-attachments/assets/5298b75e-7f3b-4be5-9afb-46766794afbc" />

## Hosts didn't show up yet

<img width="1524" height="455" alt="Screenshot From 2026-05-06 12-28-35" src="https://github.com/user-attachments/assets/37748aa5-b236-4437-9483-e4870bfe14b7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented visual loading indicators when waiting for cluster hosts to be discovered and ready.
  * Added status messages in the wizard steps to communicate host initialization status.
  * Enhanced navigation controls to prevent advancing until hosts are properly initialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->