### PR TITLE
MGMT-24437: Clear All Filters does not clear the search box input — only the status filter is reset

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusters/ClustersListToolbar.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusters/ClustersListToolbar.tsx
@@ -8,7 +8,6 @@ import {
   TextInput,
   ToolbarProps,
   ToolbarFilterProps,
-  TextInputProps,
   ButtonVariant,
   Spinner,
   ToolbarGroup,
@@ -39,7 +38,7 @@ export type ClusterFiltersType = {
 
 type ClustersListToolbarProps = {
   searchString: string;
-  setSearchString: TextInputProps['onChange'];
+  setSearchString: (value: string) => void;
   filters: ClusterFiltersType;
   setFilters: (filters: ClusterFiltersType) => void;
 };
@@ -63,9 +62,8 @@ const ClustersListToolbar: React.FC<ClustersListToolbarProps> = ({
     setFilters({
       status: [],
     });
+    setSearchString('');
   };
-
-  const onSearchNameChanged: TextInputProps['onChange'] = setSearchString;
 
   const onSelect = (type: string, isChecked: boolean, value: Cluster['status']) => {
     setFilters({
@@ -126,7 +124,7 @@ const ClustersListToolbar: React.FC<ClustersListToolbarProps> = ({
                 id="search-string"
                 type="search"
                 aria-label="string to be searched in cluster names or ids"
-                onChange={onSearchNameChanged}
+                onChange={(_event, value) => setSearchString(value)}
                 value={searchString}
                 placeholder="Filter by Name, ID or Base domain"
                 title="Filter by Name, ID or Base domain"

--- a/libs/ui-lib/lib/ocm/components/clusters/ClustersTable.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusters/ClustersTable.tsx
@@ -158,7 +158,7 @@ const ClustersTable = ({ rows, deleteCluster }: ClustersTableProps) => {
     <>
       <ClustersListToolbar
         searchString={searchString}
-        setSearchString={(_event, value) => setSearchString(value)}
+        setSearchString={setSearchString}
         filters={filters}
         setFilters={setFilters}
       />


### PR DESCRIPTION
https://redhat.atlassian.net/browse/MGMT-24437

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* The "Clear all filters" action in the clusters list now also clears the search string, ensuring a complete reset of the filtering state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openshift-assisted/assisted-installer-ui/pull/3736?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->