### PR TITLE
chore: add ui-lib package metadata

### DIFF
--- a/libs/ui-lib/package.json
+++ b/libs/ui-lib/package.json
@@ -112,6 +112,10 @@
     "type": "git",
     "url": "https://github.com/openshift-assisted/assisted-installer-ui.git"
   },
+  "bugs": {
+    "url": "https://github.com/openshift-assisted/assisted-installer-ui/issues"
+  },
+  "homepage": "https://github.com/openshift-assisted/assisted-installer-ui/tree/master/libs/ui-lib#readme",
   "scripts": {
     "build": "yarn run -T tsc --build --verbose && yarn copy:css",
     "check_circular_deps": "yarn run -T dpdm --transform --warning false --tree false --exit-code circular:1 ./lib/index.ts",


### PR DESCRIPTION
## Summary
Adds npm support metadata to `@openshift-assisted/ui-lib`:
- `bugs.url` points to the repository issue tracker
- `homepage` points to the package README

This is a package manifest-only change. It does not change runtime code, dependencies, exports, build output, or package versioning.

Fixes #3781.

## Verification
- Parsed `libs/ui-lib/package.json` and confirmed `name`, `license`, `repository`, `homepage`, and `bugs.url`
- `npm pack --dry-run --ignore-scripts --json` from `libs/ui-lib`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata fields with additional project information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->