### PR TITLE
MGMT-24183: UI does not reflect cluster encryption status after creation

### DIFF
--- a/libs/ui-lib/lib/common/components/clusterWizard/clusterDetailsValidation.ts
+++ b/libs/ui-lib/lib/common/components/clusterWizard/clusterDetailsValidation.ts
@@ -38,6 +38,38 @@ export const parseTangServers = (tangServersString?: string): TangServer[] => {
   return emptyTangServers();
 };
 
+const parseDiskEncryption = (diskEncryption: Cluster['diskEncryption']) => {
+  const enableOn = {
+    enableDiskEncryptionOnMasters: false,
+    enableDiskEncryptionOnWorkers: false,
+    enableDiskEncryptionOnArbiters: false,
+  };
+
+  if (diskEncryption?.enableOn === 'all') {
+    enableOn.enableDiskEncryptionOnMasters = true;
+    enableOn.enableDiskEncryptionOnWorkers = true;
+    enableOn.enableDiskEncryptionOnArbiters = true;
+  } else {
+    const types = diskEncryption?.enableOn?.split(',');
+
+    types?.forEach((type) => {
+      switch (type) {
+        case 'masters':
+          enableOn.enableDiskEncryptionOnMasters = true;
+          break;
+        case 'workers':
+          enableOn.enableDiskEncryptionOnWorkers = true;
+          break;
+        case 'arbiters':
+          enableOn.enableDiskEncryptionOnArbiters = true;
+          break;
+      }
+    });
+  }
+
+  return enableOn;
+};
+
 export const getClusterDetailsInitialValues = ({
   cluster,
   pullSecret,
@@ -57,6 +89,7 @@ export const getClusterDetailsInitialValues = ({
     openshiftVersion = getDefaultOpenShiftVersion(ocpVersions),
     controlPlaneCount = 3,
   } = cluster || {};
+
   return {
     name,
     openshiftVersion,
@@ -65,22 +98,15 @@ export const getClusterDetailsInitialValues = ({
     controlPlaneCount,
     useRedHatDnsService:
       !!baseDnsDomain && managedDomains.map((d) => d.domain).includes(baseDnsDomain),
-    enableDiskEncryptionOnMasters: ['all', 'masters'].includes(
-      cluster?.diskEncryption?.enableOn ?? 'none',
-    ),
-    enableDiskEncryptionOnWorkers: ['all', 'workers'].includes(
-      cluster?.diskEncryption?.enableOn ?? 'none',
-    ),
-    diskEncryptionMode: cluster?.diskEncryption?.mode ?? 'tpmv2',
-    diskEncryptionTangServers: parseTangServers(cluster?.diskEncryption?.tangServers),
-    diskEncryption: cluster?.diskEncryption ?? {},
     cpuArchitecture: cluster?.cpuArchitecture || getDefaultCpuArchitecture(),
     platform: cluster?.platform?.type || 'baremetal',
     customOpenshiftSelect: null,
     userManagedNetworking: cluster?.userManagedNetworking || false,
-    enableDiskEncryptionOnArbiters: ['all', 'arbiters'].includes(
-      cluster?.diskEncryption?.enableOn ?? 'none',
-    ),
+
+    diskEncryptionMode: cluster?.diskEncryption?.mode ?? 'tpmv2',
+    diskEncryptionTangServers: parseTangServers(cluster?.diskEncryption?.tangServers),
+    diskEncryption: cluster?.diskEncryption ?? {},
+    ...parseDiskEncryption(cluster?.diskEncryption),
   };
 };
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/MGMT-24183

before:
<img width="299" height="161" alt="image" src="https://github.com/user-attachments/assets/9f7531e7-4b76-4a94-a01d-809f0b312da0" />

after:
<img width="271" height="144" alt="image" src="https://github.com/user-attachments/assets/6d079fda-6ffd-4e36-95fb-8e9781fe2080" />
