### PR TITLE
AGENT-1519 | [Below-the-sea UI] Allow the user to select IPv6 in the Networking Stack Type field

### DIFF
--- a/libs/locales/lib/en/translation.json
+++ b/libs/locales/lib/en/translation.json
@@ -621,6 +621,7 @@
   "ai:Network ports": "Network ports",
   "ai:Network type": "Network type",
   "ai:Networking": "Networking",
+  "ai:Networking stack type": "Networking stack type",
   "ai:Networks same address families": "Networks same address families",
   "ai:Never share your downloaded ISO with anyone else.": "Never share your downloaded ISO with anyone else.",
   "ai:New hostname": "New hostname",

--- a/libs/ui-lib/lib/common/components/clusterConfiguration/utils.test.ts
+++ b/libs/ui-lib/lib/common/components/clusterConfiguration/utils.test.ts
@@ -1,5 +1,5 @@
 import { test, describe, expect } from 'vitest';
-import { isDualStack } from './utils';
+import { isDualStack, getIPv6FromDualstack } from './utils';
 import {
   MachineNetwork,
   ClusterNetwork,
@@ -271,5 +271,47 @@ describe('isDualStack', () => {
 
       expect(result).toBe(false);
     });
+  });
+});
+
+describe('getIPv6FromDualstack', () => {
+  test('returns the IPv6 entry from a dualstack array', () => {
+    const networks = [
+      { cidr: '10.128.0.0/14', hostPrefix: 23, clusterId: 'test' },
+      { cidr: 'fd01::/48', hostPrefix: 64, clusterId: 'test' },
+    ];
+    const result = getIPv6FromDualstack(networks);
+    expect(result).toEqual({ cidr: 'fd01::/48', hostPrefix: 64, clusterId: 'test' });
+  });
+
+  test('returns the IPv6 entry when IPv6 is first', () => {
+    const networks = [
+      { cidr: 'fd01::/48', hostPrefix: 64, clusterId: 'test' },
+      { cidr: '10.128.0.0/14', hostPrefix: 23, clusterId: 'test' },
+    ];
+    const result = getIPv6FromDualstack(networks);
+    expect(result).toEqual({ cidr: 'fd01::/48', hostPrefix: 64, clusterId: 'test' });
+  });
+
+  test('returns undefined when no IPv6 entry is present', () => {
+    const networks = [{ cidr: '10.128.0.0/14', hostPrefix: 23, clusterId: 'test' }];
+    expect(getIPv6FromDualstack(networks)).toBeUndefined();
+  });
+
+  test('returns undefined for an empty array', () => {
+    expect(getIPv6FromDualstack([])).toBeUndefined();
+  });
+
+  test('returns undefined for undefined input', () => {
+    expect(getIPv6FromDualstack(undefined)).toBeUndefined();
+  });
+
+  test('works with service networks (no hostPrefix)', () => {
+    const networks = [
+      { cidr: '172.30.0.0/16', clusterId: 'test' },
+      { cidr: 'fd02::/112', clusterId: 'test' },
+    ];
+    const result = getIPv6FromDualstack(networks);
+    expect(result).toEqual({ cidr: 'fd02::/112', clusterId: 'test' });
   });
 });

--- a/libs/ui-lib/lib/common/components/clusterConfiguration/utils.ts
+++ b/libs/ui-lib/lib/common/components/clusterConfiguration/utils.ts
@@ -188,6 +188,19 @@ export const canBeDualStack = (subnets: HostSubnets) =>
   subnets.some((subnet) => Address4.isValid(subnet.subnet)) &&
   subnets.some((subnet) => Address6.isValid(subnet.subnet));
 
