### PR TITLE
[release-4.21] OCPBUGS-86063: Allow to install SNO topology

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterDetailsForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterDetailsForm.tsx
@@ -125,8 +125,18 @@ const ClusterDetailsForm = (props: ClusterDetailsFormProps) => {
         ocpVersions,
         urlSearchParams: search,
         addCustomManifests: customManifestsStep,
+        isSingleClusterFeatureEnabled,
       }),
-    [infraEnv, cluster, pullSecret, managedDomains, ocpVersions, search, customManifestsStep],
+    [
+      infraEnv,
+      cluster,
+      pullSecret,
+      managedDomains,
+      ocpVersions,
+      search,
+      customManifestsStep,
+      isSingleClusterFeatureEnabled,
+    ],
   );
 
   const { t } = useTranslation();

--- a/libs/ui-lib/lib/ocm/services/ClusterDetailsService.ts
+++ b/libs/ui-lib/lib/ocm/services/ClusterDetailsService.ts
@@ -128,6 +128,7 @@ const ClusterDetailsService = {
     infraEnv,
     urlSearchParams,
     addCustomManifests,
+    isSingleClusterFeatureEnabled,
     ...args
   }: {
     cluster?: Cluster;
@@ -137,6 +138,7 @@ const ClusterDetailsService = {
     ocpVersions: OpenshiftVersionOptionType[];
     urlSearchParams: string;
     addCustomManifests?: boolean;
+    isSingleClusterFeatureEnabled?: boolean;
   }): OcmClusterDetailsValues {
     const values = getClusterDetailsInitialValues({
       cluster,
@@ -151,8 +153,12 @@ const ClusterDetailsService = {
       ? HostsNetworkConfigurationType.STATIC
       : HostsNetworkConfigurationType.DHCP;
 
+    const platform =
+      isSingleClusterFeatureEnabled && !cluster ? ('none' as PlatformType) : values.platform;
+
     return {
       ...values,
+      platform,
       cpuArchitecture,
       hostsNetworkConfigurationType,
       addCustomManifest: !!addCustomManifests,


### PR DESCRIPTION
## Summary

Cherry-pick of #3578 onto `release-4.21`.

When `ASSISTED_INSTALLER_SINGLE_CLUSTER_FEATURE` is enabled and no cluster exists yet, cluster details initial values use `platform: 'none'` so SNO topology can be installed in local ABI.

Merge conflicts with `release-4.21` were resolved by keeping both:
- `addCustomManifests` / custom manifests wizard wiring (release-4.21 only)
- `isSingleClusterFeatureEnabled` SNO platform default (from #3578)

## Test plan

- [ ] Create a new cluster with `ASSISTED_INSTALLER_SINGLE_CLUSTER_FEATURE` enabled and verify control plane count defaults to SNO (`platform: 'none'`)
- [ ] Verify custom manifests wizard step still initializes `addCustomManifest` correctly when enabled
- [ ] Regression: create cluster without single-cluster feature — platform defaults unchanged


Made with [Cursor](https://cursor.com)