### PR TITLE
MGMT-24099: UI redirects to Custom Manifest page before host discovery when cluster is OCI platform

### DIFF
--- a/libs/ui-lib-tests/cypress/integration/create-multinode/2-networking.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/create-multinode/2-networking.cy.ts
@@ -17,7 +17,6 @@ describe(`Assisted Installer Multinode Networking`, () => {
     beforeEach(() => {
       setTestStartSignal('HOST_RENAMED_3');
       commonActions.visitClusterDetailsPage();
-      commonActions.moveNextSteps(['Host discovery', 'Storage']); // to networking
     });
 
     it('Should submit updated network information', () => {

--- a/libs/ui-lib-tests/cypress/integration/create-sno/1-host-discovery.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/create-sno/1-host-discovery.cy.ts
@@ -49,6 +49,7 @@ describe(`Assisted Installer SNO Host discovery`, () => {
     beforeEach(() => {
       setTestStartSignal('HOST_DISCOVERED_1');
       commonActions.visitClusterDetailsPage();
+      commonActions.verifyIsAtStep('Host discovery');
     });
 
     it('Should rename the host, get valid state and see the "next" button enabled', () => {

--- a/libs/ui-lib-tests/cypress/integration/custom-manifests/2-modifying-existing-custom-manifest.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/custom-manifests/2-modifying-existing-custom-manifest.cy.ts
@@ -12,33 +12,6 @@ describe(`Assisted Installer Custom manifests step`, () => {
       });
     };
 
-    before(() => setTestStartSignal('ONLY_DUMMY_CUSTOM_MANIFEST_ADDED'));
-
-    beforeEach(() => {
-      setTestStartSignal('ONLY_DUMMY_CUSTOM_MANIFEST_ADDED');
-      commonActions.visitClusterDetailsPage();
-    });
-
-    it('Should move to "Custom manifests" step if the current manifests are incomplete', () => {
-      cy.wait('@list-manifests').then(() => {
-        commonActions
-          .getWizardStepNav('Custom manifests')
-          .should('have.class', ACTIVE_NAV_ITEM_CLASS);
-
-        commonActions.verifyIsAtStep('Custom manifests');
-        commonActions.verifyNextIsDisabled();
-      });
-    });
-  });
-
-  describe('Initial step for Custom Manifests', () => {
-    const setTestStartSignal = (activeSignal: string) => {
-      cy.setTestEnvironment({
-        activeSignal,
-        activeScenario: 'AI_CREATE_CUSTOM_MANIFESTS',
-      });
-    };
-
     before(() => setTestStartSignal('CUSTOM_MANIFEST_ADDED'));
 
     beforeEach(() => {
@@ -70,6 +43,7 @@ describe(`Assisted Installer Custom manifests step`, () => {
     beforeEach(() => {
       setTestStartSignal('ONLY_DUMMY_CUSTOM_MANIFEST_ADDED');
       commonActions.visitClusterDetailsPage();
+      commonActions.startAtWizardStep('Custom manifests');
     });
 
     it('Adding valid content to dummy manifest enables next button', () => {

--- a/libs/ui-lib-tests/cypress/integration/custom-manifests/3-removing-adding-custom-manifests.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/custom-manifests/3-removing-adding-custom-manifests.cy.ts
@@ -16,6 +16,7 @@ describe(`Assisted Installer Custom manifests step`, () => {
     beforeEach(() => {
       setTestStartSignal('ONLY_DUMMY_CUSTOM_MANIFEST_ADDED');
       commonActions.visitClusterDetailsPage();
+      commonActions.startAtWizardStep('Custom manifests');
       Cypress.on('uncaught:exception', (err, runnable) => {
         // returning false here prevents Cypress from
         // failing the test

--- a/libs/ui-lib-tests/cypress/integration/dualstack/2-networking.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/dualstack/2-networking.cy.ts
@@ -19,7 +19,6 @@ describe(`Assisted Installer Dualstack Networking`, () => {
     beforeEach(() => {
       setTestStartSignal('NETWORKING_DUAL_STACK_SELECT_SINGLE_STACK');
       commonActions.visitClusterDetailsPage();
-      commonActions.moveNextSteps(['Host discovery', 'Storage']);
     });
 
     it('Networking is displayed correctly', () => {
@@ -59,7 +58,6 @@ describe(`Assisted Installer Dualstack Networking`, () => {
     beforeEach(() => {
       setTestStartSignal('NETWORKING_DUAL_STACK_SELECT_DUAL_STACK');
       commonActions.visitClusterDetailsPage();
-      commonActions.moveNextSteps(['Host discovery', 'Storage']);
     });
 
     it('Can switch to single-stack', () => {

--- a/libs/ui-lib/lib/common/components/clusterWizard/validationsInfoUtils.ts
+++ b/libs/ui-lib/lib/common/components/clusterWizard/validationsInfoUtils.ts
@@ -282,29 +282,3 @@ export const areOnlySoftValidationsOfWizardStepFailing = <ClusterWizardStepsType
   }
   return true;
 };
-
-export const findValidationStep = <ClusterWizardStepsType extends string>(
-  validationId: ClusterValidationId | HostValidationId,
-  wizardStepsValidationsMap: WizardStepsValidationMap<ClusterWizardStepsType>,
-  minimumStep: ClusterWizardStepsType,
-): ClusterWizardStepsType | undefined => {
-  const wizardStepsIds = lodashKeys(wizardStepsValidationsMap) as ClusterWizardStepsType[];
-  let isBeforeMinimumStep = true;
-  return wizardStepsIds.find((wizardStepId) => {
-    if (wizardStepId === minimumStep) {
-      isBeforeMinimumStep = false;
-    }
-    if (isBeforeMinimumStep) {
-      return false;
-    }
-
-    // find first matching validation-map name, ignoring steps before minimumStep
-    const { host: hostValidationMap, cluster: clusterValidationMap } =
-      wizardStepsValidationsMap[wizardStepId];
-
-    return (
-      hostValidationMap.validationIds.includes(validationId as HostValidationId) ||
-      clusterValidationMap.validationIds.includes(validationId as ClusterValidationId)
-    );
-  });
-};

--- a/libs/ui-lib/lib/common/components/clusterWizard/validationsInfoUtils.ts
+++ b/libs/ui-lib/lib/common/components/clusterWizard/validationsInfoUtils.ts
@@ -297,8 +297,14 @@ export const findValidationStep = <ClusterWizardStepsType extends string>(
     if (isBeforeMinimumStep) {
       return false;
     }
+
     // find first matching validation-map name, ignoring steps before minimumStep
-    const { host: hostValidationMap } = wizardStepsValidationsMap[wizardStepId];
-    return hostValidationMap.validationIds.includes(validationId as HostValidationId);
+    const { host: hostValidationMap, cluster: clusterValidationMap } =
+      wizardStepsValidationsMap[wizardStepId];
+
+    return (
+      hostValidationMap.validationIds.includes(validationId as HostValidationId) ||
+      clusterValidationMap.validationIds.includes(validationId as ClusterValidationId)
+    );
   });
 };

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
@@ -116,8 +116,7 @@ const ClusterWizardContextProvider = ({
         locationState,
         staticIpInfo,
         cluster?.status,
-        cluster?.hosts,
-        customManifestsStepNeedsToBeFilled,
+        cluster,
       );
       const firstStepIds = getWizardStepIds(
         wizardStepIds,

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/wizardTransition.ts
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/wizardTransition.ts
@@ -1,5 +1,3 @@
-import uniq from 'lodash-es/uniq';
-
 import {
   Cluster,
   ClusterValidationId,
@@ -7,7 +5,6 @@ import {
   HostValidationId,
 } from '@openshift-assisted/types/assisted-installer-service';
 import {
-  findValidationStep,
   getAllClusterWizardSoftValidationIds,
   getWizardStepClusterStatus,
   WizardStepsValidationMap,
@@ -21,6 +18,8 @@ import {
 } from '../../../common/types/hosts';
 import { getKeys, stringToJSON } from '../../../common/utils';
 import { Validation, ValidationsInfo } from '../../../common';
+
+type ValidationId = ClusterValidationId | HostValidationId;
 
 export type ClusterWizardStepsType =
   | 'cluster-details'
@@ -59,16 +58,6 @@ export const disconnectedSteps: ClusterWizardStepsType[] = [
 export const ClusterWizardFlowStateNew = 'new';
 export type ClusterWizardFlowStateType = Cluster['status'] | typeof ClusterWizardFlowStateNew;
 
-export const getLastStepForWizard = (
-  customManifestsStepNeedsToBeFilled: boolean,
-): ClusterWizardStepsType => {
-  if (customManifestsStepNeedsToBeFilled) {
-    return 'custom-manifests';
-  } else {
-    return 'review';
-  }
-};
-
 export const isStepAfter = (stepA: ClusterWizardStepsType, stepB: ClusterWizardStepsType) => {
   const indexA = wizardStepsOrder.findIndex((step) => step === stepA);
   const indexB = wizardStepsOrder.findIndex((step) => step === stepB);
@@ -103,66 +92,86 @@ export const getClusterWizardFirstStep = (
     case 'pending-for-input':
     case 'adding-hosts':
     case 'insufficient':
-      return getStepForFailingHostValidations(cluster);
+      return getStepForFailingValidations(cluster);
     default:
       return 'cluster-details';
   }
 };
 
-const getStepForFailingHostValidations = (cluster?: Cluster) => {
+const MINIMUM_STEP = 'host-discovery';
+const getStepForFailingValidations = (cluster?: Cluster) => {
   // test host validations first, then cluster validations
-  const failingValidations: (ClusterValidationId | HostValidationId)[] =
-    getHostFailingValidationIds(cluster?.hosts).concat(getClusterFailingValidationIds(cluster));
+  const failingValidations: Set<ValidationId> = new Set<ValidationId>([
+    ...getHostFailingValidationIds(cluster?.hosts),
+    ...getClusterFailingValidationIds(cluster),
+  ]);
 
   let step;
-  const minimumStep = 'host-discovery';
   for (const failingValidationId of failingValidations) {
-    step = findValidationStep<ClusterWizardStepsType>(
-      failingValidationId,
-      wizardStepsValidationsMap,
-      minimumStep,
-    );
+    step = findValidationStep(failingValidationId, wizardStepsValidationsMap);
     if (step !== undefined) {
       break;
     }
   }
-  return step || minimumStep;
+  return step || MINIMUM_STEP;
 };
 
-const getHostFailingValidationIds = (
-  hosts?: Host[],
-): (ClusterValidationId | HostValidationId)[] => {
-  const failingValidations: HostValidationId[] = [];
+const getHostFailingValidationIds = (hosts?: Host[]): Set<ValidationId> => {
+  const failingValidations = new Set<HostValidationId>();
   hosts?.forEach((host) => {
     const validationsInfo = stringToJSON<HostValidationsInfo>(host.validationsInfo) || {};
     getKeys(validationsInfo).forEach((group) => {
       const f: (validation: HostValidation) => void = (validation) => {
         if (validation.status === 'failure') {
-          failingValidations.push(validation.id);
+          failingValidations.add(validation.id);
         }
       };
       const validationGroup = validationsInfo[group] as HostValidation[];
       validationGroup.forEach(f);
     });
   });
-  return uniq(failingValidations);
+  return failingValidations;
 };
 
-const getClusterFailingValidationIds = (
-  cluster?: Cluster,
-): (ClusterValidationId | HostValidationId)[] => {
-  const failingValidations: ClusterValidationId[] = [];
+const getClusterFailingValidationIds = (cluster?: Cluster): Set<ValidationId> => {
+  const failingValidations = new Set<ValidationId>();
   const validationsInfo = stringToJSON<ValidationsInfo>(cluster?.validationsInfo) || {};
+
   getKeys(validationsInfo).forEach((group) => {
     const f: (validation: Validation) => void = (validation) => {
       if (validation.status === 'failure') {
-        failingValidations.push(validation.id);
+        failingValidations.add(validation.id);
       }
     };
     const validationGroup = validationsInfo[group] as Validation[];
     validationGroup.forEach(f);
   });
-  return uniq(failingValidations);
+  return failingValidations;
+};
+
+const findValidationStep = (
+  validationId: ValidationId,
+  wizardStepsValidationsMap: WizardStepsValidationMap<ClusterWizardStepsType>,
+): ClusterWizardStepsType | undefined => {
+  let isBeforeMinimumStep = true;
+
+  return wizardStepsOrder.find((wizardStepId) => {
+    if (wizardStepId === MINIMUM_STEP) {
+      isBeforeMinimumStep = false;
+    }
+    if (isBeforeMinimumStep) {
+      return false;
+    }
+
+    // find first matching validation-map name, ignoring steps before minimumStep
+    const { host: hostValidationMap, cluster: clusterValidationMap } =
+      wizardStepsValidationsMap[wizardStepId];
+
+    return (
+      hostValidationMap.validationIds.includes(validationId as HostValidationId) ||
+      clusterValidationMap.validationIds.includes(validationId as ClusterValidationId)
+    );
+  });
 };
 
 type TransitionProps = { cluster: Cluster };

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/wizardTransition.ts
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/wizardTransition.ts
@@ -1,3 +1,11 @@
+import uniq from 'lodash-es/uniq';
+
+import {
+  Cluster,
+  ClusterValidationId,
+  Host,
+  HostValidationId,
+} from '@openshift-assisted/types/assisted-installer-service';
 import {
   findValidationStep,
   getAllClusterWizardSoftValidationIds,
@@ -12,11 +20,7 @@ import {
   Validation as HostValidation,
 } from '../../../common/types/hosts';
 import { getKeys, stringToJSON } from '../../../common/utils';
-import {
-  Cluster,
-  Host,
-  HostValidationId,
-} from '@openshift-assisted/types/assisted-installer-service';
+import { Validation, ValidationsInfo } from '../../../common';
 
 export type ClusterWizardStepsType =
   | 'cluster-details'
@@ -79,8 +83,7 @@ export const getClusterWizardFirstStep = (
   locationState: ClusterWizardFlowStateType | undefined,
   staticIpInfo: StaticIpInfo | undefined,
   state?: ClusterWizardFlowStateType,
-  hosts?: Host[] | undefined,
-  customManifestsStepNeedsToBeFilled?: boolean,
+  cluster?: Cluster,
 ): ClusterWizardStepsType => {
   // Just for the first time when the cluster is created
   if (locationState === ClusterWizardFlowStateNew && !staticIpInfo) {
@@ -96,33 +99,39 @@ export const getClusterWizardFirstStep = (
 
   switch (state) {
     case 'ready':
-      return getLastStepForWizard(customManifestsStepNeedsToBeFilled || false);
+      return 'review';
     case 'pending-for-input':
     case 'adding-hosts':
     case 'insufficient':
-      if (customManifestsStepNeedsToBeFilled) {
-        return 'custom-manifests';
-      }
-      return getStepForFailingHostValidations(hosts);
+      return getStepForFailingHostValidations(cluster);
     default:
       return 'cluster-details';
   }
 };
 
-const getStepForFailingHostValidations = (hosts: Host[] | undefined) => {
-  const failingValidations: HostValidationId[] = getHostFailingValidationIds(hosts);
-  const minimumStep = 'host-discovery';
+const getStepForFailingHostValidations = (cluster?: Cluster) => {
+  // test host validations first, then cluster validations
+  const failingValidations: (ClusterValidationId | HostValidationId)[] =
+    getHostFailingValidationIds(cluster?.hosts).concat(getClusterFailingValidationIds(cluster));
+
   let step;
+  const minimumStep = 'host-discovery';
   for (const failingValidationId of failingValidations) {
-    step = findValidationStep<string>(failingValidationId, wizardStepsValidationsMap, minimumStep);
+    step = findValidationStep<ClusterWizardStepsType>(
+      failingValidationId,
+      wizardStepsValidationsMap,
+      minimumStep,
+    );
     if (step !== undefined) {
       break;
     }
   }
-  return (step || minimumStep) as ClusterWizardStepsType;
+  return step || minimumStep;
 };
 
-const getHostFailingValidationIds = (hosts: Host[] | undefined) => {
+const getHostFailingValidationIds = (
+  hosts?: Host[],
+): (ClusterValidationId | HostValidationId)[] => {
   const failingValidations: HostValidationId[] = [];
   hosts?.forEach((host) => {
     const validationsInfo = stringToJSON<HostValidationsInfo>(host.validationsInfo) || {};
@@ -136,7 +145,24 @@ const getHostFailingValidationIds = (hosts: Host[] | undefined) => {
       validationGroup.forEach(f);
     });
   });
-  return failingValidations;
+  return uniq(failingValidations);
+};
+
+const getClusterFailingValidationIds = (
+  cluster?: Cluster,
+): (ClusterValidationId | HostValidationId)[] => {
+  const failingValidations: ClusterValidationId[] = [];
+  const validationsInfo = stringToJSON<ValidationsInfo>(cluster?.validationsInfo) || {};
+  getKeys(validationsInfo).forEach((group) => {
+    const f: (validation: Validation) => void = (validation) => {
+      if (validation.status === 'failure') {
+        failingValidations.push(validation.id);
+      }
+    };
+    const validationGroup = validationsInfo[group] as Validation[];
+    validationGroup.forEach(f);
+  });
+  return uniq(failingValidations);
 };
 
 type TransitionProps = { cluster: Cluster };
@@ -190,6 +216,7 @@ const hostDiscoveryStepValidationsMap: WizardStepValidationMap = {
     groups: ['hardware'],
     validationIds: [
       'connected',
+      'hostname-valid',
       'media-connected',
       'lso-requirements-satisfied',
       'odf-requirements-satisfied',
@@ -230,12 +257,18 @@ const storageStepValidationsMap: WizardStepValidationMap = {
 const networkingStepValidationsMap: WizardStepValidationMap = {
   cluster: {
     groups: ['network'],
-    validationIds: [],
+    validationIds: [
+      'api-vips-defined',
+      'machine-cidr-defined',
+      'cluster-cidr-defined',
+      'service-cidr-defined',
+      'all-hosts-are-ready-to-install',
+    ],
   },
   host: {
     allowedStatuses: ['known', 'disabled'],
     groups: ['network'],
-    validationIds: [],
+    validationIds: ['apps-domain-name-resolved-correctly'],
   },
   // TODO(jtomasek): container-images-available validation is currently not running on the backend, it stays in pending.
   // marking it as soft validation is the easy way to prevent it from blocking the progress.
@@ -248,6 +281,19 @@ const networkingStepValidationsMap: WizardStepValidationMap = {
     'mtu-valid',
     'custom-manifests-requirements-satisfied',
   ],
+};
+
+const customManifestsValidationsMap: WizardStepValidationMap = {
+  cluster: {
+    groups: ['network'],
+    validationIds: ['platform-requirements-satisfied', 'custom-manifests-requirements-satisfied'],
+  },
+  host: {
+    allowedStatuses: ['known', 'disabled'],
+    groups: ['network'],
+    validationIds: [],
+  },
+  softValidationIds: ['ntp-synced', 'container-images-available', 'mtu-valid'],
 };
 
 const reviewStepValidationsMap: WizardStepValidationMap = {
@@ -265,7 +311,6 @@ const reviewStepValidationsMap: WizardStepValidationMap = {
 
 const credentialsValidationMap = buildEmptyValidationsMap();
 
-const customManifestsValidationsMap = buildEmptyValidationsMap();
 const disconnectedReviewValidationsMap = buildEmptyValidationsMap();
 const disconnectedBasicValidationsMap = buildEmptyValidationsMap();
 
@@ -274,13 +319,13 @@ export const wizardStepsValidationsMap: WizardStepsValidationMap<ClusterWizardSt
   'static-ip-yaml-view': staticIpValidationsMap,
   'static-ip-network-wide-configurations': staticIpValidationsMap,
   'static-ip-host-configurations': staticIpValidationsMap,
-  'custom-manifests': customManifestsValidationsMap,
   operators: operatorsStepValidationsMap,
   'host-discovery': hostDiscoveryStepValidationsMap,
   storage: storageStepValidationsMap,
   networking: networkingStepValidationsMap,
-  review: reviewStepValidationsMap,
+  'custom-manifests': customManifestsValidationsMap,
   'credentials-download': credentialsValidationMap,
+  review: reviewStepValidationsMap,
   'disconnected-review': disconnectedReviewValidationsMap,
   'disconnected-basic': disconnectedBasicValidationsMap,
 };


### PR DESCRIPTION
https://redhat.atlassian.net/browse/MGMT-24099

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Simplified cluster wizard initial-step routing for more consistent landing (better handling of cluster- and host-level validations).
  * Updated validation coverage to include hostname, API VIPs, and additional network-related soft checks (NTP sync, container images, MTU), improving issue visibility without unnecessarily blocking progress.
  * Custom manifests now correctly influence whether users stay on Review or enter the Custom Manifests step.

* **Tests**
  * End-to-end tests updated to start at explicit wizard steps and assert current step for more stable, focused flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openshift-assisted/assisted-installer-ui/pull/3739?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->