### PR TITLE
OCPBUGS-86214: Collapsing sections on review and installation pages leaves blank white space instead of compacting layout

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/TableSummaryExpandable.css
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/TableSummaryExpandable.css
@@ -1,0 +1,3 @@
+.pf-v6-c-expandable-section:not(.pf-m-expanded) {
+  --pf-v6-c-expandable-section__content--MaxHeight: 0;
+}

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/TableSummaryExpandable.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/TableSummaryExpandable.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ExpandableSection, Content } from '@patternfly/react-core';
+import './TableSummaryExpandable.css';
 
 export const TableSummaryExpandable = ({
   title,
@@ -20,7 +21,6 @@ export const TableSummaryExpandable = ({
       id={id ? id : title}
     >
       {children}
-      <br />
     </ExpandableSection>
   );
 };


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-86214

Before:

<img width="1891" height="991" alt="image" src="https://github.com/user-attachments/assets/2627d3cd-bbf7-4c88-af38-8a8dbf1ab22a" />

After: 

<img width="1891" height="991" alt="image" src="https://github.com/user-attachments/assets/c068bbd1-198d-4eb0-ad51-a17d1d33a669" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved expandable section styling in cluster configuration review
  * Fixed section collapse behavior with proper content height handling
  * Removed unnecessary spacing between expandable content and section controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->