### PR TITLE
OCPBUGS-72598: Custom manifests are broken in local assisted UI

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/manifestsConfiguration/CustomManifestsPage.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/manifestsConfiguration/CustomManifestsPage.tsx
@@ -22,6 +22,7 @@ import { getFieldId } from '../../../../common/components/ui/formik';
 import { isOciPlatformType } from '../../utils';
 import DeleteCustomManifestModal from './DeleteCustomManifestModal';
 import { ClustersService } from '../../../services';
+import { userProvidedManifests } from './components/utils';
 import { useClusterWizardContext } from '../../clusterWizard/ClusterWizardContext';
 
 export const CustomManifestsPage = ({
@@ -77,7 +78,13 @@ export const CustomManifestsPage = ({
   const cleanCustomManifests = React.useCallback(async () => {
     if (!clusterWizardContext.uiSettings?.customManifestsAdded || !cluster.id) return;
     const { data: manifests } = await ClustersAPI.getManifests(cluster.id);
-    await ClustersService.removeClusterManifests(manifests, cluster.id);
+    const manifestsToRemove = userProvidedManifests(manifests).map((manifest) => ({
+      ...manifest,
+      folder: manifest.folder || 'manifests',
+      fileName: manifest.fileName || '',
+      yamlContent: '',
+    }));
+    await ClustersService.removeClusterManifests(manifestsToRemove, cluster.id);
     setUseCustomManifests(false);
     setDeleteModalOpen(false);
     await clusterWizardContext.updateUISettings({

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/manifestsConfiguration/components/CustomManifestsForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/manifestsConfiguration/components/CustomManifestsForm.tsx
@@ -23,6 +23,7 @@ import { CustomManifestValues, ManifestFormData } from '../data/dataTypes';
 import useClusterCustomManifests from '../../../../hooks/useClusterCustomManifests';
 import { ClustersService } from '../../../../services';
 import { CustomManifestsArray } from './CustomManifestsArray';
+import { userProvidedManifests } from './utils';
 import { selectCurrentClusterPermissionsState } from '../../../../store/slices/current-cluster/selectors';
 import { useClusterWizardContext } from '../../../clusterWizard/ClusterWizardContext';
 import { ClustersAPI } from '../../../../services/apis';
@@ -70,7 +71,8 @@ export const CustomManifestsForm = ({
     if (customManifests && !customManifestsLocalRef.current.length) {
       const initValues = getInitialValues(customManifests);
       setInitialValues(initValues);
-      customManifestsLocalRef.current = !!customManifests.length ? initValues.manifests : [];
+      customManifestsLocalRef.current =
+        userProvidedManifests(customManifests).length > 0 ? initValues.manifests : [];
     }
   }, [customManifests, getInitialValues]);
 

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/manifestsConfiguration/components/utils.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/manifestsConfiguration/components/utils.tsx
@@ -1,5 +1,10 @@
 import { CustomManifestValues, ListManifestsExtended, ManifestFormData } from '../data/dataTypes';
 
+/** Manifests created by the installer (e.g. OVE defaults); not editable in the wizard. */
+export const userProvidedManifests = <T extends { manifestSource?: string }>(
+  manifests: T[] | undefined,
+): T[] => (manifests ?? []).filter((m) => m.manifestSource !== 'system');
+
 export const getManifestName = (manifestIdx: number) => `Custom manifest ${manifestIdx + 1}`;
 
 export const getFormData = (manifests: ListManifestsExtended): ManifestFormData => {
@@ -18,11 +23,11 @@ export const getEmptyManifest = (): CustomManifestValues => {
 };
 
 export const getManifestValues = (manifests: ListManifestsExtended): ManifestFormData => {
-  if (!!manifests.length) {
-    return getFormData(manifests);
-  } else {
-    return getEmptyManifestsValues();
+  const userManifests = userProvidedManifests(manifests);
+  if (userManifests.length > 0) {
+    return getFormData(userManifests);
   }
+  return getEmptyManifestsValues();
 };
 
 export const getEmptyManifestsValues = (): ManifestFormData => {
@@ -32,8 +37,9 @@ export const getEmptyManifestsValues = (): ManifestFormData => {
 export const getClusterCustomManifests = (
   customManifests: ListManifestsExtended,
 ): CustomManifestValues[] => {
-  if (customManifests && customManifests.length > 0) {
-    return customManifests.map((manifest) => ({
+  const userManifests = userProvidedManifests(customManifests);
+  if (userManifests.length > 0) {
+    return userManifests.map((manifest) => ({
       folder: manifest.folder || 'manifests',
       filename: manifest.fileName || '',
       manifestYaml: manifest.yamlContent || '',

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewSummary.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewSummary.tsx
@@ -19,10 +19,7 @@ import { ReviewCustomManifestsTable } from './ReviewCustomManifestsTable';
 import PlatformIntegrationNote from '../platformIntegration/PlatformIntegrationNote';
 import useClusterCustomManifests from '../../../hooks/useClusterCustomManifests';
 import { Cluster } from '@openshift-assisted/types/assisted-installer-service';
-import { ListManifestsExtended } from '../manifestsConfiguration/data/dataTypes';
-
-const userProvidedManifests = (manifests: ListManifestsExtended | undefined) =>
-  (manifests ?? []).filter((m) => m.manifestSource !== 'system');
+import { userProvidedManifests } from '../manifestsConfiguration/components/utils';
 
 export const ReviewSummaryContent = ({ cluster }: { cluster: Cluster }) => {
   const { customManifests } = useClusterCustomManifests(cluster.id, false);

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
@@ -66,7 +66,7 @@ const getWizardStepIds = (
     stepsCopy = removeStepFromClusterWizard(stepsCopy, 'static-ip-network-wide-configurations', 2);
   }
 
-  if (isSingleClusterFeatureEnabled) {
+  if (isSingleClusterFeatureEnabled && !stepsCopy.includes('credentials-download')) {
     stepsCopy = addStepToClusterWizard(stepsCopy, 'custom-manifests', ['credentials-download']);
   }
 
@@ -122,7 +122,6 @@ const ClusterWizardContextProvider = ({
       const firstStepIds = getWizardStepIds(
         wizardStepIds,
         staticIpInfo?.view,
-
         isSingleClusterFeatureEnabled,
       );
 
@@ -150,7 +149,7 @@ const ClusterWizardContextProvider = ({
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [uiSettings, UISettingsLoading, UISettingsError]);
+  }, [uiSettings, UISettingsLoading, UISettingsError, isSingleClusterFeatureEnabled]);
 
   const contextValue = React.useMemo<ClusterWizardContextType | null>(() => {
     if (!wizardStepIds || !currentStepId) {
@@ -167,7 +166,6 @@ const ClusterWizardContextProvider = ({
       const newStepIds = getWizardStepIds(
         wizardStepIds,
         staticIpInfo.view,
-
         isSingleClusterFeatureEnabled,
       );
       setWizardStepIds(newStepIds);
@@ -207,12 +205,7 @@ const ClusterWizardContextProvider = ({
       onUpdateHostNetworkConfigType(type: HostsNetworkConfigurationType): void {
         if (type === HostsNetworkConfigurationType.STATIC) {
           setWizardStepIds(
-            getWizardStepIds(
-              wizardStepIds,
-              StaticIpView.FORM,
-
-              isSingleClusterFeatureEnabled,
-            ),
+            getWizardStepIds(wizardStepIds, StaticIpView.FORM, isSingleClusterFeatureEnabled),
           );
         } else {
           setWizardStepIds(

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
@@ -67,7 +67,7 @@ const getWizardStepIds = (
   }
 
   if (isSingleClusterFeatureEnabled) {
-    stepsCopy = addStepToClusterWizard(stepsCopy, 'networking', ['credentials-download']);
+    stepsCopy = addStepToClusterWizard(stepsCopy, 'custom-manifests', ['credentials-download']);
   }
 
   return stepsCopy;


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-72598



fixes the issues  mentioned in the comments section, because the main issue in the ticket was already fixed by a different pr in the past.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed custom manifest deletion to properly filter user-provided manifests from system manifests.
  * Improved manifest form initialization to correctly identify user-provided manifests.
  * Corrected cluster wizard step sequence for custom manifest workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->