### PR TITLE
MGMT-24304: On disconnected environment no Openshift version is set by default on standalone cluster details page and no version is shown in the dropdown till Show all available are shown

### DIFF
--- a/libs/ui-lib/lib/cim/components/ClusterDeployment/clusterDetails/ACMClusterDeploymentDetailsStep.tsx
+++ b/libs/ui-lib/lib/cim/components/ClusterDeployment/clusterDetails/ACMClusterDeploymentDetailsStep.tsx
@@ -4,7 +4,7 @@ import { Stack } from '@patternfly/react-core';
 import noop from 'lodash-es/noop.js';
 import { ClusterDetailsValues, getRichTextValidation } from '../../../../common';
 import { ClusterImageSetK8sResource } from '../../../types/k8s/cluster-image-set';
-import { useDetailsFormik } from './ClusterDeploymentDetailsStep';
+import { useDetailsFormik } from './useDetailsFormik';
 import { ClusterDetailsFormFieldsProps } from './ClusterDetailsFormFields';
 import { OsImage } from '../../../types';
 import { getOCPVersions } from '../../helpers';
@@ -58,9 +58,11 @@ export const ACMClusterDeploymentDetailsStep: React.FC<ACMClusterDeploymentDetai
   ...rest
 }) => {
   const ocpVersions = getOCPVersions(clusterImages, !!isNutanix, osImages);
+  const allOcpVersions = getOCPVersions(clusterImages, !!isNutanix, osImages, true);
 
   const [initialValues, validationSchema] = useDetailsFormik({
     ocpVersions,
+    allOcpVersions,
     usedClusterNames,
   });
 

--- a/libs/ui-lib/lib/cim/components/ClusterDeployment/clusterDetails/ClusterDeploymentDetailsStep.tsx
+++ b/libs/ui-lib/lib/cim/components/ClusterDeployment/clusterDetails/ClusterDeploymentDetailsStep.tsx
@@ -1,101 +1,18 @@
 import React from 'react';
 import { Formik } from 'formik';
-import { Lazy } from 'yup';
 import { Grid, GridItem, useWizardContext } from '@patternfly/react-core';
 
-import {
-  useAlerts,
-  getClusterDetailsInitialValues,
-  getClusterDetailsValidationSchema,
-  ClusterWizardStepHeader,
-  ClusterDetailsValues,
-  getRichTextValidation,
-  OpenshiftVersionOptionType,
-} from '../../../../common';
+import { useAlerts, ClusterWizardStepHeader, getRichTextValidation } from '../../../../common';
 
 import { ClusterDeploymentDetailsStepProps, ClusterDeploymentDetailsValues } from '../types';
-import { getAICluster, getNetworkType, getOCPVersions } from '../../helpers';
-import {
-  AgentClusterInstallK8sResource,
-  AgentK8sResource,
-  ClusterDeploymentK8sResource,
-  InfraEnvK8sResource,
-} from '../../../types';
+import { getOCPVersions } from '../../helpers';
 import {
   ClusterDeploymentDetailsForm,
   ClusterDeploymentDetailsFormWrapper,
 } from './ClusterDeploymentDetailsForm';
 import { getGridSpans } from '../helpers';
 import { useTranslation } from '../../../../common/hooks/use-translation-wrapper';
-
-type UseDetailsFormikArgs = {
-  usedClusterNames: string[];
-  ocpVersions: OpenshiftVersionOptionType[];
-  clusterDeployment?: ClusterDeploymentK8sResource;
-  agentClusterInstall?: AgentClusterInstallK8sResource;
-  agents?: AgentK8sResource[];
-  infraEnv?: InfraEnvK8sResource;
-};
-
-export const useDetailsFormik = ({
-  clusterDeployment,
-  agentClusterInstall,
-  agents,
-  usedClusterNames,
-  infraEnv,
-  ocpVersions,
-}: UseDetailsFormikArgs): [
-  ClusterDetailsValues & { networkType: 'OpenShiftSDN' | 'OVNKubernetes' },
-  Lazy<{ baseDnsDomain: string }>,
-] => {
-  const { t } = useTranslation();
-  const isEdit = !!clusterDeployment || !!agentClusterInstall;
-
-  const cluster = React.useMemo(
-    () =>
-      clusterDeployment && agentClusterInstall
-        ? getAICluster({
-            clusterDeployment,
-            agentClusterInstall,
-            agents,
-            infraEnv,
-          })
-        : undefined,
-    [agentClusterInstall, clusterDeployment, agents, infraEnv],
-  );
-
-  const initialValues = React.useMemo(
-    () => {
-      const initValues = getClusterDetailsInitialValues({
-        managedDomains: [], // not supported
-        cluster,
-        ocpVersions,
-      });
-
-      const ocpVersion = ocpVersions.find(
-        (ocpVersion) => ocpVersion.value === initValues.openshiftVersion,
-      );
-      return {
-        ...initValues,
-        networkType: getNetworkType(ocpVersion),
-      };
-    },
-    [], // eslint-disable-line react-hooks/exhaustive-deps
-  );
-
-  const validationSchema = React.useMemo(
-    () =>
-      getClusterDetailsValidationSchema({
-        usedClusterNames,
-        pullSecretSet: isEdit,
-        validateUniqueName: true,
-        t,
-      }),
-    [usedClusterNames, isEdit, t],
-  );
-
-  return [initialValues, validationSchema];
-};
+import { useDetailsFormik } from './useDetailsFormik';
 
 export const ClusterDeploymentDetailsStep: React.FC<ClusterDeploymentDetailsStepProps> = ({
   clusterImages,
@@ -113,11 +30,13 @@ export const ClusterDeploymentDetailsStep: React.FC<ClusterDeploymentDetailsStep
   const { goToNextStep } = useWizardContext();
 
   const ocpVersions = getOCPVersions(clusterImages, isNutanix);
+  const allOcpVersions = getOCPVersions(clusterImages, isNutanix, undefined, true);
   const gridSpans = getGridSpans(isPreviewOpen);
 
   const [initialValues, validationSchema] = useDetailsFormik({
     clusterDeployment,
     ocpVersions,
+    allOcpVersions,
     agentClusterInstall,
     agents,
     usedClusterNames,

--- a/libs/ui-lib/lib/cim/components/ClusterDeployment/clusterDetails/ClusterDetailsFormFields.tsx
+++ b/libs/ui-lib/lib/cim/components/ClusterDeployment/clusterDetails/ClusterDetailsFormFields.tsx
@@ -17,7 +17,6 @@ import { ClusterDetailsValues } from '../../../../common/components/clusterWizar
 import { useTranslation } from '../../../../common/hooks/use-translation-wrapper';
 import CpuArchitectureDropdown from '../../common/CpuArchitectureDropdown';
 import ControlPlaneNodesDropdown from '../../../../common/components/clusterConfiguration/ControlPlaneNodesDropdown';
-import { getNetworkType } from '../../helpers';
 
 export type ClusterDetailsFormFieldsProps = {
   isEditFlow: boolean;
@@ -59,18 +58,8 @@ export const ClusterDetailsFormFields: React.FC<ClusterDetailsFormFieldsProps> =
   const { t } = useTranslation();
   const nameInputRef = React.useRef<HTMLInputElement>();
   const [openshiftVersionModalOpen, setOpenshiftVersionModalOpen] = React.useState(false);
-  const { values, setFieldValue } = useFormikContext<ClusterDetailsValues>();
+  const { values } = useFormikContext<ClusterDetailsValues>();
   const { name, baseDnsDomain } = values;
-
-  React.useEffect(() => {
-    if (!versions.length && !values.openshiftVersion && !isEditFlow) {
-      const fallbackOpenShiftVersion = allVersions.find((version) => version.default);
-      setFieldValue('customOpenshiftSelect', fallbackOpenShiftVersion?.value);
-      setFieldValue('openshiftVersion', fallbackOpenShiftVersion?.value);
-      setFieldValue('networkType', getNetworkType(fallbackOpenShiftVersion));
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   React.useEffect(() => {
     nameInputRef.current?.focus();

--- a/libs/ui-lib/lib/cim/components/ClusterDeployment/clusterDetails/useDetailsFormik.tsx
+++ b/libs/ui-lib/lib/cim/components/ClusterDeployment/clusterDetails/useDetailsFormik.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { Lazy } from 'yup';
+import {
+  ClusterDetailsValues,
+  getClusterDetailsInitialValues,
+  getClusterDetailsValidationSchema,
+  OpenshiftVersionOptionType,
+  useTranslation,
+} from '../../../../common';
+import {
+  AgentClusterInstallK8sResource,
+  AgentK8sResource,
+  ClusterDeploymentK8sResource,
+  InfraEnvK8sResource,
+} from '../../../types';
+import { getAICluster, getNetworkType } from '../../helpers';
+
+type UseDetailsFormikArgs = {
+  usedClusterNames: string[];
+  ocpVersions: OpenshiftVersionOptionType[];
+  allOcpVersions: OpenshiftVersionOptionType[];
+  clusterDeployment?: ClusterDeploymentK8sResource;
+  agentClusterInstall?: AgentClusterInstallK8sResource;
+  agents?: AgentK8sResource[];
+  infraEnv?: InfraEnvK8sResource;
+};
+
+export const useDetailsFormik = ({
+  clusterDeployment,
+  agentClusterInstall,
+  agents,
+  usedClusterNames,
+  infraEnv,
+  ocpVersions,
+  allOcpVersions,
+}: UseDetailsFormikArgs): [
+  ClusterDetailsValues & { networkType: 'OpenShiftSDN' | 'OVNKubernetes' },
+  Lazy<{ baseDnsDomain: string }>,
+] => {
+  const { t } = useTranslation();
+  const isEdit = !!clusterDeployment || !!agentClusterInstall;
+
+  const cluster = React.useMemo(
+    () =>
+      clusterDeployment && agentClusterInstall
+        ? getAICluster({
+            clusterDeployment,
+            agentClusterInstall,
+            agents,
+            infraEnv,
+          })
+        : undefined,
+    [agentClusterInstall, clusterDeployment, agents, infraEnv],
+  );
+
+  const initialValues = React.useMemo(
+    () => {
+      let initValues = getClusterDetailsInitialValues({
+        managedDomains: [], // not supported
+        cluster,
+        ocpVersions,
+      });
+
+      let ocpVersion = ocpVersions.find(
+        (ocpVersion) => ocpVersion.value === initValues.openshiftVersion,
+      );
+
+      if (!ocpVersion) {
+        ocpVersion = allOcpVersions.find((version) => version.default);
+        initValues = {
+          ...initValues,
+          openshiftVersion: ocpVersion?.value || '',
+          customOpenshiftSelect: ocpVersion?.value || '',
+        };
+      }
+
+      return {
+        ...initValues,
+        networkType: getNetworkType(ocpVersion),
+      };
+    },
+    [], // eslint-disable-line react-hooks/exhaustive-deps
+  );
+
+  const validationSchema = React.useMemo(
+    () =>
+      getClusterDetailsValidationSchema({
+        usedClusterNames,
+        pullSecretSet: isEdit,
+        validateUniqueName: true,
+        t,
+      }),
+    [usedClusterNames, isEdit, t],
+  );
+
+  return [initialValues, validationSchema];
+};

--- a/libs/ui-lib/lib/cim/components/common/CpuArchitectureDropdown.tsx
+++ b/libs/ui-lib/lib/cim/components/common/CpuArchitectureDropdown.tsx
@@ -86,7 +86,7 @@ const CpuArchitectureDropdown = ({
             id={fieldId}
             ref={toggleRef}
             onClick={() => setCpuArchOpen(!cpuArchOpen)}
-            className="pf-v6-u-w-100"
+            isFullWidth
           >
             {value ? architectureData[value].label : t('ai:CPU architecture')}
           </MenuToggle>
@@ -94,6 +94,7 @@ const CpuArchitectureDropdown = ({
         isOpen={cpuArchOpen}
         onSelect={onCpuArchSelect}
         onOpenChange={() => setCpuArchOpen(!cpuArchOpen)}
+        shouldFocusToggleOnSelect
       >
         {dropdownItems}
       </Dropdown>

--- a/libs/ui-lib/lib/common/components/clusterConfiguration/ExternalPlatformsDropdown.tsx
+++ b/libs/ui-lib/lib/common/components/clusterConfiguration/ExternalPlatformsDropdown.tsx
@@ -75,11 +75,13 @@ export const ExternalPlatformsDropdown = ({ isDisabled }: { isDisabled: boolean 
       <Dropdown
         isOpen={isOpen}
         toggle={(toggleRef) => (
-          <MenuToggle ref={toggleRef} className="pf-v5-u-w-100" onClick={() => setIsOpen(!isOpen)}>
+          <MenuToggle ref={toggleRef} onClick={() => setIsOpen(!isOpen)} isFullWidth>
             {value ? platforms[value] : t('ai:Integrate with external partner platforms')}
           </MenuToggle>
         )}
         onSelect={onSelect}
+        onOpenChange={() => setIsOpen(!isOpen)}
+        shouldFocusToggleOnSelect
       >
         {options}
       </Dropdown>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/MGMT-24304

With OCP Console 4.22 the `customOpenshiftSelect` fallback wasn't getting set (likely to React 18 concurrency changes).

Needs:  https://github.com/stolostron/console/pull/6242

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dropdown components to use full-width styling for improved consistency and better UI presentation.

* **Improvements**
  * Enhanced focus behavior in dropdown menus when selecting items for improved keyboard navigation experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openshift-assisted/assisted-installer-ui/pull/3723?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->