### PR TITLE
MGMT-23172: Improve the UX of the operators tab

### DIFF
--- a/libs/types/assisted-installer-service.d.ts
+++ b/libs/types/assisted-installer-service.d.ts
@@ -103,9 +103,23 @@ export interface Bundle {
    */
   description?: string;
   /**
-   * List of operators associated with the bundle.
+   * List of operators always included in the bundle.
    */
   operators?: string[];
+  /**
+   * List of operators that can be optionally selected by the user for this bundle. All are selected by default.
+   */
+  optionalOperators?: string[];
+}
+export interface BundleCreateParams {
+  /**
+   * Bundle identifier (e.g., "openshift-ai").
+   */
+  id: string;
+  /**
+   * List of optional operator names the user selected for this bundle.
+   */
+  optionalOperators?: string[];
 }
 export interface Cluster {
   /**
@@ -333,9 +347,17 @@ export interface Cluster {
    */
   additionalNtpSource?: string;
   /**
+   * A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for the cluster hosts.
+   */
+  ntpSources?: string;
+  /**
    * Operators that are associated with this cluster.
    */
   monitoredOperators?: MonitoredOperator[];
+  /**
+   * Bundles that were selected for this cluster, with the optional operators chosen by the user. Derived from monitored operators' sourceBundles. Not persisted directly.
+   */
+  operatorBundles?: BundleCreateParams[];
   /**
    * Unique identifier of the AMS subscription in OCM.
    */
@@ -494,11 +516,22 @@ export interface ClusterCreateParams {
    */
   additionalNtpSource?: string;
   /**
-   * List of OLM operators to be installed.
+   * A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for the cluster hosts.
+   */
+  ntpSources?: string;
+  /**
+   * List of standalone OLM operators to be installed (not part of any bundle).
    * For the full list of supported operators, check the endpoint `/v2/supported-operators`:
    *
    */
   olmOperators?: OperatorCreateParams[];
+  /**
+   * List of operator bundles selected by the user with their optional operator choices.
+   * The backend expands bundles into their required operators, adds selected optional operators,
+   * resolves all dependencies, and tracks bundle membership via sourceBundles on monitored operators.
+   *
+   */
+  operatorBundles?: BundleCreateParams[];
   /**
    * Enable/disable hyperthreading on master nodes, arbiter nodes, worker nodes, or a combination of them.
    */
@@ -2366,6 +2399,10 @@ export interface MonitoredOperator {
    * Whether the operator can't be installed without being required by another operator.
    */
   dependencyOnly?: boolean;
+  /**
+   * IDs of the bundles this operator was selected through. Empty for standalone selections. An operator can belong to multiple bundles.
+   */
+  sourceBundles?: string[];
 }
 export type MonitoredOperatorsList = MonitoredOperator[];
 export interface MtuReport {
@@ -2935,11 +2972,22 @@ export interface V2ClusterUpdateParams {
    */
   additionalNtpSource?: string;
   /**
-   * List of OLM operators to be installed.
+   * A comma-separated list of NTP sources (name or IP) to be used as the only NTP configuration for the cluster hosts.
+   */
+  ntpSources?: string;
+  /**
+   * List of standalone OLM operators to be installed (not part of any bundle).
    * For the full list of supported operators, check the endpoint `/v2/supported-operators`:
    *
    */
   olmOperators?: OperatorCreateParams[];
+  /**
+   * List of operator bundles selected by the user with their optional operator choices.
+   * The backend expands bundles into their required operators, adds selected optional operators,
+   * resolves all dependencies, and tracks bundle membership via sourceBundles on monitored operators.
+   *
+   */
+  operatorBundles?: BundleCreateParams[];
   /**
    * Enable/disable hyperthreading on master nodes, arbiter nodes, worker nodes, or a combination of them.
    */

--- a/libs/ui-lib/lib/common/components/clusterWizard/ReviewValidations.tsx
+++ b/libs/ui-lib/lib/common/components/clusterWizard/ReviewValidations.tsx
@@ -47,6 +47,20 @@ const PendingValidations = ({ id, count }: { id: string; count: number }) => {
   return <div id={id}>{t('ai:There is still {{count}} pending check', { count: count })}</div>;
 };
 
+const InformationalValidation = ({ validation }: { validation: ClusterValidation }) => {
+  const { t } = useTranslation();
+  const label = clusterValidationLabels(t)[validation.id] || validation.id || '';
+
+  return (
+    <div id={`info-validation-${validation.id}`}>
+      <Icon status="success">
+        <CheckCircleIcon />
+      </Icon>{' '}
+      {label}. {validation.message}
+    </div>
+  );
+};
+
 const ValidationActionLink = <S extends string>({
   step,
   setCurrentStepId,
@@ -171,6 +185,16 @@ export const ClusterValidations = <S extends string>({
             wizardStepNames={wizardStepNames}
             wizardStepsValidationsMap={wizardStepsValidationsMap}
           />,
+        );
+      }
+
+      if (
+        validation.status === 'success' &&
+        validation.id === 'openshift-ai-gpu-requirements-satisfied' &&
+        validation.message
+      ) {
+        failingValidations.push(
+          <InformationalValidation key={`info-${validation.id}`} validation={validation} />,
         );
       }
     };

--- a/libs/ui-lib/lib/common/types/clusters.ts
+++ b/libs/ui-lib/lib/common/types/clusters.ts
@@ -1,5 +1,6 @@
 import { IRow } from '@patternfly/react-table';
 import {
+  BundleCreateParams,
   Cluster,
   V2ClusterUpdateParams,
   ClusterValidationId,
@@ -57,8 +58,11 @@ export type HostDiscoveryValues = V2ClusterUpdateParams & {
 export type StorageValues = V2ClusterUpdateParams & {
   nodeLabeling: string;
 };
+
+export type SelectedBundle = BundleCreateParams;
+
 export type OperatorsValues = {
-  selectedBundles: string[];
+  selectedBundles: SelectedBundle[];
   selectedOperators: string[];
 };
 

--- a/libs/ui-lib/lib/common/types/clusters.ts
+++ b/libs/ui-lib/lib/common/types/clusters.ts
@@ -59,10 +59,8 @@ export type StorageValues = V2ClusterUpdateParams & {
   nodeLabeling: string;
 };
 
-export type SelectedBundle = BundleCreateParams;
-
 export type OperatorsValues = {
-  selectedBundles: SelectedBundle[];
+  selectedBundles: BundleCreateParams[];
   selectedOperators: string[];
 };
 

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OperatorCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OperatorCheckbox.tsx
@@ -136,9 +136,14 @@ const OperatorCheckbox = ({
   const fieldId = getFieldId(operatorId, 'input');
   const supportLevel = getFeatureSupportLevel(featureId);
 
-  const isInBundle = values.selectedBundles.some(
-    (sb) => !!bundles.find((b) => b.id === sb)?.operators?.includes(operatorId),
+  const isRequiredByBundle = values.selectedBundles.some(
+    (selectedBundle) =>
+      !!bundles.find((bundle) => bundle.id === selectedBundle.id)?.operators?.includes(operatorId),
   );
+  const isSelectedForBundle = values.selectedBundles.some((selectedBundle) =>
+    selectedBundle.optionalOperators?.includes(operatorId),
+  );
+  const isInBundle = isRequiredByBundle || isSelectedForBundle;
 
   const isChecked = values.selectedOperators.includes(operatorId) || isInBundle;
 
@@ -154,8 +159,10 @@ const OperatorCheckbox = ({
     parentOperatorName = opSpecs[parentOperator.operatorName]?.title || parentOperator.operatorName;
   }
 
-  const disabledReason = isInBundle
-    ? 'This operator is part of a bundle and cannot be deselected.'
+  const disabledReason = isRequiredByBundle
+    ? 'This operator is part of a selected bundle and cannot be deselected.'
+    : isSelectedForBundle
+    ? 'This optional operator is selected through a bundle. Use the bundle card to change it.'
     : notStandalone
     ? 'This operator cannot be installed as a standalone'
     : parentOperatorName

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OperatorCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OperatorCheckbox.tsx
@@ -145,29 +145,42 @@ const OperatorCheckbox = ({
   );
   const isInBundle = isRequiredByBundle || isSelectedForBundle;
 
+  const isOperatorActive = (opName: string) =>
+    values.selectedOperators.includes(opName) ||
+    values.selectedBundles.some((selectedBundle) => {
+      const bundle = bundles.find(({ id }) => id === selectedBundle.id);
+      return (
+        bundle?.operators?.includes(opName) || selectedBundle.optionalOperators?.includes(opName)
+      );
+    });
+
   const isChecked = values.selectedOperators.includes(operatorId) || isInBundle;
 
-  const parentOperator = preflightRequirements?.operators?.find((op) =>
-    op.dependencies?.includes(operatorId),
+  const parentOperator = preflightRequirements?.operators?.find(
+    (op) =>
+      !!op.operatorName &&
+      op.dependencies?.includes(operatorId) &&
+      isOperatorActive(op.operatorName),
   );
 
-  let parentOperatorName = '';
-  if (
-    parentOperator?.operatorName &&
-    values.selectedOperators.includes(parentOperator.operatorName)
-  ) {
-    parentOperatorName = opSpecs[parentOperator.operatorName]?.title || parentOperator.operatorName;
+  let requiredByOperatorName = '';
+  if (parentOperator?.operatorName) {
+    requiredByOperatorName =
+      opSpecs[parentOperator.operatorName]?.title || parentOperator.operatorName;
   }
 
-  const disabledReason = isRequiredByBundle
-    ? 'This operator is part of a selected bundle and cannot be deselected.'
-    : isSelectedForBundle
-    ? 'This optional operator is selected through a bundle. Use the bundle card to change it.'
-    : notStandalone
-    ? 'This operator cannot be installed as a standalone'
-    : parentOperatorName
-    ? `This operator is a dependency of ${parentOperatorName}`
-    : getFeatureDisabledReason(featureId);
+  let disabledReason = getFeatureDisabledReason(featureId);
+
+  if (isRequiredByBundle) {
+    disabledReason = 'This operator is part of a selected bundle and cannot be deselected.';
+  } else if (isSelectedForBundle) {
+    disabledReason =
+      'This optional operator is selected through a bundle. Use the bundle card to change it.';
+  } else if (requiredByOperatorName) {
+    disabledReason = `This operator is required by ${requiredByOperatorName}`;
+  } else if (notStandalone && !values.selectedOperators.includes(operatorId)) {
+    disabledReason = 'This operator cannot be installed as a standalone';
+  }
 
   return (
     <FormGroup fieldId={fieldId} id={`form-control__${fieldId}`}>

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/bundleSpecs.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/bundleSpecs.tsx
@@ -31,8 +31,10 @@ export const bundleSpecs: { [key: string]: BundleSpec } = {
     incompatibleBundles: [],
     Description: () => (
       <List>
-        <ListItem>GPUs are recommended for optimal AI/ML workload performance.</ListItem>
-        <ListItem>Select the GPU operators you want to install.</ListItem>
+        <ListItem>
+          GPUs are recommended for optimal AI/ML workload performance. Please select the GPU
+          operators you want to install.
+        </ListItem>
       </List>
     ),
     docsLink: `https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/${getYearForAssistedInstallerDocumentationLink()}/html/installing_openshift_container_platform_with_the_assisted_installer/customizing-with-bundles-and-operators#openshift-ai-bundle_customizing-with-bundles-and-operators`,

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/bundleSpecs.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/bundleSpecs.tsx
@@ -32,10 +32,7 @@ export const bundleSpecs: { [key: string]: BundleSpec } = {
     Description: () => (
       <List>
         <ListItem>GPUs are recommended for optimal AI/ML workload performance.</ListItem>
-        <ListItem>
-          NVIDIA GPU, AMD GPU and Kernel Module Management may or may not be installed based on the
-          GPU discovered on your hosts.
-        </ListItem>
+        <ListItem>Select the GPU operators you want to install.</ListItem>
       </List>
     ),
     docsLink: `https://docs.redhat.com/en/documentation/assisted_installer_for_openshift_container_platform/${getYearForAssistedInstallerDocumentationLink()}/html/installing_openshift_container_platform_with_the_assisted_installer/customizing-with-bundles-and-operators#openshift-ai-bundle_customizing-with-bundles-and-operators`,

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/utils.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/utils.tsx
@@ -1,8 +1,8 @@
 import {
+  BundleCreateParams,
   Bundle,
   PreflightHardwareRequirements,
 } from '@openshift-assisted/types/assisted-installer-service';
-import { SelectedBundle } from '../../../../common/types';
 import { OperatorSpec } from '../../../../common/components/operators/operatorSpecs';
 
 const getOperatorDependencies = (
@@ -69,7 +69,7 @@ const getBundleOperators = (
 
 export const getNewBundleOperators = (
   currentOperators: string[],
-  currentBundles: SelectedBundle[],
+  currentBundles: BundleCreateParams[],
   allBundles: Bundle[],
   newBundle: Bundle,
   preflightRequirements: PreflightHardwareRequirements | undefined,

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/utils.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/utils.tsx
@@ -2,6 +2,7 @@ import {
   Bundle,
   PreflightHardwareRequirements,
 } from '@openshift-assisted/types/assisted-installer-service';
+import { SelectedBundle } from '../../../../common/types';
 import { OperatorSpec } from '../../../../common/components/operators/operatorSpecs';
 
 const getOperatorDependencies = (
@@ -68,7 +69,7 @@ const getBundleOperators = (
 
 export const getNewBundleOperators = (
   currentOperators: string[],
-  currentBundles: string[],
+  currentBundles: SelectedBundle[],
   allBundles: Bundle[],
   newBundle: Bundle,
   preflightRequirements: PreflightHardwareRequirements | undefined,
@@ -81,10 +82,10 @@ export const getNewBundleOperators = (
     return Array.from(new Set(combined));
   }
 
-  const newBundles = currentBundles.filter((b) => b !== newBundle.id);
+  const newBundles = currentBundles.filter((bundle) => bundle.id !== newBundle.id);
   const operatorsToKeep = [
-    ...newBundles.reduce((acc, bundleId) => {
-      const bundle = allBundles.find(({ id }) => id === bundleId);
+    ...newBundles.reduce((acc, selectedBundle) => {
+      const bundle = allBundles.find(({ id }) => id === selectedBundle.id);
       if (bundle) {
         const bundleOperators = getBundleOperators(bundle, preflightRequirements);
         bundleOperators.forEach((op) => {

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewOperatorsTable.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewOperatorsTable.tsx
@@ -2,31 +2,68 @@ import React from 'react';
 import { Title } from '@patternfly/react-core';
 import { Table, TableVariant, Tbody, Td, Tr } from '@patternfly/react-table';
 import { genericTableRowKey, selectOlmOperators } from '../../../../common';
-import { Cluster } from '@openshift-assisted/types/assisted-installer-service';
+import { useStateSafely } from '../../../../common/hooks';
+import { Bundle, Cluster } from '@openshift-assisted/types/assisted-installer-service';
 import { TableSummaryExpandable } from './TableSummaryExpandable';
 import { useOperatorSpecs } from '../../../../common/components/operators/operatorSpecs';
+import BundleService from '../../../services/BundleService';
 
-const getBundleTitle = (bundleId: string) => {
-  if (bundleId === 'openshift-ai') {
-    return 'OpenShift AI';
+const fetchBundles = async (
+  openshiftVersion: string,
+  cpuArchitecture: string,
+  platformType: string,
+): Promise<Bundle[]> => {
+  try {
+    return await BundleService.listBundles(
+      openshiftVersion,
+      cpuArchitecture,
+      platformType,
+      undefined,
+    );
+  } catch (_e) {
+    return [] as Bundle[];
   }
-
-  if (bundleId === 'lso') {
-    return 'Local Storage Operator';
-  }
-
-  return bundleId
-    .split('-')
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(' ');
 };
 
 export const ReviewOperatorsTable = ({ cluster }: { cluster: Cluster }) => {
   const { byKey: opSpecs } = useOperatorSpecs();
   const selectedBundles = cluster.operatorBundles || [];
+  const [bundleTitlesById, setBundleTitlesById] = useStateSafely<Record<string, string>>({});
+  const hasFetchedBundles = React.useRef(false);
+  const hasSelectedBundles = selectedBundles.length > 0;
+  React.useEffect(() => {
+    if (!hasFetchedBundles.current && hasSelectedBundles) {
+      hasFetchedBundles.current = true;
+      void (async () => {
+        const bundles = await fetchBundles(
+          cluster.openshiftVersion || '',
+          cluster.cpuArchitecture || '',
+          cluster.platform?.type || '',
+        );
+        const titlesById = Object.fromEntries(
+          bundles
+            .filter((bundle) => !!bundle.id && !!bundle.title)
+            .map((bundle) => [bundle.id, bundle.title]),
+        ) as Record<string, string>;
+        setBundleTitlesById(titlesById);
+      })();
+    }
+  }, [
+    cluster.cpuArchitecture,
+    cluster.openshiftVersion,
+    cluster.platform?.type,
+    hasSelectedBundles,
+    setBundleTitlesById,
+  ]);
+
   const bundleRows = selectedBundles.map((bundle) => ({
     rowId: `bundle-${bundle.id}`,
-    cells: [{ title: getBundleTitle(bundle.id), props: { 'data-testid': `bundle-${bundle.id}` } }],
+    cells: [
+      {
+        title: bundleTitlesById[bundle.id] || bundle.id,
+        props: { 'data-testid': `bundle-${bundle.id}` },
+      },
+    ],
   }));
 
   const rows = React.useMemo(

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewOperatorsTable.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewOperatorsTable.tsx
@@ -1,12 +1,33 @@
 import React from 'react';
+import { Title } from '@patternfly/react-core';
 import { Table, TableVariant, Tbody, Td, Tr } from '@patternfly/react-table';
 import { genericTableRowKey, selectOlmOperators } from '../../../../common';
 import { Cluster } from '@openshift-assisted/types/assisted-installer-service';
 import { TableSummaryExpandable } from './TableSummaryExpandable';
 import { useOperatorSpecs } from '../../../../common/components/operators/operatorSpecs';
 
+const getBundleTitle = (bundleId: string) => {
+  if (bundleId === 'openshift-ai') {
+    return 'OpenShift AI';
+  }
+
+  if (bundleId === 'lso') {
+    return 'Local Storage Operator';
+  }
+
+  return bundleId
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+};
+
 export const ReviewOperatorsTable = ({ cluster }: { cluster: Cluster }) => {
   const { byKey: opSpecs } = useOperatorSpecs();
+  const selectedBundles = cluster.operatorBundles || [];
+  const bundleRows = selectedBundles.map((bundle) => ({
+    rowId: `bundle-${bundle.id}`,
+    cells: [{ title: getBundleTitle(bundle.id), props: { 'data-testid': `bundle-${bundle.id}` } }],
+  }));
 
   const rows = React.useMemo(
     () =>
@@ -28,30 +49,62 @@ export const ReviewOperatorsTable = ({ cluster }: { cluster: Cluster }) => {
     [cluster, opSpecs],
   );
 
-  if (!rows?.length) {
+  if (!rows?.length && selectedBundles.length === 0) {
     return null;
   }
 
   return (
-    <TableSummaryExpandable title={'Operators'} id={'operators-expandable'}>
-      <Table
-        variant={TableVariant.compact}
-        borders={false}
-        aria-label={'Operators review table'}
-        className="review-table"
-      >
-        <Tbody>
-          {rows.map((row, i) => (
-            <Tr key={genericTableRowKey(row.rowId)}>
-              {row.cells.map((cell, j) => (
-                <Td key={`cell-${i}-${j}`} {...cell.props}>
-                  {cell.title}
-                </Td>
+    <TableSummaryExpandable title={'Bundles and operators'} id={'operators-expandable'}>
+      {bundleRows.length > 0 && (
+        <>
+          <Title headingLevel="h4" size="md" className="pf-v6-u-mb-sm">
+            Bundles ({bundleRows.length})
+          </Title>
+          <Table
+            variant={TableVariant.compact}
+            borders={false}
+            aria-label={'Bundles review table'}
+            className="review-table pf-v6-u-mb-md"
+          >
+            <Tbody>
+              {bundleRows.map((row, i) => (
+                <Tr key={genericTableRowKey(row.rowId)}>
+                  {row.cells.map((cell, j) => (
+                    <Td key={`bundle-cell-${i}-${j}`} {...cell.props}>
+                      {cell.title}
+                    </Td>
+                  ))}
+                </Tr>
               ))}
-            </Tr>
-          ))}
-        </Tbody>
-      </Table>
+            </Tbody>
+          </Table>
+        </>
+      )}
+      {rows.length > 0 && (
+        <>
+          <Title headingLevel="h4" size="md" className="pf-v6-u-mb-sm">
+            Operators ({rows.length})
+          </Title>
+          <Table
+            variant={TableVariant.compact}
+            borders={false}
+            aria-label={'Operators review table'}
+            className="review-table"
+          >
+            <Tbody>
+              {rows.map((row, i) => (
+                <Tr key={genericTableRowKey(row.rowId)}>
+                  {row.cells.map((cell, j) => (
+                    <Td key={`cell-${i}-${j}`} {...cell.props}>
+                      {cell.title}
+                    </Td>
+                  ))}
+                </Tr>
+              ))}
+            </Tbody>
+          </Table>
+        </>
+      )}
     </TableSummaryExpandable>
   );
 };

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterDetails.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterDetails.tsx
@@ -24,7 +24,6 @@ import {
   UISettingService,
 } from '../../services';
 import { Cluster, InfraEnv } from '@openshift-assisted/types/assisted-installer-service';
-import BundleService from '../../services/BundleService';
 import { useFeature } from '../../hooks/use-feature';
 
 type ClusterDetailsProps = {
@@ -80,21 +79,10 @@ const ClusterDetails = ({ cluster, infraEnv }: ClusterDetailsProps) => {
       try {
         const searchParams = new URLSearchParams(location.search);
         const isAssistedMigration = searchParams.get('source') === 'assisted_migration';
-        //For Assisted Migration we need the LVMs operator and also the virtualization bundle operators
+        // For Assisted Migration we need LVM as standalone and the virtualization bundle.
         if (isAssistedMigration) {
           params.olmOperators = [{ name: 'lvm' }];
-          const selectedBundle = (
-            await BundleService.listBundles(
-              params.openshiftVersion,
-              params.cpuArchitecture,
-              params.platform?.type,
-            )
-          ).find((b) => b.id === 'virtualization');
-          const virtOperators = selectedBundle?.operators;
-          params.olmOperators = [
-            ...params.olmOperators,
-            ...(virtOperators ? virtOperators.map((op) => ({ name: op })) : []),
-          ];
+          params.operatorBundles = [{ id: 'virtualization', optionalOperators: [] }];
         }
         const cluster = await ClustersService.create(
           params,

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/Operators.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/Operators.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useDispatch } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import { Formik, FormikConfig, useFormikContext } from 'formik';
-import { Cluster } from '@openshift-assisted/types/assisted-installer-service';
+import { BundleCreateParams, Cluster } from '@openshift-assisted/types/assisted-installer-service';
 import {
   ClusterWizardStep,
   getFormikErrorFields,
@@ -29,9 +29,31 @@ const getOperatorsInitialValues = (
   uiSettings: UISettingsValues | undefined,
   cluster: Cluster,
 ): OperatorsValues => {
+  const olmOperators = selectOlmOperators(cluster);
+  const selectedOperators = olmOperators
+    .filter((operator) => operator.name && !operator.sourceBundles?.length)
+    .flatMap(({ name }) => (name ? [name] : []));
+
+  const selectedBundlesFromOperatorBundles = (cluster.operatorBundles || []).map(
+    ({ id, optionalOperators }) => ({
+      id,
+      optionalOperators: optionalOperators || [],
+    }),
+  );
+
+  // Backward compatibility: old clusters can miss `operatorBundles`.
+  const selectedBundlesFromUiSettings = (uiSettings?.bundlesSelected || []).map((id) => ({
+    id,
+    optionalOperators: [],
+  }));
+
+  const selectedBundles = !!cluster.operatorBundles?.length
+    ? selectedBundlesFromOperatorBundles
+    : selectedBundlesFromUiSettings;
+
   return {
-    selectedBundles: uiSettings?.bundlesSelected || [],
-    selectedOperators: selectOlmOperators(cluster).map((o) => o.name || ''),
+    selectedBundles,
+    selectedOperators,
   };
 };
 
@@ -81,20 +103,31 @@ const Operators = ({ cluster }: { cluster: Cluster }) => {
   const dispatch = useDispatch();
   const { updateUISettings, uiSettings } = useClusterWizardContext();
   const { addAlert, clearAlerts } = useAlerts();
+  const initialValues = React.useMemo(
+    () => getOperatorsInitialValues(uiSettings, cluster),
+    [cluster, uiSettings],
+  );
 
   const handleSubmit: FormikConfig<OperatorsValues>['onSubmit'] = async (values) => {
     clearAlerts();
 
-    const enabledOperators = values.selectedOperators.map((so) => ({
-      name: so,
-    }));
+    const selectedOperators = values.selectedOperators.map((name) => ({ name }));
+
+    const selectedBundles: BundleCreateParams[] = values.selectedBundles.map(
+      ({ id, optionalOperators }) => ({
+        id,
+        optionalOperators,
+      }),
+    );
 
     try {
       const { data: updatedCluster } = await ClustersService.update(cluster.id, cluster.tags, {
-        olmOperators: enabledOperators,
+        operatorBundles: selectedBundles,
+        olmOperators: selectedOperators,
       });
 
-      await updateUISettings({ bundlesSelected: values.selectedBundles });
+      // Backward compatibility: old clusters used uiSettings.bundlesSelected, keep a single source of truth in operatorBundles.
+      await updateUISettings({ bundlesSelected: undefined });
 
       dispatch(updateCluster(updatedCluster));
     } catch (e) {
@@ -108,7 +141,7 @@ const Operators = ({ cluster }: { cluster: Cluster }) => {
   };
 
   return (
-    <Formik initialValues={getOperatorsInitialValues(uiSettings, cluster)} onSubmit={handleSubmit}>
+    <Formik initialValues={initialValues} onSubmit={handleSubmit}>
       <OperatorsForm cluster={cluster} />
     </Formik>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/Operators.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/Operators.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useDispatch } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
 import { Formik, FormikConfig, useFormikContext } from 'formik';
-import { BundleCreateParams, Cluster } from '@openshift-assisted/types/assisted-installer-service';
+import { Cluster } from '@openshift-assisted/types/assisted-installer-service';
 import {
   ClusterWizardStep,
   getFormikErrorFields,
@@ -32,7 +32,7 @@ const getOperatorsInitialValues = (
   const olmOperators = selectOlmOperators(cluster);
   const selectedOperators = olmOperators
     .filter((operator) => operator.name && !operator.sourceBundles?.length)
-    .flatMap(({ name }) => (name ? [name] : []));
+    .map(({ name }) => name as string);
 
   const selectedBundlesFromOperatorBundles = (cluster.operatorBundles || []).map(
     ({ id, optionalOperators }) => ({
@@ -111,25 +111,27 @@ const Operators = ({ cluster }: { cluster: Cluster }) => {
   const handleSubmit: FormikConfig<OperatorsValues>['onSubmit'] = async (values) => {
     clearAlerts();
 
-    const selectedOperators = values.selectedOperators.map((name) => ({ name }));
-
-    const selectedBundles: BundleCreateParams[] = values.selectedBundles.map(
-      ({ id, optionalOperators }) => ({
-        id,
-        optionalOperators,
-      }),
-    );
-
     try {
       const { data: updatedCluster } = await ClustersService.update(cluster.id, cluster.tags, {
-        operatorBundles: selectedBundles,
-        olmOperators: selectedOperators,
+        operatorBundles: values.selectedBundles,
+        olmOperators: values.selectedOperators.map((name) => ({ name })),
       });
 
-      // Backward compatibility: old clusters used uiSettings.bundlesSelected, keep a single source of truth in operatorBundles.
-      await updateUISettings({ bundlesSelected: undefined });
-
       dispatch(updateCluster(updatedCluster));
+
+      // Backward compatibility: old clusters used uiSettings.bundlesSelected, keep operatorBundles as source of truth.
+      if (uiSettings?.bundlesSelected?.length) {
+        try {
+          await updateUISettings({ bundlesSelected: undefined });
+        } catch (uiSettingsError) {
+          handleApiError(uiSettingsError, () =>
+            addAlert({
+              title: 'Failed to update UI settings',
+              message: getApiErrorMessage(uiSettingsError),
+            }),
+          );
+        }
+      }
     } catch (e) {
       handleApiError(e, () =>
         addAlert({ title: 'Failed to update the cluster', message: getApiErrorMessage(e) }),

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsBundle.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsBundle.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  Alert,
   Card,
   CardBody,
   CardHeader,
@@ -13,21 +14,24 @@ import {
   Title,
   Tooltip,
 } from '@patternfly/react-core';
+import { Bundle, Cluster } from '@openshift-assisted/types/assisted-installer-service';
 import {
-  Bundle,
-  PreflightHardwareRequirements,
-} from '@openshift-assisted/types/assisted-installer-service';
-import { ExternalLink, OperatorsValues, PopoverIcon, singleClusterBundles } from '../../../common';
+  ExternalLink,
+  OperatorsValues,
+  PopoverIcon,
+  selectClusterValidationsInfo,
+  singleClusterBundles,
+} from '../../../common';
 import { useFormikContext } from 'formik';
 import { useNewFeatureSupportLevel } from '../../../common/components/newFeatureSupportLevels';
 import { useFeature } from '../../hooks/use-feature';
-import { getNewBundleOperators } from '../clusterConfiguration/operators/utils';
 import { bundleSpecs } from '../clusterConfiguration/operators/bundleSpecs';
 import {
   highlightMatch,
   useOperatorSpecs,
 } from '../../../common/components/operators/operatorSpecs';
 import { useClusterWizardContext } from './ClusterWizardContext';
+import OptionalOperatorsDropdown from './OptionalOperatorsDropdown';
 import './OperatorsBundle.css';
 
 const BundleLabel = ({ bundle, searchTerm }: { bundle: Bundle; searchTerm?: string }) => {
@@ -73,13 +77,13 @@ const BundleLabel = ({ bundle, searchTerm }: { bundle: Bundle; searchTerm?: stri
 const BundleCard = ({
   bundle,
   bundles,
-  preflightRequirements,
   searchTerm,
+  informationalMessage,
 }: {
   bundle: Bundle;
   bundles: Bundle[];
-  preflightRequirements: PreflightHardwareRequirements | undefined;
   searchTerm?: string;
+  informationalMessage?: string;
 }) => {
   const { values, setFieldValue } = useFormikContext<OperatorsValues>();
   const { isFeatureSupported } = useNewFeatureSupportLevel();
@@ -97,7 +101,7 @@ const BundleCard = ({
   const bundleSpec = bundleSpecs[bundle.id || ''];
 
   const incompatibleBundle = bundleSpec?.incompatibleBundles?.find((b) =>
-    values.selectedBundles.includes(b),
+    values.selectedBundles.some((bundleSelection) => bundleSelection.id === b),
   );
   const isAssistedMigration = uiSettings?.isAssistedMigration;
   const disabledReason = hasUnsupportedOperators
@@ -112,23 +116,30 @@ const BundleCard = ({
     ? 'This bundle is not available for the current configuration, you might be able to use the standalone operators instead.'
     : undefined;
 
+  const addBundle = (
+    selectedBundles: OperatorsValues['selectedBundles'],
+    bundle: Bundle,
+  ): OperatorsValues['selectedBundles'] => [
+    ...selectedBundles,
+    { id: bundle.id || '', optionalOperators: bundle.optionalOperators || [] },
+  ];
+
+  const removeBundle = (
+    selectedBundles: OperatorsValues['selectedBundles'],
+    bundleId: Bundle['id'],
+  ): OperatorsValues['selectedBundles'] =>
+    selectedBundles.filter((selectedBundle) => selectedBundle.id !== bundleId);
+
   const onSelect = (checked: boolean) => {
-    const newBundles = checked
-      ? [...values.selectedBundles, bundle.id || '']
-      : values.selectedBundles.filter((sb) => sb !== bundle.id);
-    setFieldValue('selectedBundles', newBundles);
-    const newOperators = getNewBundleOperators(
-      values.selectedOperators,
-      newBundles,
-      bundles,
-      bundle,
-      preflightRequirements,
-      checked,
-    );
-    setFieldValue('selectedOperators', newOperators);
+    const nextBundles = checked
+      ? addBundle(values.selectedBundles, bundle)
+      : removeBundle(values.selectedBundles, bundle.id);
+    setFieldValue('selectedBundles', nextBundles);
   };
 
-  const isSelected = values.selectedBundles.includes(bundle.id || '');
+  const isSelected = values.selectedBundles.some(
+    (selectedBundle) => selectedBundle.id === bundle.id,
+  );
   const checkboxId = `bundle-${bundle.id || ''}`;
   return (
     <Tooltip content={disabledReason} hidden={!disabledReason}>
@@ -145,7 +156,7 @@ const BundleCard = ({
             selectableActionId: checkboxId,
             selectableActionAriaLabelledby: checkboxId,
             name: checkboxId,
-            onChange: (_, checked) => onSelect(checked),
+            onChange: (_, checked) => onSelect(!!checked),
             isChecked: isSelected,
           }}
         >
@@ -158,6 +169,25 @@ const BundleCard = ({
             <StackItem isFilled>
               <div>{highlightMatch(bundle.description || '', searchTerm)}</div>
             </StackItem>
+            {!!bundle.optionalOperators?.length && (
+              <StackItem onClick={(e) => e.stopPropagation()}>
+                <OptionalOperatorsDropdown
+                  bundleId={bundle.id || ''}
+                  optionalOperatorIds={bundle.optionalOperators}
+                  selectedBundles={values.selectedBundles}
+                  setSelectedBundles={(selectedBundles) =>
+                    setFieldValue('selectedBundles', selectedBundles)
+                  }
+                  isDisabled={!isSelected || !!disabledReason}
+                  getOperatorLabel={(operatorId) => opSpecs[operatorId]?.title || operatorId}
+                />
+              </StackItem>
+            )}
+            {informationalMessage && (
+              <StackItem>
+                <Alert isInline variant="info" title={informationalMessage} />
+              </StackItem>
+            )}
           </Stack>
         </CardBody>
       </Card>
@@ -168,15 +198,29 @@ const BundleCard = ({
 const OperatorsBundle = ({
   bundles,
   allBundles,
-  preflightRequirements,
   searchTerm,
+  cluster,
 }: {
   bundles: Bundle[];
   allBundles: Bundle[];
-  preflightRequirements: PreflightHardwareRequirements | undefined;
   searchTerm?: string;
+  cluster: Cluster;
 }) => {
   const isSingleClusterFeatureEnabled = useFeature('ASSISTED_INSTALLER_SINGLE_CLUSTER_FEATURE');
+  const openshiftAiGpuInfoMessage = React.useMemo(() => {
+    const validationsInfo = selectClusterValidationsInfo(cluster);
+    if (!validationsInfo) {
+      return undefined;
+    }
+    return Object.values(validationsInfo)
+      .flat()
+      .find(
+        (validation) =>
+          validation?.id === 'openshift-ai-gpu-requirements-satisfied' &&
+          validation?.status === 'success' &&
+          !!validation.message,
+      )?.message;
+  }, [cluster]);
 
   return (
     <Stack hasGutter>
@@ -195,8 +239,10 @@ const OperatorsBundle = ({
               <BundleCard
                 bundle={bundles.find((b) => b.id === bundle.id) || bundle}
                 bundles={bundles}
-                preflightRequirements={preflightRequirements}
                 searchTerm={searchTerm}
+                informationalMessage={
+                  bundle.id === 'openshift-ai' ? openshiftAiGpuInfoMessage : undefined
+                }
               />
             </GalleryItem>
           ))}

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsSelect.test.ts
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsSelect.test.ts
@@ -10,7 +10,7 @@ function calculateSelectedOperators(
 ): string[] {
   // Calculate all selected operators (direct selections + bundle selections)
   const bundleOperators = values.selectedBundles.flatMap(
-    (bundleId) => bundles.find((b) => b.id === bundleId)?.operators || [],
+    (bundle) => bundles.find((b) => b.id === bundle.id)?.operators || [],
   );
 
   const allSelectedOperators = values.selectedOperators
@@ -62,7 +62,7 @@ describe('OperatorsSelect counting logic', () => {
   it('should count bundle operators when a bundle is selected', () => {
     const values: OperatorsValues = {
       selectedOperators: ['lvm'], // 1 manually selected
-      selectedBundles: ['virtualization'], // bundle with 3 operators: cnv, nmstate, mtv
+      selectedBundles: [{ id: 'virtualization', optionalOperators: [] }], // bundle with 3 operators: cnv, nmstate, mtv
     };
 
     const result = calculateSelectedOperators(values, mockBundles, mockOpSpecs);
@@ -77,7 +77,7 @@ describe('OperatorsSelect counting logic', () => {
   it('should not double-count operators that are both manually selected and in a bundle', () => {
     const values: OperatorsValues = {
       selectedOperators: ['lvm', 'cnv'], // cnv is also in the bundle
-      selectedBundles: ['virtualization'], // bundle with: cnv, nmstate, mtv
+      selectedBundles: [{ id: 'virtualization', optionalOperators: [] }], // bundle with: cnv, nmstate, mtv
     };
 
     const result = calculateSelectedOperators(values, mockBundles, mockOpSpecs);
@@ -107,7 +107,10 @@ describe('OperatorsSelect counting logic', () => {
   it('should handle multiple bundles correctly', () => {
     const values: OperatorsValues = {
       selectedOperators: ['lvm'],
-      selectedBundles: ['virtualization', 'openshift-ai'], // Two bundles
+      selectedBundles: [
+        { id: 'virtualization', optionalOperators: [] },
+        { id: 'openshift-ai', optionalOperators: [] },
+      ], // Two bundles
     };
 
     const result = calculateSelectedOperators(values, mockBundles, mockOpSpecs);
@@ -125,7 +128,10 @@ describe('OperatorsSelect counting logic', () => {
   it('should handle overlapping operators in multiple bundles', () => {
     const values: OperatorsValues = {
       selectedOperators: [],
-      selectedBundles: ['virtualization', 'openshift-ai'], // Both bundles have 'odf' (but only virtualization has it in our mock)
+      selectedBundles: [
+        { id: 'virtualization', optionalOperators: [] },
+        { id: 'openshift-ai', optionalOperators: [] },
+      ], // Both bundles have 'odf' (but only virtualization has it in our mock)
     };
 
     // Let's modify the virtualization bundle to include odf to test overlap

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsStep.tsx
@@ -92,9 +92,9 @@ export const OperatorsStep = ({ cluster }: ClusterOperatorProps) => {
       <StackItem>
         <OperatorsBundle
           bundles={filteredBundles}
-          preflightRequirements={preflightRequirements}
           searchTerm={searchTerm}
           allBundles={allBundles}
+          cluster={cluster}
         />
       </StackItem>
       <StackItem>

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/OptionalOperatorsDropdown.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/OptionalOperatorsDropdown.tsx
@@ -28,11 +28,13 @@ const OptionalOperatorsDropdown = ({
 }: OptionalOperatorsDropdownProps) => {
   const [isOpen, setIsOpen] = React.useState(false);
   const toggleLabel = bundleId === 'openshift-ai' ? 'GPU operators' : 'Optional operators';
-  const bundle = selectedBundles.find((bundleSelection) => bundleSelection.id === bundleId);
-  const selectedOptionalOperators = bundle?.optionalOperators || [];
+  const selectedBundleEntry = selectedBundles.find(
+    (bundleSelection) => bundleSelection.id === bundleId,
+  );
+  const selectedOptionalOperators = selectedBundleEntry?.optionalOperators || [];
 
   const updateBundleOptionalOperators = (operatorId: string) => {
-    if (bundle) {
+    if (selectedBundleEntry) {
       const isCurrentlySelected = selectedOptionalOperators.includes(operatorId);
       const nextOptionalOperators = isCurrentlySelected
         ? selectedOptionalOperators.filter((optionalOperator) => optionalOperator !== operatorId)
@@ -55,10 +57,8 @@ const OptionalOperatorsDropdown = ({
     _event: React.MouseEvent | React.ChangeEvent | undefined,
     value?: string | number,
   ) => {
-    const operatorId = value as string | undefined;
-    if (operatorId) {
-      updateBundleOptionalOperators(operatorId);
-    }
+    const operatorId = value as string;
+    updateBundleOptionalOperators(operatorId);
   };
 
   return (
@@ -74,10 +74,14 @@ const OptionalOperatorsDropdown = ({
           onClick={() => setIsOpen((prevIsOpen) => !prevIsOpen)}
           isExpanded={isOpen}
           isDisabled={isDisabled}
+          style={{ minWidth: '190px' }}
         >
           {toggleLabel}
           {selectedOptionalOperators.length > 0 && (
-            <Badge isRead>{selectedOptionalOperators.length}</Badge>
+            <>
+              {' '}
+              <Badge isRead>{selectedOptionalOperators.length}</Badge>
+            </>
           )}
         </MenuToggle>
       )}

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/OptionalOperatorsDropdown.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/OptionalOperatorsDropdown.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react';
+import {
+  Badge,
+  MenuToggle,
+  MenuToggleElement,
+  Select,
+  SelectList,
+  SelectOption,
+} from '@patternfly/react-core';
+import { OperatorsValues } from '../../../common';
+
+type OptionalOperatorsDropdownProps = {
+  bundleId: string;
+  optionalOperatorIds: string[];
+  selectedBundles: OperatorsValues['selectedBundles'];
+  setSelectedBundles: (selectedBundles: OperatorsValues['selectedBundles']) => void;
+  isDisabled: boolean;
+  getOperatorLabel: (operatorId: string) => string;
+};
+
+const OptionalOperatorsDropdown = ({
+  bundleId,
+  optionalOperatorIds,
+  selectedBundles,
+  setSelectedBundles,
+  isDisabled,
+  getOperatorLabel,
+}: OptionalOperatorsDropdownProps) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const toggleLabel = bundleId === 'openshift-ai' ? 'GPU operators' : 'Optional operators';
+  const bundle = selectedBundles.find((bundleSelection) => bundleSelection.id === bundleId);
+  const selectedOptionalOperators = bundle?.optionalOperators || [];
+
+  const updateBundleOptionalOperators = (operatorId: string) => {
+    if (bundle) {
+      const isCurrentlySelected = selectedOptionalOperators.includes(operatorId);
+      const nextOptionalOperators = isCurrentlySelected
+        ? selectedOptionalOperators.filter((optionalOperator) => optionalOperator !== operatorId)
+        : [...selectedOptionalOperators, operatorId];
+
+      const updatedBundles = selectedBundles.map((bundleSelection) =>
+        bundleSelection.id === bundleId
+          ? {
+              ...bundleSelection,
+              optionalOperators: nextOptionalOperators,
+            }
+          : bundleSelection,
+      );
+
+      setSelectedBundles(updatedBundles);
+    }
+  };
+
+  const onSelect = (
+    _event: React.MouseEvent | React.ChangeEvent | undefined,
+    value?: string | number,
+  ) => {
+    const operatorId = value as string | undefined;
+    if (operatorId) {
+      updateBundleOptionalOperators(operatorId);
+    }
+  };
+
+  return (
+    <Select
+      role="menu"
+      isOpen={isOpen}
+      onSelect={onSelect}
+      selected={selectedOptionalOperators}
+      onOpenChange={(nextIsOpen) => setIsOpen(nextIsOpen)}
+      toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+        <MenuToggle
+          ref={toggleRef}
+          onClick={() => setIsOpen((prevIsOpen) => !prevIsOpen)}
+          isExpanded={isOpen}
+          isDisabled={isDisabled}
+        >
+          {toggleLabel}
+          {selectedOptionalOperators.length > 0 && (
+            <Badge isRead>{selectedOptionalOperators.length}</Badge>
+          )}
+        </MenuToggle>
+      )}
+    >
+      <SelectList>
+        {optionalOperatorIds.map((operatorId) => (
+          <SelectOption
+            id={`optional-operator-${bundleId}-${operatorId}`}
+            key={operatorId}
+            value={operatorId}
+            hasCheckbox
+            isSelected={selectedOptionalOperators.includes(operatorId)}
+          >
+            {getOperatorLabel(operatorId)}
+          </SelectOption>
+        ))}
+      </SelectList>
+    </Select>
+  );
+};
+
+export default OptionalOperatorsDropdown;


### PR DESCRIPTION

https://redhat.atlassian.net/browse/MGMT-23172

needs: https://github.com/openshift/assisted-service/pull/10387

<img width="688" height="382" alt="image" src="https://github.com/user-attachments/assets/24f9a4ea-36dc-410d-b264-792319ae18ab" />
<img width="688" height="382" alt="image" src="https://github.com/user-attachments/assets/7b66cbae-2126-4f23-97c1-a6ed13a34136" />
<img width="1883" height="928" alt="Screenshot From 2026-06-11 11-06-28" src="https://github.com/user-attachments/assets/052b7629-a7e7-4596-ab5f-818ae81194b0" />
<img width="1133" height="312" alt="image" src="https://github.com/user-attachments/assets/e4d0eec1-ba3f-4c04-9dd8-6a74c717c103" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional operator selection within bundle cards (including a dedicated dropdown UI).
  * Added informational validation display for specific “requirement satisfied” checks.
* **Improvements**
  * Updated operator review to show “Bundles and operators” and a bundles section when applicable, including bundle titles.
  * Persist bundle selections including optional operators and improved checkbox behavior/disabled messaging.
  * Standardized Assisted Migration operator/bundle configuration to a fixed setup.
* **Tests**
  * Updated operator selection tests to match the new bundle selection data shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->