### PR TITLE
MGMT-24321: TNA cluster creation: use existing hosts (latebinding flow) that were added to infraenv by uploading BMH yaml - no possibility to choose Arbiter

### DIFF
--- a/libs/ui-lib/lib/cim/components/ClusterDeployment/ClusterDeploymentWizard.tsx
+++ b/libs/ui-lib/lib/cim/components/ClusterDeployment/ClusterDeploymentWizard.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
 import { Grid, GridItem, Wizard, WizardStep } from '@patternfly/react-core';
-import { AlertsContextProvider, LoadingState } from '../../../common';
+import { AlertsContextProvider, ErrorState, LoadingState } from '../../../common';
 import { ClusterDeploymentWizardProps } from './types';
 import { ACMFeatureSupportLevelProvider } from '../featureSupportLevels';
 import { YamlPreview, useYamlPreview } from '../YamlPreview';
@@ -14,6 +14,7 @@ import { ClusterDeploymentHostsDiscoveryStep } from './hostDiscovery';
 import { ClusterDeploymentNetworkingStep } from './networking';
 import { ClusterDeploymentReviewStep } from './review';
 import { ClusterDeploymentCustomManifestsStep } from './customManifests';
+import { useAgents } from '../../hooks';
 
 export const ClusterDeploymentWizard = ({
   className,
@@ -27,7 +28,6 @@ export const ClusterDeploymentWizard = ({
   fetchSecret,
   clusterDeployment,
   agentClusterInstall,
-  agents,
   bareMetalHosts,
   clusterImages,
   aiConfigMap,
@@ -54,11 +54,19 @@ export const ClusterDeploymentWizard = ({
     fetchKlusterletAddonConfig,
   });
 
+  const [agents, loaded, error] = useAgents({ isList: true });
+
   // if initialStep is set, it is either 'host-selection' or 'host-discovery', both at index 4
   // if initialStep is not set, start at 'cluster-details' which is at index 2
   const startIndex = initialStep ? 4 : 2;
   const stepNames = wizardStepNames(t);
   const isAIFlow = !!infraEnv;
+
+  if (!loaded) {
+    return <LoadingState />;
+  } else if (error) {
+    return <ErrorState />;
+  }
 
   return (
     <Grid style={{ height: '100%' }}>

--- a/libs/ui-lib/lib/cim/components/ClusterDeployment/types.ts
+++ b/libs/ui-lib/lib/cim/components/ClusterDeployment/types.ts
@@ -141,7 +141,6 @@ export type ClusterDeploymentWizardProps = {
 
   clusterDeployment: ClusterDeploymentK8sResource;
   agentClusterInstall: AgentClusterInstallK8sResource;
-  agents: AgentK8sResource[];
   bareMetalHosts: BareMetalHostK8sResource[];
   aiConfigMap?: ConfigMapK8sResource;
   infraEnv?: InfraEnvK8sResource;

--- a/libs/ui-lib/lib/cim/hooks/index.tsx
+++ b/libs/ui-lib/lib/cim/hooks/index.tsx
@@ -1,3 +1,4 @@
 export * from './useConfigMaps';
 export * from './useAgentServiceConfig';
 export * from './useEvents';
+export * from './useAgents';

--- a/libs/ui-lib/lib/cim/hooks/useAgents.tsx
+++ b/libs/ui-lib/lib/cim/hooks/useAgents.tsx
@@ -1,0 +1,15 @@
+import { useK8sWatchResource } from './useK8sWatchResource';
+import { AgentK8sResource } from '../types';
+import { K8sWatchHookProps } from './types';
+
+export const useAgents = (props: K8sWatchHookProps) =>
+  useK8sWatchResource<AgentK8sResource[]>(
+    {
+      groupVersionKind: {
+        group: 'agent-install.openshift.io',
+        kind: 'Agent',
+        version: 'v1beta1',
+      },
+    },
+    props,
+  );


### PR DESCRIPTION
https://redhat.atlassian.net/browse/MGMT-24321

Reproduction of this bug is flaky at best, but to my best understanding, `recoil` (which ACM Console uses to poll data) is not _perfectly_ compatible with React 18 (used by OCP Console 4.22+) and because of that, the `agent` array doesn't get updated in the UI even though the actual data changes after we make a request.

Fetching the agent data directly avoids this issue.

**Before:**

https://github.com/user-attachments/assets/bb42177d-76b5-4243-bf83-4f86fb4eb9c2


**After:**

https://github.com/user-attachments/assets/1055bc10-74e7-46d4-b745-4bd562ed14f0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cluster Deployment Wizard now displays loading and error states during agent data retrieval.

* **Refactor**
  * Improved internal architecture by introducing a dedicated hook for managing agent data, enhancing code organization and reusability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openshift-assisted/assisted-installer-ui/pull/3711)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->