### PR TITLE
OCPBUGS-85230: Ensure follow-redirects pkg resolves to ^1.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "lodash": "^4.17.23",
     "lodash-es": "^4.17.23",
     "qs": "^6.14.1",
-    "axios": "^1.15.1"
+    "axios": "^1.15.1",
+    "follow-redirects": "^1.16.0"
   },
   "workspaces": [
     "apps/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9371,16 +9371,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0":
-  version: 1.15.11
-  resolution: "follow-redirects@npm:1.15.11"
-  peerDependenciesMeta:
-    debug:
-      optional: true
-  checksum: 20bf55e9504f59e6cc3743ba27edb2ebf41edea1baab34799408f2c050f73f0c612728db21c691276296d2795ea8a812dc532a98e8793619fcab91abe06d017f
-  languageName: node
-  linkType: hard
-
 "follow-redirects@npm:^1.16.0":
   version: 1.16.0
   resolution: "follow-redirects@npm:1.16.0"


### PR DESCRIPTION
Remediating CVE-2026-40895
```
yarn why follow-redirects
├─ axios@npm:1.16.0
│  └─ follow-redirects@npm:1.16.0 [77f99] (via npm:^1.16.0 [77f99])
│
└─ http-proxy@npm:1.18.1
   └─ follow-redirects@npm:1.16.0 [77f99] (via npm:^1.16.0 [77f99])

```