+export const isPrimaryIPv6 = (machineNetworks: MachineNetwork[] | undefined): boolean => {
+  const cidr = machineNetworks?.[0]?.cidr;
+  return !!cidr && Address6.isValid(cidr);
+};
+
+/**
+ * Find the IPv6 entry in a dualstack network array.
+ * Dualstack arrays contain one IPv4 and one IPv6 entry; this helper returns the IPv6 one.
+ */
+export const getIPv6FromDualstack = <T extends { cidr?: string }>(
+  networks: T[] | undefined,
+): T | undefined => networks?.find((n) => n.cidr && Address6.isValid(n.cidr));
+
 const areNetworksDualStack = (
   networks: (MachineNetwork | ClusterNetwork | ServiceNetwork)[] | undefined,
   openshiftVersion?: string,

--- a/libs/ui-lib/lib/common/components/clusterWizard/networkingSteps/AvailableSubnetsControl.tsx
+++ b/libs/ui-lib/lib/common/components/clusterWizard/networkingSteps/AvailableSubnetsControl.tsx
@@ -252,9 +252,9 @@ export const AvailableSubnetsControl = ({
                   name="machineNetworks.0.cidr"
                   machineSubnets={primaryMachineSubnets}
                   isDisabled={isDisabled}
-                  onAfterSelect={(newSelection) =>
-                    reorderNetworksForPrimary(newSelection, values, setFieldValue)
-                  }
+                  onAfterSelect={(newSelection) => {
+                    reorderNetworksForPrimary(newSelection, values, setFieldValue);
+                  }}
                   data-testid="subnets-dropdown-toggle-primary"
                 />
               </StackItem>

--- a/libs/ui-lib/lib/common/components/clusterWizard/networkingSteps/StackTypeControlGroup.tsx
+++ b/libs/ui-lib/lib/common/components/clusterWizard/networkingSteps/StackTypeControlGroup.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ButtonVariant, FormGroup, Split, SplitItem, Tooltip } from '@patternfly/react-core';
+import { ButtonVariant, FormGroup, Radio, Split, SplitItem, Tooltip } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
 import { Address4, Address6 } from 'ip-address';
 
@@ -9,10 +9,9 @@ import {
   NETWORK_TYPE_OVN,
   NETWORK_TYPE_SDN,
 } from '../../../types';
-import { getFieldId } from '../../ui';
+import { ConfirmationModal, getFieldId, PopoverIcon } from '../../ui';
 import { DUAL_STACK, NO_SUBNET_SET, SINGLE_STACK } from '../../../config';
 import { RadioField } from '../../ui/formik';
-import { ConfirmationModal, PopoverIcon } from '../../ui';
 import { useTranslation } from '../../../hooks/use-translation-wrapper';
 import { reorderNetworksByCurrentPrimary } from './reorderNetworks';
 import {
@@ -72,36 +71,32 @@ export const StackTypeControlGroup = ({
 
   const IPv6Subnets = hostSubnets.filter((subnet) => Address6.isValid(subnet.subnet));
   const cidrIPv6 = IPv6Subnets.length >= 1 ? IPv6Subnets[0].subnet : NO_SUBNET_SET;
+  const isSingleStackSelected = values.stackType !== DUAL_STACK;
+
   const shouldSetSingleStack =
     !isViewerMode && !isDualStackSelectable && values.stackType === DUAL_STACK;
 
   const setSingleStack = React.useCallback(() => {
     setFieldValue('stackType', SINGLE_STACK);
 
-    // Determine whether the first machine network is IPv4
     const firstNetwork = values.machineNetworks?.[0];
     const isFirstIPv4 = Boolean(firstNetwork?.cidr && Address4.isValid(firstNetwork.cidr));
 
     if (values.machineNetworks && values.machineNetworks?.length >= 2) {
-      // For single-stack IPv4, prefer IPv4 machine network
       if (isFirstIPv4) {
-        // Keep the first network if it's IPv4
         setFieldValue('machineNetworks', [firstNetwork]);
       } else {
-        // If first is IPv6, look for IPv4 network or set empty for auto-selection
         const ipv4Network = values.machineNetworks.find(
           (network) => network.cidr && Address4.isValid(network.cidr),
         );
         if (ipv4Network) {
           setFieldValue('machineNetworks', [ipv4Network]);
         } else {
-          // No IPv4 network found, set empty for auto-selection
           setFieldValue('machineNetworks', []);
         }
       }
     }
 
-    // Set cluster/service to IPv4 defaults when switching to single-stack
     if (values.clusterNetworks && values.clusterNetworks.length >= 1) {
       const defaultCluster =
         defaultNetworkValues.clusterNetworksIpv4 && defaultNetworkValues.clusterNetworksIpv4[0];
@@ -110,12 +105,12 @@ export const StackTypeControlGroup = ({
         ? {
             cidr: defaultCluster.cidr,
             hostPrefix: defaultCluster.hostPrefix,
-            clusterId: firstCluster.clusterId, // ← Preserve clusterId from original network
+            clusterId: firstCluster.clusterId,
           }
         : {
             cidr: '',
             hostPrefix: '',
-            clusterId: clusterId, // ← Use current clusterId
+            clusterId: clusterId,
           };
       setFieldValue('clusterNetworks', [ipv4Cluster]);
     }
@@ -126,22 +121,20 @@ export const StackTypeControlGroup = ({
       const ipv4Service = defaultService
         ? {
             cidr: defaultService.cidr,
-            clusterId: firstService.clusterId, // ← Preserve clusterId from original network
+            clusterId: firstService.clusterId,
           }
         : {
             cidr: '',
-            clusterId: clusterId, // ← Use current clusterId
+            clusterId: clusterId,
           };
       setFieldValue('serviceNetworks', [ipv4Service]);
     }
 
-    // Keep only IPv4 VIPs when switching to single-stack (unless DHCP allocation is used)
     if (!values.vipDhcpAllocation) {
       const pruneVips = (
         vips?: { ip?: string; clusterId?: Cluster['id'] }[],
       ): { ip: string; clusterId: Cluster['id'] }[] => {
         if (!vips || vips.length === 0) return [];
-        // Choose which index to keep based on whether the first network is IPv4
         const keepIndex = isFirstIPv4 ? 0 : 1;
         const chosen = vips[keepIndex];
         return chosen && chosen.ip
@@ -177,12 +170,10 @@ export const StackTypeControlGroup = ({
     }
 
     if (values.machineNetworks && values.machineNetworks?.length < 2) {
-      // Ensure IPv4 is primary when switching to dual-stack
       const firstNetwork = values.machineNetworks[0];
       const isFirstIPv6 = firstNetwork?.cidr && Address6.isValid(firstNetwork.cidr);
 
       if (isFirstIPv6) {
-        // If first network is IPv6, make IPv4 primary and IPv6 secondary
         const IPv4Subnets = hostSubnets.filter((subnet) => Address4.isValid(subnet.subnet));
         const cidrIPv4 = IPv4Subnets.length >= 1 ? IPv4Subnets[0].subnet : NO_SUBNET_SET;
         setFieldValue(
@@ -194,7 +185,6 @@ export const StackTypeControlGroup = ({
           false,
         );
       } else {
-        // If first network is IPv4, add IPv6 as secondary
         setFieldValue(
           'machineNetworks',
           [...values.machineNetworks, { cidr: cidrIPv6, clusterId: clusterId }],
@@ -225,7 +215,6 @@ export const StackTypeControlGroup = ({
       };
       setFieldValue('serviceNetworks', [...values.serviceNetworks, secondServiceNetwork], false);
     }
-    // Initialize VIPs for dual-stack
     if (values.apiVips && values.apiVips.length < 2) {
       setFieldValue(
         'apiVips',
@@ -244,8 +233,9 @@ export const StackTypeControlGroup = ({
       );
     }
   };
-  // Ensure cluster/service networks ordering matches the new primary family
+
   const primaryCidr = values.machineNetworks?.[0]?.cidr;
+
   React.useEffect(() => {
     if (isViewerMode) {
       return;
@@ -261,10 +251,11 @@ export const StackTypeControlGroup = ({
     values.serviceNetworks,
   ]);
 
-  const setStackType = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.value === DUAL_STACK) {
-      setDualStack();
-    } else if (
+  const handleSingleStackRadioClick = () => {
+    if (isSingleStackSelected) {
+      return;
+    }
+    if (
       hasDualStackConfigurationChanged(
         defaultNetworkValues.clusterNetworksDualstack || [],
         defaultNetworkValues.serviceNetworksDualstack || [],
@@ -284,32 +275,34 @@ export const StackTypeControlGroup = ({
     }
   }, [shouldSetSingleStack, setSingleStack]);
 
+  const singleStackPopoverContent = allowSingleStackIPv6
+    ? t('ai:Select a single address family (IPv4 or IPv6) for your machine network.')
+    : t('ai:Select this when your hosts are using only IPv4.');
+
+  const singleStackRadioId = getFieldId('stackType', 'radio', SINGLE_STACK);
+
   return (
     <>
       <FormGroup
-        label="Networking stack type"
+        label={t('ai:Networking stack type')}
         fieldId={getFieldId('stackType', 'radio')}
-        onChange={setStackType}
         isInline
       >
         <Split>
           <SplitItem>
-            <RadioField
-              name={'stackType'}
+            <Radio
+              id={singleStackRadioId}
+              name="stackType"
               value={SINGLE_STACK}
-              isDisabled={!isDualStackSelectable || isViewerMode}
               label={`${singleStackLabel}\u00A0`}
+              isChecked={isSingleStackSelected}
+              isDisabled={!isDualStackSelectable || isViewerMode}
+              onChange={() => handleSingleStackRadioClick()}
+              data-testid="form-radio-stackType-singleStack-field"
             />
           </SplitItem>
           <SplitItem>
-            <PopoverIcon
-              bodyContent={
-                allowSingleStackIPv6
-                  ? t('ai:Select a single address family (IPv4 or IPv6) for your machine network.')
-                  : t('ai:Select this when your hosts are using only IPv4.')
-              }
-              buttonStyle={{ top: '-4px' }}
-            />
+            <PopoverIcon bodyContent={singleStackPopoverContent} buttonStyle={{ top: '-4px' }} />
           </SplitItem>
         </Split>
         <Split>
@@ -325,6 +318,8 @@ export const StackTypeControlGroup = ({
                 value={DUAL_STACK}
                 isDisabled={!isDualStackSelectable || isViewerMode}
                 label="Dual-stack&nbsp;"
+                callFormikOnChange={false}
+                onChange={() => setDualStack()}
               />
             </Tooltip>
           </SplitItem>
@@ -343,7 +338,7 @@ export const StackTypeControlGroup = ({
           titleIconVariant={'warning'}
           confirmationButtonText={'Change'}
           confirmationButtonVariant={ButtonVariant.primary}
-          content={<p>All data and configuration done for 'Dual-stack' will be lost.</p>}
+          content={<p>All data and configuration done for &apos;Dual-stack&apos; will be lost.</p>}
           onClose={() => {
             setConfirmModal(false);
             setDualStack();

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
@@ -6,13 +6,16 @@ import {
   canBeDualStack,
   CpuArchitecture,
   DUAL_STACK,
+  getIPv6FromDualstack,
   HostSubnets,
   isAdvNetworkConf,
   isSNO,
   NetworkConfigurationValues,
+  NO_SUBNET_SET,
   selectApiVip,
   selectIngressVip,
 } from '../../../../common';
+import { Address6 } from 'ip-address';
 import {
   ManagedNetworkingControlGroup,
   UserManagedNetworkingTextContent,
@@ -36,6 +39,7 @@ import {
 } from '@openshift-assisted/types/assisted-installer-service';
 import useSupportLevelsAPI from '../../../hooks/useSupportLevelsAPI';
 import { isOciPlatformType } from '../../utils';
+import { useFeature } from '../../../hooks/use-feature';
 
 export type NetworkConfigurationProps = VirtualIPControlGroupProps & {
   hostSubnets: HostSubnets;
@@ -136,8 +140,10 @@ const NetworkConfiguration = ({
     cluster.platform?.type,
   );
   const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
-  const { setFieldValue, values, validateField } = useFormikContext<NetworkConfigurationValues>();
+  const { setFieldValue, values, validateField, validateForm } =
+    useFormikContext<NetworkConfigurationValues>();
 
+  const isSingleClusterFeature = useFeature('ASSISTED_INSTALLER_SINGLE_CLUSTER_FEATURE');
   const isSNOCluster = isSNO(cluster);
   const isUserManagedNetworking = values.managedNetworkingType === 'userManaged';
   const isDualStack = values.stackType === DUAL_STACK;
@@ -177,25 +183,44 @@ const NetworkConfiguration = ({
       setAdvanced(checked);
 
       if (!checked) {
-        setFieldValue(
-          'clusterNetworks',
-          isDualStack
-            ? defaultNetworkSettings.clusterNetworksDualstack
-            : defaultNetworkSettings.clusterNetworksIpv4,
-          true,
-        );
-        setFieldValue(
-          'serviceNetworks',
-          isDualStack
-            ? defaultNetworkSettings.serviceNetworksDualstack
-            : defaultNetworkSettings.serviceNetworksIpv4,
-          true,
-        );
+        const primaryCidr = values.machineNetworks?.[0]?.cidr;
+        const isIPv6Stack = !!primaryCidr && Address6.isValid(primaryCidr);
+
+        let clusterNetworkDefaults;
+        let serviceNetworkDefaults;
+
+        if (isDualStack) {
+          clusterNetworkDefaults = defaultNetworkSettings.clusterNetworksDualstack;
+
+          serviceNetworkDefaults = defaultNetworkSettings.serviceNetworksDualstack;
+        } else if (isIPv6Stack) {
+          const ipv6EntryCluster = getIPv6FromDualstack(
+            defaultNetworkSettings.clusterNetworksDualstack,
+          );
+          clusterNetworkDefaults = ipv6EntryCluster
+            ? [ipv6EntryCluster]
+            : defaultNetworkSettings.clusterNetworksIpv4;
+
+          const ipv6EntryService = getIPv6FromDualstack(
+            defaultNetworkSettings.serviceNetworksDualstack,
+          );
+          serviceNetworkDefaults = ipv6EntryService
+            ? [ipv6EntryService]
+            : defaultNetworkSettings.serviceNetworksIpv4;
+        } else {
+          clusterNetworkDefaults = defaultNetworkSettings.clusterNetworksIpv4;
+
+          serviceNetworkDefaults = defaultNetworkSettings.serviceNetworksIpv4;
+        }
+
+        setFieldValue('clusterNetworks', clusterNetworkDefaults, true);
+        setFieldValue('serviceNetworks', serviceNetworkDefaults, true);
       }
     },
     [
       setFieldValue,
       isDualStack,
+      values.machineNetworks,
       defaultNetworkSettings.clusterNetworksDualstack,
       defaultNetworkSettings.clusterNetworksIpv4,
       defaultNetworkSettings.serviceNetworksDualstack,
@@ -208,6 +233,55 @@ const NetworkConfiguration = ({
       toggleAdvConfiguration(true);
     }
   }, [isDualStack, isViewerMode, toggleAdvConfiguration]);
+
+  React.useEffect(() => {
+    if (!isSingleClusterFeature || isViewerMode || isDualStack || isAdvanced) {
+      return;
+    }
+    const primaryCidr = values.machineNetworks?.[0]?.cidr;
+    if (!primaryCidr || primaryCidr === NO_SUBNET_SET) {
+      return;
+    }
+    const isIPv6 = Address6.isValid(primaryCidr);
+    const currentClusterCidr = values.clusterNetworks?.[0]?.cidr;
+    const clusterIsIPv6 = currentClusterCidr ? Address6.isValid(currentClusterCidr) : null;
+
+    if (clusterIsIPv6 === isIPv6) {
+      return;
+    }
+
+    if (isIPv6) {
+      const ipv6Cluster = getIPv6FromDualstack(defaultNetworkSettings.clusterNetworksDualstack);
+      if (ipv6Cluster) {
+        setFieldValue('clusterNetworks', [{ ...ipv6Cluster, clusterId: cluster.id }]);
+      }
+      const ipv6Service = getIPv6FromDualstack(defaultNetworkSettings.serviceNetworksDualstack);
+      if (ipv6Service) {
+        setFieldValue('serviceNetworks', [{ cidr: ipv6Service.cidr, clusterId: cluster.id }]);
+      }
+    } else {
+      const ipv4Cluster = defaultNetworkSettings.clusterNetworksIpv4?.[0];
+      if (ipv4Cluster) {
+        setFieldValue('clusterNetworks', [{ ...ipv4Cluster, clusterId: cluster.id }]);
+      }
+      const ipv4Service = defaultNetworkSettings.serviceNetworksIpv4?.[0];
+      if (ipv4Service) {
+        setFieldValue('serviceNetworks', [{ cidr: ipv4Service.cidr, clusterId: cluster.id }]);
+      }
+    }
+    void validateForm();
+  }, [
+    isSingleClusterFeature,
+    isViewerMode,
+    isDualStack,
+    isAdvanced,
+    values.machineNetworks,
+    values.clusterNetworks,
+    defaultNetworkSettings,
+    setFieldValue,
+    validateForm,
+    cluster.id,
+  ]);
 
   const managedNetworkingState = React.useMemo(
     () =>
@@ -252,6 +326,7 @@ const NetworkConfiguration = ({
             hostSubnets={hostSubnets}
             defaultNetworkValues={defaultNetworkSettings}
             isViewerMode={isViewerMode}
+            allowSingleStackIPv6={isSingleClusterFeature}
           />
         </StackItem>
       )}
@@ -277,6 +352,7 @@ const NetworkConfiguration = ({
             }
             openshiftVersion={cluster.openshiftVersion}
             isViewerMode={isViewerMode}
+            allowSingleStackIPv6={isSingleClusterFeature}
           />
         </StackItem>
       )}

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfiguration.tsx
@@ -126,6 +126,33 @@ const getManagedNetworkingState = (
   };
 };
 
+type DefaultNetworkSettings = NetworkConfigurationProps['defaultNetworkSettings'];
+
+const getNetworkDefaultsByFamily = (
+  settings: DefaultNetworkSettings,
+  isDualStack: boolean,
+  isIPv6: boolean,
+) => {
+  if (isDualStack) {
+    return {
+      clusterNetworkDefaults: settings.clusterNetworksDualstack,
+      serviceNetworkDefaults: settings.serviceNetworksDualstack,
+    };
+  }
+  if (isIPv6) {
+    const ipv6Cluster = getIPv6FromDualstack(settings.clusterNetworksDualstack);
+    const ipv6Service = getIPv6FromDualstack(settings.serviceNetworksDualstack);
+    return {
+      clusterNetworkDefaults: ipv6Cluster ? [ipv6Cluster] : settings.clusterNetworksIpv4,
+      serviceNetworkDefaults: ipv6Service ? [ipv6Service] : settings.serviceNetworksIpv4,
+    };
+  }
+  return {
+    clusterNetworkDefaults: settings.clusterNetworksIpv4,
+    serviceNetworkDefaults: settings.serviceNetworksIpv4,
+  };
+};
+
 const NetworkConfiguration = ({
   cluster,
   hostSubnets,
@@ -185,47 +212,16 @@ const NetworkConfiguration = ({
       if (!checked) {
         const primaryCidr = values.machineNetworks?.[0]?.cidr;
         const isIPv6Stack = !!primaryCidr && Address6.isValid(primaryCidr);
-
-        let clusterNetworkDefaults;
-        let serviceNetworkDefaults;
-
-        if (isDualStack) {
-          clusterNetworkDefaults = defaultNetworkSettings.clusterNetworksDualstack;
-
-          serviceNetworkDefaults = defaultNetworkSettings.serviceNetworksDualstack;
-        } else if (isIPv6Stack) {
-          const ipv6EntryCluster = getIPv6FromDualstack(
-            defaultNetworkSettings.clusterNetworksDualstack,
-          );
-          clusterNetworkDefaults = ipv6EntryCluster
-            ? [ipv6EntryCluster]
-            : defaultNetworkSettings.clusterNetworksIpv4;
-
-          const ipv6EntryService = getIPv6FromDualstack(
-            defaultNetworkSettings.serviceNetworksDualstack,
-          );
-          serviceNetworkDefaults = ipv6EntryService
-            ? [ipv6EntryService]
-            : defaultNetworkSettings.serviceNetworksIpv4;
-        } else {
-          clusterNetworkDefaults = defaultNetworkSettings.clusterNetworksIpv4;
-
-          serviceNetworkDefaults = defaultNetworkSettings.serviceNetworksIpv4;
-        }
-
+        const { clusterNetworkDefaults, serviceNetworkDefaults } = getNetworkDefaultsByFamily(
+          defaultNetworkSettings,
+          isDualStack,
+          isIPv6Stack,
+        );
         setFieldValue('clusterNetworks', clusterNetworkDefaults, true);
         setFieldValue('serviceNetworks', serviceNetworkDefaults, true);
       }
     },
-    [
-      setFieldValue,
-      isDualStack,
-      values.machineNetworks,
-      defaultNetworkSettings.clusterNetworksDualstack,
-      defaultNetworkSettings.clusterNetworksIpv4,
-      defaultNetworkSettings.serviceNetworksDualstack,
-      defaultNetworkSettings.serviceNetworksIpv4,
-    ],
+    [setFieldValue, isDualStack, values.machineNetworks, defaultNetworkSettings],
   );
 
   React.useEffect(() => {
@@ -250,24 +246,16 @@ const NetworkConfiguration = ({
       return;
     }
 
-    if (isIPv6) {
-      const ipv6Cluster = getIPv6FromDualstack(defaultNetworkSettings.clusterNetworksDualstack);
-      if (ipv6Cluster) {
-        setFieldValue('clusterNetworks', [{ ...ipv6Cluster, clusterId: cluster.id }]);
-      }
-      const ipv6Service = getIPv6FromDualstack(defaultNetworkSettings.serviceNetworksDualstack);
-      if (ipv6Service) {
-        setFieldValue('serviceNetworks', [{ cidr: ipv6Service.cidr, clusterId: cluster.id }]);
-      }
-    } else {
-      const ipv4Cluster = defaultNetworkSettings.clusterNetworksIpv4?.[0];
-      if (ipv4Cluster) {
-        setFieldValue('clusterNetworks', [{ ...ipv4Cluster, clusterId: cluster.id }]);
-      }
-      const ipv4Service = defaultNetworkSettings.serviceNetworksIpv4?.[0];
-      if (ipv4Service) {
-        setFieldValue('serviceNetworks', [{ cidr: ipv4Service.cidr, clusterId: cluster.id }]);
-      }
+    const { clusterNetworkDefaults, serviceNetworkDefaults } = getNetworkDefaultsByFamily(
+      defaultNetworkSettings,
+      false,
+      isIPv6,
+    );
+    if (clusterNetworkDefaults) {
+      setFieldValue('clusterNetworks', clusterNetworkDefaults);
+    }
+    if (serviceNetworkDefaults) {
+      setFieldValue('serviceNetworks', serviceNetworkDefaults);
     }
     void validateForm();
   }, [

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
@@ -9,7 +9,7 @@ import {
   getFormikErrorFields,
   getHostSubnets,
   HostSubnets,
-  SINGLE_STACK,
+  DUAL_STACK,
   isSNO,
   LoadingState,
   NetworkConfigurationValues,
@@ -262,7 +262,7 @@ const NetworkConfigurationPage = ({ cluster }: { cluster: Cluster }) => {
         if (values.vipDhcpAllocation) {
           delete params.apiVips;
           delete params.ingressVips;
-        } else if (values.stackType === SINGLE_STACK) {
+        } else if (values.stackType !== DUAL_STACK) {
           // The API will rebuild the default machineNetwork
           params.machineNetworks = [];
         }

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/networkConfigurationValidation.ts
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/networkConfigurationValidation.ts
@@ -1,8 +1,11 @@
 import * as Yup from 'yup';
 import { TFunction } from 'i18next';
+import { Address6 } from 'ip-address';
 import {
   clusterNetworksValidationSchema,
   dualStackValidationSchema,
+  getIPv6FromDualstack,
+  isPrimaryIPv6,
   HostSubnets,
   isDualStack,
   isSNO,
@@ -10,6 +13,7 @@ import {
   NetworkConfigurationValues,
   serviceNetworkValidationSchema,
   IPv4ValidationSchema,
+  IPv6ValidationSchema,
   sshPublicKeyValidationSchema,
   SINGLE_STACK,
   DUAL_STACK,
@@ -36,6 +40,38 @@ export const getNetworkInitialValues = (
 ): NetworkConfigurationValues => {
   const isSNOCluster = isSNO(cluster);
   const isDualStackType = isDualStack(cluster);
+  const primaryMachineNetworkCidr = cluster.machineNetworks?.[0]?.cidr;
+  const isIPv6OnlyStack =
+    !isDualStackType && !!primaryMachineNetworkCidr && Address6.isValid(primaryMachineNetworkCidr);
+
+  const getStackType = (): NetworkConfigurationValues['stackType'] => {
+    if (isDualStackType) return DUAL_STACK;
+    return SINGLE_STACK;
+  };
+
+  const getDefaultClusterNetworks = () => {
+    if (isDualStackType) return defaultNetworkValues.clusterNetworksDualstack;
+    if (isIPv6OnlyStack) {
+      const ipv6Entry = getIPv6FromDualstack(defaultNetworkValues.clusterNetworksDualstack);
+      return ipv6Entry ? [{ ...ipv6Entry, clusterId: cluster?.id }] : undefined;
+    }
+    return defaultNetworkValues.clusterNetworksIpv4?.map((network) => ({
+      ...network,
+      clusterId: cluster?.id,
+    }));
+  };
+
+  const getDefaultServiceNetworks = () => {
+    if (isDualStackType) return defaultNetworkValues.serviceNetworksDualstack;
+    if (isIPv6OnlyStack) {
+      const ipv6Entry = getIPv6FromDualstack(defaultNetworkValues.serviceNetworksDualstack);
+      return ipv6Entry ? [{ ...ipv6Entry, clusterId: cluster?.id }] : undefined;
+    }
+    return defaultNetworkValues.serviceNetworksIpv4?.map((network) => ({
+      ...network,
+      clusterId: cluster?.id,
+    }));
+  };
 
   return {
     apiVips: cluster.apiVips,
@@ -50,23 +86,9 @@ export const getNetworkInitialValues = (
         : 'clusterManaged',
     networkType: cluster.networkType || NETWORK_TYPE_OVN,
     machineNetworks: cluster.machineNetworks || [],
-    stackType: isDualStackType ? DUAL_STACK : SINGLE_STACK,
-    clusterNetworks:
-      cluster.clusterNetworks ||
-      (isDualStackType
-        ? defaultNetworkValues.clusterNetworksDualstack
-        : defaultNetworkValues.clusterNetworksIpv4?.map((network) => ({
-            ...network,
-            clusterId: cluster?.id,
-          }))),
-    serviceNetworks:
-      cluster.serviceNetworks ||
-      (isDualStackType
-        ? defaultNetworkValues.serviceNetworksDualstack
-        : defaultNetworkValues.serviceNetworksIpv4?.map((network) => ({
-            ...network,
-            clusterId: cluster?.id,
-          }))),
+    stackType: getStackType(),
+    clusterNetworks: cluster.clusterNetworks || getDefaultClusterNetworks(),
+    serviceNetworks: cluster.serviceNetworks || getDefaultServiceNetworks(),
   };
 };
 
@@ -87,7 +109,12 @@ export const getNetworkConfigurationValidationSchema = (
           : machineNetworksValidationSchema.when('stackType', {
               is: (stackType: NetworkConfigurationValues['stackType']) =>
                 stackType === SINGLE_STACK,
-              then: () => machineNetworksValidationSchema.concat(IPv4ValidationSchema),
+              then: () => {
+                if (isPrimaryIPv6(values.machineNetworks)) {
+                  return machineNetworksValidationSchema.concat(IPv6ValidationSchema);
+                }
+                return machineNetworksValidationSchema.concat(IPv4ValidationSchema);
+              },
               otherwise: () =>
                 values.machineNetworks && values.machineNetworks?.length >= 2
                   ? machineNetworksValidationSchema.concat(
@@ -97,13 +124,23 @@ export const getNetworkConfigurationValidationSchema = (
             }),
       clusterNetworks: clusterNetworksValidationSchema(t).when('stackType', {
         is: (stackType: NetworkConfigurationValues['stackType']) => stackType === SINGLE_STACK,
-        then: (schema) => schema.concat(IPv4ValidationSchema),
+        then: (schema) => {
+          if (isPrimaryIPv6(values.machineNetworks)) {
+            return schema.concat(IPv6ValidationSchema);
+          }
+          return schema.concat(IPv4ValidationSchema);
+        },
         otherwise: (schema) =>
           schema.concat(dualStackValidationSchema('cluster network', t, openshiftVersion)),
       }),
       serviceNetworks: serviceNetworkValidationSchema(t).when('stackType', {
         is: (stackType: NetworkConfigurationValues['stackType']) => stackType === SINGLE_STACK,
-        then: (schema) => schema.concat(IPv4ValidationSchema),
+        then: (schema) => {
+          if (isPrimaryIPv6(values.machineNetworks)) {
+            return schema.concat(IPv6ValidationSchema);
+          }
+          return schema.concat(IPv4ValidationSchema);
+        },
         otherwise: (schema) =>
           schema.concat(dualStackValidationSchema('service network', t, openshiftVersion)),
       }),

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewNetworkingTable.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewNetworkingTable.tsx
@@ -8,6 +8,7 @@ import {
   useTranslation,
 } from '../../../../common';
 import { getManagementType, getStackTypeLabel } from './utils';
+import { useFeature } from '../../../hooks/use-feature';
 import { Cluster } from '@openshift-assisted/types/assisted-installer-service';
 
 type ReviewTableRowsType = {
@@ -17,6 +18,7 @@ type ReviewTableRowsType = {
 
 export const ReviewNetworkingTable = ({ cluster }: { cluster: Cluster }) => {
   const { t } = useTranslation();
+  const isSingleClusterFeature = useFeature('ASSISTED_INSTALLER_SINGLE_CLUSTER_FEATURE');
   const rows = React.useMemo(() => {
     const networkRows = [
       {
@@ -34,7 +36,7 @@ export const ReviewNetworkingTable = ({ cluster }: { cluster: Cluster }) => {
         cells: [
           { title: 'Stack type', colSpan: 2 },
           {
-            title: getStackTypeLabel(cluster),
+            title: getStackTypeLabel(cluster, isSingleClusterFeature),
             props: { 'data-testid': 'stack-type', colSpan: 2 },
           },
         ],
@@ -125,7 +127,7 @@ export const ReviewNetworkingTable = ({ cluster }: { cluster: Cluster }) => {
       });
 
     return networkRows;
-  }, [cluster]);
+  }, [cluster, isSingleClusterFeature]);
 
   const rowsAdvanced = React.useMemo(() => {
     return [

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/utils.test.ts
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/utils.test.ts
@@ -169,6 +169,47 @@ describe('getStackTypeLabel', () => {
     });
   });
 
+  describe('with isSingleClusterFeature=true', () => {
+    test('returns "Single stack" for IPv4 single-stack cluster', () => {
+      const cluster = createCluster({
+        machineNetworks: [createMachineNetwork('192.168.1.0/24')],
+        clusterNetworks: [createClusterNetwork('10.128.0.0/14', 23)],
+        serviceNetworks: [createServiceNetwork('172.30.0.0/16')],
+      });
+
+      expect(getStackTypeLabel(cluster, true)).toBe('Single stack');
+    });
+
+    test('returns "Single stack" for IPv6 single-stack cluster', () => {
+      const cluster = createCluster({
+        machineNetworks: [createMachineNetwork('2001:db8::/64')],
+        clusterNetworks: [createClusterNetwork('fd01::/48', 64)],
+        serviceNetworks: [createServiceNetwork('fd02::/112')],
+      });
+
+      expect(getStackTypeLabel(cluster, true)).toBe('Single stack');
+    });
+
+    test('still returns "Dual-stack" for dual-stack cluster', () => {
+      const cluster = createCluster({
+        machineNetworks: [
+          createMachineNetwork('192.168.1.0/24'),
+          createMachineNetwork('2001:db8::/64'),
+        ],
+        clusterNetworks: [
+          createClusterNetwork('10.128.0.0/14', 23),
+          createClusterNetwork('fd01::/48', 64),
+        ],
+        serviceNetworks: [
+          createServiceNetwork('172.30.0.0/16'),
+          createServiceNetwork('fd02::/112'),
+        ],
+      });
+
+      expect(getStackTypeLabel(cluster, true)).toBe('Dual-stack');
+    });
+  });
+
   describe('edge cases', () => {
     test('handles undefined openshiftVersion', () => {
       const cluster = createCluster({

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/utils.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/utils.tsx
@@ -5,8 +5,11 @@ import { Cluster, DiskEncryption } from '@openshift-assisted/types/assisted-inst
 export const getManagementType = ({ userManagedNetworking }: Cluster): string =>
   userManagedNetworking ? 'User-managed networking' : 'Cluster-managed networking';
 
-export const getStackTypeLabel = (cluster: Cluster): string =>
-  isDualStack(cluster) ? 'Dual-stack' : 'IPv4';
+export const getStackTypeLabel = (cluster: Cluster, isSingleClusterFeature = false): string => {
+  if (isDualStack(cluster)) return 'Dual-stack';
+  if (isSingleClusterFeature) return 'Single stack';
+  return 'IPv4';
+};
 
 export const getDiskEncryptionEnabledOnStatus = (diskEncryption: DiskEncryption['enableOn']) => {
   let diskEncryptionType = null;


### PR DESCRIPTION
[AGENT-1519](https://redhat.atlassian.net/browse/AGENT-1519) | [Below-the-sea UI] Allow the user to select IPv6 in the Networking Stack Type field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added explicit IPv6 single-stack networking stack type for cluster configuration
* Expanded cluster networking options to include dedicated IPv6 single-stack mode alongside existing IPv4 and dual-stack options
* Enhanced static IP configuration to support IPv6-only deployments

## Tests
* Added comprehensive test coverage for IPv6 single-stack and subnet selection scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->