### PR TITLE
OCPBUGS-86187: Remove Arbiter button

### DIFF
--- a/libs/ui-lib/lib/common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionControlGroup.tsx
+++ b/libs/ui-lib/lib/common/components/clusterConfiguration/DiskEncryptionFields/DiskEncryptionControlGroup.tsx
@@ -29,6 +29,7 @@ const hasFilledTangServers = (tangServers: TangServer[]): boolean => {
 export interface DiskEncryptionControlGroupProps {
   values: DiskEncryptionValues;
   isSNO: boolean;
+  isArbiterEncryptionAvailable?: boolean;
   isDisabled?: boolean;
   docVersion?: string;
 }
@@ -36,6 +37,7 @@ export interface DiskEncryptionControlGroupProps {
 const DiskEncryptionControlGroup = ({
   values,
   isSNO = false,
+  isArbiterEncryptionAvailable = true,
   isDisabled = false,
   docVersion,
 }: DiskEncryptionControlGroupProps) => {
@@ -77,6 +79,12 @@ const DiskEncryptionControlGroup = ({
       setFieldValue('enableDiskEncryptionOnWorkers', false);
     }
   }, [isSNO, setFieldValue]);
+
+  React.useEffect(() => {
+    if (!isArbiterEncryptionAvailable) {
+      setFieldValue('enableDiskEncryptionOnArbiters', false);
+    }
+  }, [isArbiterEncryptionAvailable, setFieldValue]);
   const { t } = useTranslation();
   const disableMessage = t('ai:This option is not editable after the draft cluster is created');
   const tooltipProps = {
@@ -105,14 +113,16 @@ const DiskEncryptionControlGroup = ({
             />
           </StackItem>
         </RenderIf>
-        <StackItem>
-          <SwitchField
-            tooltipProps={tooltipProps}
-            name="enableDiskEncryptionOnArbiters"
-            label={t('ai:Arbiter')}
-            isDisabled={isDisabled}
-          />
-        </StackItem>
+        <RenderIf condition={isArbiterEncryptionAvailable}>
+          <StackItem>
+            <SwitchField
+              tooltipProps={tooltipProps}
+              name="enableDiskEncryptionOnArbiters"
+              label={t('ai:Arbiter')}
+              isDisabled={isDisabled}
+            />
+          </StackItem>
+        </RenderIf>
         <RenderIf
           condition={
             enableDiskEncryptionOnMasters ||

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmClusterDetailsFormFields.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import * as React from 'react';
 import { Form } from '@patternfly/react-core';
 import { useFormikContext } from 'formik';
@@ -40,6 +39,7 @@ import ControlPlaneNodesDropdown, {
   DEFAULT_VALUE_CPN,
   isCPNDropdownItemEnabled,
 } from './ControlPlaneNodesDropdown';
+import { isFeatureSupportedAndAvailable } from '../featureSupportLevels/featureStateUtils';
 
 export type OcmClusterDetailsFormFieldsProps = {
   cluster?: Cluster;
@@ -79,6 +79,13 @@ export const OcmClusterDetailsFormFields = ({
     architectureData[values.cpuArchitecture as SupportedCpuArchitecture].label;
 
   const featureSupportLevelContext = useNewFeatureSupportLevel();
+  const tnaSupport = featureSupportLevelContext.getFeatureSupportLevel(
+    'TNA',
+    featureSupportLevelData ?? undefined,
+  );
+  const isArbiterEncryptionAvailable = isSingleClusterFeatureEnabled
+    ? false
+    : isFeatureSupportedAndAvailable(tnaSupport);
 
   React.useEffect(() => {
     nameInputRef.current?.focus();
@@ -223,6 +230,7 @@ export const OcmClusterDetailsFormFields = ({
         values={values}
         isDisabled={cluster?.pullSecretSet}
         isSNO={values.controlPlaneCount === 1}
+        isArbiterEncryptionAvailable={isArbiterEncryptionAvailable}
         docVersion={openshiftVersion}
       />
     </Form>


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-86187

<img width="1895" height="935" alt="image" src="https://github.com/user-attachments/assets/24706d61-7785-4a35-a153-e4331a9dd23e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Arbiter disk encryption is now hidden and automatically turned off when the cluster or feature set doesn't support it, preventing invalid configurations.
  * Cluster details form now evaluates feature availability and only shows the arbiter encryption option when applicable, ensuring UI and form state remain consistent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openshift-assisted/assisted-installer-ui/pull/3744?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->