### PR TITLE
MGMT-22058: Add hosts modal huge space between inline alert and buttons

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/DiscoveryImageForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/DiscoveryImageForm.tsx
@@ -19,6 +19,7 @@ import { mapClusterCpuArchToInfraEnvCpuArch } from '../../services/CpuArchitectu
 import { usePullSecret } from '../../hooks';
 import { Cluster } from '@openshift-assisted/types/assisted-installer-service';
 import { isOciPlatformType } from '../utils';
+import { ModalBody } from '@patternfly/react-core';
 
 type DiscoveryImageFormProps = {
   cluster: Cluster;
@@ -93,10 +94,18 @@ const DiscoveryImageForm = ({
   };
 
   if (infraEnvError) {
-    return <ErrorState />;
+    return (
+      <ModalBody style={{ height: '696px' }}>
+        <ErrorState />
+      </ModalBody>
+    );
   }
   if (!infraEnv) {
-    return <LoadingState />;
+    return (
+      <ModalBody style={{ height: '696px' }}>
+        <LoadingState />
+      </ModalBody>
+    );
   }
   return (
     <OcmDiscoveryImageConfigForm

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/DiscoveryImageModal.css
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/DiscoveryImageModal.css
@@ -1,3 +1,0 @@
-#generate-discovery-iso-modal {
-  height: 791px;
-}

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/DiscoveryImageModal.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/DiscoveryImageModal.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { Button, ButtonVariant, Modal, ModalHeader, ModalVariant } from '@patternfly/react-core';
+import {
+  Button,
+  ButtonVariant,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalVariant,
+} from '@patternfly/react-core';
 import { pluralize } from 'humanize-plus';
 import {
   AI_CISCO_INTERSIGHT_TAG,
@@ -14,7 +21,6 @@ import { useModalDialogsContext } from '../hosts/ModalDialogsContext';
 import useInfraEnvImageUrl from '../../hooks/useInfraEnvImageUrl';
 import useInfraEnvIpxeImageUrl from '../../hooks/useInfraEnvIpxeImageUrl';
 import DownloadIpxeScript from '../../../common/components/clusterConfiguration/DownloadIpxeScript';
-import './DiscoveryImageModal.css';
 import { Cluster } from '@openshift-assisted/types/assisted-installer-service';
 import { ClustersService } from '../../services';
 import { useDispatch } from 'react-redux';
@@ -115,7 +121,11 @@ export const DiscoveryImageModal = () => {
         data-testid="discovery-modal-title"
         title={`Add ${pluralize(+isSNOCluster, 'host')}`}
       />
-      {(isoDownloadError || ipxeDownloadError) && <ErrorState />}
+      {(isoDownloadError || ipxeDownloadError) && (
+        <ModalBody>
+          <ErrorState />
+        </ModalBody>
+      )}
       {isoDownloadUrl ? (
         <DownloadIso
           fileName={`discovery_image_${cluster.name || ''}.iso`}

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmDiscoveryImageConfigForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmDiscoveryImageConfigForm.tsx
@@ -145,7 +145,7 @@ export const OcmDiscoveryImageConfigForm = ({
       {({ submitForm, isSubmitting, status, setStatus }) => {
         return (
           <>
-            <ModalBody>
+            <ModalBody style={{ maxHeight: '611px' }}>
               <Stack hasGutter>
                 <StackItem>
                   <Alert variant={AlertVariant.info} isInline title={alertDiscoveryText} />


### PR DESCRIPTION
https://redhat.atlassian.net/browse/MGMT-22058

Attempted to resolve [MGMT-22058](https://redhat.atlassian.net/browse/MGMT-22058) and avoid reintroducing [MGMT-14325](https://redhat.atlassian.net/browse/MGMT-14325)

Before: 

<img width="765" height="989" alt="image" src="https://github.com/user-attachments/assets/bb137933-2bc1-4f78-b23e-00898e82cedb" />

After:

<img width="765" height="989" alt="image" src="https://github.com/user-attachments/assets/93e854e9-d8c7-45ff-8cfb-c185db1e6288" />

## Summary by CodeRabbit

* **Refactor**
  * Restructured discovery image modal component layouts and error state rendering patterns to improve overall code organization and consistency across discovery image configuration dialogs.

* **Style**
  * Adjusted modal sizing, heights, and layout styling for the discovery image configuration interface to enhance visual consistency and presentation across all related modal components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->