### PR TITLE
Revert "OCPBUGS-84038 | [Below the sea UI] Lack of visual feedback (spinner) on disabled "Next" button during background validation"

### DIFF
--- a/libs/locales/lib/en/translation.json
+++ b/libs/locales/lib/en/translation.json
@@ -1013,7 +1013,6 @@
   "ai:Vsphere disk uuid enabled": "Vsphere disk uuid enabled",
   "ai:Waiting for host..._one": "Waiting for host...",
   "ai:Waiting for host..._other": "Waiting for hosts...",
-  "ai:Waiting for hosts to be ready...": "Waiting for hosts to be ready...",
   "ai:Waiting for hosts...": "Waiting for hosts...",
   "ai:Warning": "Warning",
   "ai:Web Console URL": "Web Console URL",

--- a/libs/ui-lib/lib/common/components/hosts/HostsTable.tsx
+++ b/libs/ui-lib/lib/common/components/hosts/HostsTable.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Spinner } from '@patternfly/react-core';
 import { ConnectedIcon } from '@patternfly/react-icons/dist/js/icons/connected-icon';
 import { HostsNotShowingLink, HostsNotShowingLinkProps } from '../clusterConfiguration';
 import { Host } from '@openshift-assisted/types/assisted-installer-service';
@@ -30,7 +29,6 @@ export const HostsTableEmptyState = ({
       icon={ConnectedIcon}
       title={t('ai:Waiting for host...', { count: +isSNO })}
       content={t('ai:Hosts may take a few minutes to appear here after booting.')}
-      primaryAction={<Spinner size="xl" />}
       secondaryActions={
         setDiscoveryHintModalOpen && [
           <HostsNotShowingLink

--- a/libs/ui-lib/lib/common/components/ui/WizardFooter.tsx
+++ b/libs/ui-lib/lib/common/components/ui/WizardFooter.tsx
@@ -27,7 +27,6 @@ export type WizardFooterGenericProps = {
   submittingText?: string;
   nextButtonText?: string;
   isNextButtonLoading?: boolean;
-  isWaitingForHosts?: boolean;
 };
 
 type WizardFooterProps = WizardFooterGenericProps & {
@@ -54,7 +53,6 @@ export const WizardFooter: React.FC<WizardFooterProps> = ({
   cluster,
   onFetchEvents,
   isNextButtonLoading,
-  isWaitingForHosts,
 }) => {
   const { t } = useTranslation();
   submittingText = submittingText || t('ai:Saving changes...');
@@ -118,14 +116,6 @@ export const WizardFooter: React.FC<WizardFooterProps> = ({
             <ActionListItem>
               <Content component={ContentVariants.small}>
                 <Spinner size="sm" data-testid="wizard-footer-spinner" /> {submittingText}
-              </Content>
-            </ActionListItem>
-          )}
-          {isWaitingForHosts && !isSubmitting && (
-            <ActionListItem>
-              <Content component={ContentVariants.small}>
-                <Spinner size="sm" data-testid="wizard-footer-hosts-spinner" />{' '}
-                {t('ai:Waiting for hosts to be ready...')}
               </Content>
             </ActionListItem>
           )}

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
@@ -113,20 +113,18 @@ const NetworkConfigurationForm: React.FC<{
     clusterWizardContext.moveNext();
   }, [addAlert, cluster.id, clusterWizardContext, dispatch, isSingleClusterFeatureEnabled]);
 
-  const isNextDisabled =
-    isSubmitting ||
-    isAutoSaveRunning ||
-    !!alerts.length ||
-    !isValid ||
-    !canNextNetwork({ cluster });
-
   const footer = (
     <ClusterWizardFooter
       cluster={cluster}
       errorFields={errorFields}
       isSubmitting={isSubmitting}
-      isNextDisabled={isNextDisabled}
-      isWaitingForHosts={!canNextNetwork({ cluster })}
+      isNextDisabled={
+        isSubmitting ||
+        isAutoSaveRunning ||
+        !!alerts.length ||
+        !isValid ||
+        !canNextNetwork({ cluster })
+      }
       onNext={() => void onNext()}
       onBack={() => clusterWizardContext.moveBack()}
       isBackDisabled={isSubmitting || isAutoSaveRunning}

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/HostDiscovery.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/HostDiscovery.tsx
@@ -32,7 +32,6 @@ const HostDiscoveryForm = ({ cluster }: { cluster: Cluster }) => {
   const errorFields = getFormikErrorFields(errors, touched);
   const isBinding = useLateBinding(cluster);
 
-  const hasHosts = (cluster.hosts?.length ?? 0) > 0;
   const isNextDisabled =
     !isValid ||
     !!alerts.length ||
@@ -41,15 +40,12 @@ const HostDiscoveryForm = ({ cluster }: { cluster: Cluster }) => {
     isBinding ||
     !canNextHostDiscovery({ cluster });
 
-  const isWaitingForHosts = hasHosts && (isBinding || !canNextHostDiscovery({ cluster }));
-
   const footer = (
     <ClusterWizardFooter
       cluster={cluster}
       errorFields={errorFields}
       isSubmitting={isSubmitting}
       isNextDisabled={isNextDisabled}
-      isWaitingForHosts={isWaitingForHosts}
       onNext={() => clusterWizardContext.moveNext()}
       onBack={() => clusterWizardContext.moveBack()}
       isBackDisabled={isSubmitting || isAutoSaveRunning}

--- a/libs/ui-lib/lib/ocm/components/hosts/HostsTableEmptyState.tsx
+++ b/libs/ui-lib/lib/ocm/components/hosts/HostsTableEmptyState.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Spinner } from '@patternfly/react-core';
 import { ConnectedIcon } from '@patternfly/react-icons/dist/js/icons/connected-icon';
 import EmptyState from '../../../common/components/ui/uiState/EmptyState';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
@@ -17,7 +16,6 @@ const HostsTableEmptyState = ({ isSingleNode = false }: HostsTableEmptyStateProp
       icon={ConnectedIcon}
       title={t('ai:Waiting for host...', { count: isSingleNode ? 1 : 2 })}
       content={t('ai:Hosts may take a few minutes to appear here after booting.')}
-      primaryAction={<Spinner size="xl" />}
       secondaryActions={[
         <HostsDiscoveryTroubleshootingInfoLinkWithModal key={'hosts-not-showing'} />,
       ]}


### PR DESCRIPTION
Reverts openshift-assisted/assisted-installer-ui#3687

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the hosts waiting state UI by removing the loading spinner component for a cleaner interface.
  * Updated "Waiting for hosts" message text for improved clarity.
  * Streamlined form footer and wizard state management logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/openshift-assisted/assisted-installer-ui/pull/3757?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->