### PR TITLE
OCPBUGS-85310: Static ip prefill for ove below the sea

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/components/StaticIpForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/components/StaticIpForm.tsx
@@ -8,6 +8,8 @@ import { useErrorMonitor } from '../../../../../common/components/ErrorHandling/
 import { getApiErrorMessage } from '../../../../../common/api';
 import { StaticIpFormProps } from './propTypes';
 import { selectCurrentClusterPermissionsState } from '../../../../store/slices/current-cluster/selectors';
+import { useFeature } from '../../../../hooks/use-feature';
+import { getStaticNetworkConfig } from '../data/fromInfraEnv';
 
 /** Reports form state and triggers save on every value change (useFormikAutoSave) */
 const AutosaveWithParentUpdate = <StaticIpFormValues extends object>({
@@ -69,7 +71,14 @@ export const StaticIpForm = <StaticIpFormValues extends object>({
   const { clearAlerts, addAlert } = useAlerts();
   const { captureException } = useErrorMonitor();
   const { isViewerMode } = useSelector(selectCurrentClusterPermissionsState);
-  const initialValues = showEmptyValues ? getEmptyValues() : getInitialValues(infraEnv);
+  const isSingleClusterFeatureEnabled = useFeature('ASSISTED_INSTALLER_SINGLE_CLUSTER_FEATURE');
+  const prefillFromInfraEnv = isSingleClusterFeatureEnabled && !!getStaticNetworkConfig(infraEnv);
+  const initialValues = React.useMemo(() => {
+    if (showEmptyValues && !prefillFromInfraEnv) {
+      return getEmptyValues();
+    }
+    return getInitialValues(infraEnv);
+  }, [showEmptyValues, prefillFromInfraEnv, infraEnv, getInitialValues, getEmptyValues]);
 
   const handleSubmit = async (values: StaticIpFormValues) => {
     clearAlerts();

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/components/StaticIpPage.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/components/StaticIpPage.tsx
@@ -9,7 +9,8 @@ import {
 } from '@patternfly/react-core';
 import { StaticIpInfo, StaticIpView } from '../data/dataTypes';
 import StaticIpViewRadioGroup from './StaticIpViewRadioGroup';
-import { getStaticIpInfo } from '../data/fromInfraEnv';
+import { getStaticIpInfo, getStaticNetworkConfig } from '../data/fromInfraEnv';
+import { useFeature } from '../../../../hooks/use-feature';
 import { StaticIpFormState, StaticIpPageProps, StaticIpViewProps } from './propTypes';
 import { YamlView } from './YamlView/YamlView';
 import { useClusterWizardContext } from '../../../clusterWizard/ClusterWizardContext';
@@ -34,6 +35,8 @@ export const StaticIpPage: React.FC<StaticIpPageProps> = ({
   onFormStateChange: onFormStateChangeParent,
 }) => {
   const clusterWizardContext = useClusterWizardContext();
+  const isSingleClusterFeatureEnabled = useFeature('ASSISTED_INSTALLER_SINGLE_CLUSTER_FEATURE');
+  const prefillFromInfraEnv = isSingleClusterFeatureEnabled && !!getStaticNetworkConfig(infraEnv);
   const [confirmOnChangeView, setConfirmOnChangeView] = React.useState<boolean>(false);
   const [viewChanged, setViewChanged] = React.useState<boolean>(false);
 
@@ -45,10 +48,10 @@ export const StaticIpPage: React.FC<StaticIpPageProps> = ({
     [clusterWizardContext],
   );
 
-  const initialStaticIpInfo = React.useMemo<StaticIpInfo | undefined>(() => {
-    return getStaticIpInfo(infraEnv);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const initialStaticIpInfo = React.useMemo<StaticIpInfo | undefined>(
+    () => getStaticIpInfo(infraEnv),
+    [infraEnv],
+  );
 
   const onFormStateChange = React.useCallback(
     (formState: StaticIpFormState) => {
@@ -65,7 +68,7 @@ export const StaticIpPage: React.FC<StaticIpPageProps> = ({
     onFormStateChange,
     infraEnv,
     updateInfraEnv,
-    showEmptyValues: viewChanged,
+    showEmptyValues: viewChanged && !prefillFromInfraEnv,
   };
 
   const content = (() => {

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/NewClusterWizard.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/NewClusterWizard.tsx
@@ -5,24 +5,28 @@ import { useClusterWizardContext } from './ClusterWizardContext';
 import ReviewStep from './disconnected/ReviewStep';
 import BasicStep from './disconnected/BasicStep';
 import { ClusterWizardStepsType } from './wizardTransition';
+import { useInfraEnv } from '../../hooks';
+import { CpuArchitecture } from '../../../common/types';
+import { InfraEnv } from '@openshift-assisted/types/assisted-installer-service';
 
-const getCurrentStep = (currentStepId: ClusterWizardStepsType) => {
+const getCurrentStep = (currentStepId: ClusterWizardStepsType, infraEnv?: InfraEnv) => {
   switch (currentStepId) {
     case 'disconnected-review':
       return <ReviewStep />;
     case 'disconnected-basic':
       return <BasicStep />;
     default:
-      return <ClusterDetails />;
+      return <ClusterDetails infraEnv={infraEnv} />;
   }
 };
 
 const NewClusterWizard: React.FC = () => {
+  const { infraEnv } = useInfraEnv('', CpuArchitecture.USE_DAY1_ARCHITECTURE);
   const { currentStepId } = useClusterWizardContext();
 
   return (
     <div className={classNames('pf-v6-c-wizard', 'cluster-wizard')}>
-      {getCurrentStep(currentStepId)}
+      {getCurrentStep(currentStepId, infraEnv)}
     </div>
   );
 };

--- a/libs/ui-lib/lib/ocm/hooks/useInfraEnvId.ts
+++ b/libs/ui-lib/lib/ocm/hooks/useInfraEnvId.ts
@@ -55,12 +55,12 @@ export default function useInfraEnvId(
   ]);
 
   React.useEffect(() => {
-    if (!clusterId) {
+    if (!clusterId && !isSingleClusterFeatureEnabled) {
       setError('Missing clusterId to load infrastructure environment');
     } else if (!infraEnvId) {
       void findInfraEnvId();
     }
-  }, [clusterId, findInfraEnvId, infraEnvId]);
+  }, [clusterId, findInfraEnvId, infraEnvId, isSingleClusterFeatureEnabled]);
 
   return { infraEnvId, error };
 }

--- a/libs/ui-lib/lib/ocm/services/InfraEnvsService.ts
+++ b/libs/ui-lib/lib/ocm/services/InfraEnvsService.ts
@@ -21,7 +21,10 @@ const InfraEnvsService = {
       const { data: infraEnvs } = await InfraEnvsAPI.list(
         !isSingleClusterFeatureEnabled ? clusterId : '',
       );
-      if (infraEnvs.length > 0) {
+      if (isSingleClusterFeatureEnabled) {
+        return infraEnvs[0].id;
+      }
+      if (infraEnvs.length > 0 && clusterId) {
         InfraEnvCache.updateInfraEnvs(clusterId, infraEnvs);
         infraEnvId = InfraEnvCache.getInfraEnvId(clusterId, cpuArchitecture);
       }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-85310

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Static IP form and page can prefill network data from the infrastructure environment when the single-cluster feature is enabled
  * Cluster creation flow now considers infrastructure environment data when determining the current step

* **Bug Fixes**
  * Empty fields now show only when prefill is unavailable
  * InfraEnv loading now respects the single-cluster feature and selects the available infra env when enabled
<!-- end of auto-generated comment: release notes by coderabbit.ai -->