### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,5 +59,8 @@
     "apps/*",
     "libs/*",
     "tools/*"
-  ]
+  ],
+  "bugs": {
+    "url": "https://github.com/openshift-assisted/assisted-installer-ui/issues"
+  }
 }


### PR DESCRIPTION
Adds missing `bugs` metadata to `package.json`.

Fixes npm tooling unable to resolve package metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed configuration file structure to ensure proper formatting and correct positioning of metadata fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->