### PR TITLE
ACM-35000: Update @openshift-assisted/ui-lib for dynamic plugin SDK 4.22 and react-router 7 compatibility

### DIFF
--- a/apps/assisted-chatbot/package.json
+++ b/apps/assisted-chatbot/package.json
@@ -36,7 +36,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-i18next": "^11.11.4",
-    "react-router-dom": "^6.0.0"
+    "react-router": "^7.17.0"
   },
   "devDependencies": {
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^3.0.0",

--- a/apps/assisted-chatbot/package.json
+++ b/apps/assisted-chatbot/package.json
@@ -36,7 +36,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-i18next": "^11.11.4",
-    "react-router-dom-v5-compat": "^6.30.3"
+    "react-router-dom": "^6.0.0"
   },
   "devDependencies": {
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^3.0.0",

--- a/apps/assisted-chatbot/package.json
+++ b/apps/assisted-chatbot/package.json
@@ -45,6 +45,8 @@
     "@tsconfig/vite-react": "^7.0.2",
     "@types/react": "18.2.37",
     "@types/react-dom": "^18.2.0",
+    "@types/history": "^4",
+    "history": "^4.10.1",
     "rimraf": "^6.0.0",
     "ts-patch": "^3.0.2",
     "typescript": "^5.9.3"

--- a/apps/assisted-disconnected-ui/package.json
+++ b/apps/assisted-disconnected-ui/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@openshift-assisted/ui-lib": "workspace:*",
-    "@openshift-console/dynamic-plugin-sdk": "^4.19.1",
+    "@openshift-console/dynamic-plugin-sdk": "^4.22.0",
     "@patternfly/patternfly": "6.4.0",
     "@patternfly/react-code-editor": "6.4.1",
     "@patternfly/react-core": "6.4.1",

--- a/apps/assisted-disconnected-ui/package.json
+++ b/apps/assisted-disconnected-ui/package.json
@@ -21,8 +21,7 @@
     "react-i18next": "^11.11.4",
     "react-monaco-editor": "^0.59.0",
     "react-redux": "^8.0.5",
-    "react-router-dom": "5.3.x",
-    "react-router-dom-v5-compat": "^6.30.3",
+    "react-router-dom": "^6.0.0",
     "redux": "^4",
     "uuid": "^14.0",
     "yup": "^1.4.0"

--- a/apps/assisted-disconnected-ui/package.json
+++ b/apps/assisted-disconnected-ui/package.json
@@ -21,7 +21,7 @@
     "react-i18next": "^11.11.4",
     "react-monaco-editor": "^0.59.0",
     "react-redux": "^8.0.5",
-    "react-router-dom": "^6.0.0",
+    "react-router": "^7.17.0",
     "redux": "^4",
     "uuid": "^14.0",
     "yup": "^1.4.0"

--- a/apps/assisted-disconnected-ui/src/components/App.tsx
+++ b/apps/assisted-disconnected-ui/src/components/App.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom-v5-compat';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import {
   Brand,
   Masthead,

--- a/apps/assisted-disconnected-ui/src/components/App.tsx
+++ b/apps/assisted-disconnected-ui/src/components/App.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route } from 'react-router';
 import {
   Brand,
   Masthead,
@@ -50,9 +50,7 @@ export const App: React.FC = () => {
   );
 
   return (
-    <BrowserRouter
-      future={{ v7_relativeSplatPath: true, v7_startTransition: true, v7_fetcherPersist: true }}
-    >
+    <BrowserRouter>
       <Provider store={Store.storeDay1}>
         <Page masthead={header} isManagedSidebar defaultManagedSidebarIsOpen={false}>
           <AppRouter />

--- a/apps/assisted-disconnected-ui/src/components/App.tsx
+++ b/apps/assisted-disconnected-ui/src/components/App.tsx
@@ -50,7 +50,9 @@ export const App: React.FC = () => {
   );
 
   return (
-    <BrowserRouter>
+    <BrowserRouter
+      future={{ v7_relativeSplatPath: true, v7_startTransition: true, v7_fetcherPersist: true }}
+    >
       <Provider store={Store.storeDay1}>
         <Page masthead={header} isManagedSidebar defaultManagedSidebarIsOpen={false}>
           <AppRouter />

--- a/apps/assisted-disconnected-ui/src/components/ClusterPage.tsx
+++ b/apps/assisted-disconnected-ui/src/components/ClusterPage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { SingleClusterPage, Store } from '@openshift-assisted/ui-lib/ocm';
-import { useParams } from 'react-router-dom-v5-compat';
+import { useParams } from 'react-router-dom';
 import {
   ClustersAPI,
   getHostProgressStages,

--- a/apps/assisted-disconnected-ui/src/components/ClusterPage.tsx
+++ b/apps/assisted-disconnected-ui/src/components/ClusterPage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { SingleClusterPage, Store } from '@openshift-assisted/ui-lib/ocm';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import {
   ClustersAPI,
   getHostProgressStages,

--- a/apps/assisted-disconnected-ui/src/components/CreateClusterWizard.tsx
+++ b/apps/assisted-disconnected-ui/src/components/CreateClusterWizard.tsx
@@ -9,7 +9,7 @@ import {
   ModalDialogsContextProvider,
 } from '@openshift-assisted/ui-lib/ocm';
 import { Alert, PageSection } from '@patternfly/react-core';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import ResetSingleClusterModal from './ResetSingleClusterModal';
 
 const CreateClusterWizard = () => {
@@ -28,7 +28,7 @@ const CreateClusterWizard = () => {
   }
 
   if (clusterId) {
-    navigate(`/${clusterId}`);
+    void navigate(`/${clusterId}`);
   }
 
   return (

--- a/apps/assisted-disconnected-ui/src/components/CreateClusterWizard.tsx
+++ b/apps/assisted-disconnected-ui/src/components/CreateClusterWizard.tsx
@@ -9,7 +9,7 @@ import {
   ModalDialogsContextProvider,
 } from '@openshift-assisted/ui-lib/ocm';
 import { Alert, PageSection } from '@patternfly/react-core';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router-dom';
 import ResetSingleClusterModal from './ResetSingleClusterModal';
 
 const CreateClusterWizard = () => {

--- a/apps/assisted-disconnected-ui/src/components/ResetSingleClusterModal.tsx
+++ b/apps/assisted-disconnected-ui/src/components/ResetSingleClusterModal.tsx
@@ -18,7 +18,7 @@ import {
   handleApiError,
   useTranslation,
 } from '@openshift-assisted/ui-lib/common';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router-dom';
 
 const ResetSingleClusterModal: React.FC = () => {
   const navigate = useNavigate();

--- a/apps/assisted-disconnected-ui/src/components/ResetSingleClusterModal.tsx
+++ b/apps/assisted-disconnected-ui/src/components/ResetSingleClusterModal.tsx
@@ -18,7 +18,7 @@ import {
   handleApiError,
   useTranslation,
 } from '@openshift-assisted/ui-lib/common';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 const ResetSingleClusterModal: React.FC = () => {
   const navigate = useNavigate();
@@ -43,7 +43,7 @@ const ResetSingleClusterModal: React.FC = () => {
       setError(undefined);
       setIsLoading(true);
       await ClustersService.remove(cluster.id);
-      navigate(`/`);
+      void navigate(`/`);
     } catch (e) {
       handleApiError(e, () => {
         setError({

--- a/apps/assisted-ui/package.json
+++ b/apps/assisted-ui/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@openshift-assisted/ui-lib": "workspace:*",
-    "@openshift-console/dynamic-plugin-sdk": "^4.19.1",
+    "@openshift-console/dynamic-plugin-sdk": "^4.22.0",
     "@patternfly/patternfly": "6.4.0",
     "@patternfly/react-code-editor": "6.4.1",
     "@patternfly/react-core": "6.4.1",

--- a/apps/assisted-ui/package.json
+++ b/apps/assisted-ui/package.json
@@ -21,8 +21,7 @@
     "react-i18next": "^11.11.4",
     "react-monaco-editor": "^0.59.0",
     "react-redux": "^8.0.5",
-    "react-router-dom": "5.3.x",
-    "react-router-dom-v5-compat": "^6.30.3",
+    "react-router-dom": "^6.0.0",
     "redux": "^4",
     "uuid": "^14.0",
     "yup": "^1.4.0"

--- a/apps/assisted-ui/package.json
+++ b/apps/assisted-ui/package.json
@@ -21,7 +21,7 @@
     "react-i18next": "^11.11.4",
     "react-monaco-editor": "^0.59.0",
     "react-redux": "^8.0.5",
-    "react-router-dom": "^6.0.0",
+    "react-router": "^7.17.0",
     "redux": "^4",
     "uuid": "^14.0",
     "yup": "^1.4.0"

--- a/apps/assisted-ui/package.json
+++ b/apps/assisted-ui/package.json
@@ -31,8 +31,6 @@
     "@tsconfig/vite-react": "^7.0.2",
     "@types/react": "18.2.37",
     "@types/react-dom": "^18.2.0",
-    "@types/react-router": "^5.1.x",
-    "@types/react-router-dom": "5.3.x",
     "@vitejs/plugin-react-swc": "^4.3.0",
     "vite": "^8.0.16",
     "vite-plugin-environment": "^1.1.3"

--- a/apps/assisted-ui/src/components/App.tsx
+++ b/apps/assisted-ui/src/components/App.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 import { BrowserRouter, type BrowserRouterProps } from 'react-router-dom';
-import { CompatRouter, Route } from 'react-router-dom-v5-compat';
+import { Route } from 'react-router-dom';
 import { Page } from '@patternfly/react-core';
 import * as OCM from '@openshift-assisted/ui-lib/ocm';
 import { Header } from './Header';
@@ -17,12 +17,10 @@ const BrowserRouter18 = BrowserRouter as any as React.FC<
 
 export const App: React.FC = () => (
   <BrowserRouter18 basename={Config.routeBasePath}>
-    <CompatRouter>
-      <Page masthead={<Header />} isManagedSidebar defaultManagedSidebarIsOpen={false}>
-        <UILibRoutes allEnabledFeatures={Features.STANDALONE_DEPLOYMENT_ENABLED_FEATURES}>
-          <Route path={'/day2-flow-mock'} element={<HostsClusterDetailTabMock />} />
-        </UILibRoutes>
-      </Page>
-    </CompatRouter>
+    <Page masthead={<Header />} isManagedSidebar defaultManagedSidebarIsOpen={false}>
+      <UILibRoutes allEnabledFeatures={Features.STANDALONE_DEPLOYMENT_ENABLED_FEATURES}>
+        <Route path={'/day2-flow-mock'} element={<HostsClusterDetailTabMock />} />
+      </UILibRoutes>
+    </Page>
   </BrowserRouter18>
 );

--- a/apps/assisted-ui/src/components/App.tsx
+++ b/apps/assisted-ui/src/components/App.tsx
@@ -1,6 +1,5 @@
 import type React from 'react';
-import { BrowserRouter, type BrowserRouterProps } from 'react-router-dom';
-import { Route } from 'react-router-dom';
+import { BrowserRouter, Route, type BrowserRouterProps } from 'react-router';
 import { Page } from '@patternfly/react-core';
 import * as OCM from '@openshift-assisted/ui-lib/ocm';
 import { Header } from './Header';
@@ -16,10 +15,7 @@ const BrowserRouter18 = BrowserRouter as any as React.FC<
 >;
 
 export const App: React.FC = () => (
-  <BrowserRouter18
-    basename={Config.routeBasePath}
-    future={{ v7_relativeSplatPath: true, v7_fetcherPersist: true, v7_startTransition: true }}
-  >
+  <BrowserRouter18 basename={Config.routeBasePath}>
     <Page masthead={<Header />} isManagedSidebar defaultManagedSidebarIsOpen={false}>
       <UILibRoutes allEnabledFeatures={Features.STANDALONE_DEPLOYMENT_ENABLED_FEATURES}>
         <Route path={'/day2-flow-mock'} element={<HostsClusterDetailTabMock />} />

--- a/apps/assisted-ui/src/components/App.tsx
+++ b/apps/assisted-ui/src/components/App.tsx
@@ -16,7 +16,10 @@ const BrowserRouter18 = BrowserRouter as any as React.FC<
 >;
 
 export const App: React.FC = () => (
-  <BrowserRouter18 basename={Config.routeBasePath}>
+  <BrowserRouter18
+    basename={Config.routeBasePath}
+    future={{ v7_relativeSplatPath: true, v7_fetcherPersist: true, v7_startTransition: true }}
+  >
     <Page masthead={<Header />} isManagedSidebar defaultManagedSidebarIsOpen={false}>
       <UILibRoutes allEnabledFeatures={Features.STANDALONE_DEPLOYMENT_ENABLED_FEATURES}>
         <Route path={'/day2-flow-mock'} element={<HostsClusterDetailTabMock />} />

--- a/apps/assisted-ui/src/components/Header.tsx
+++ b/apps/assisted-ui/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 import { Brand, Masthead, MastheadLogo, MastheadMain, MastheadBrand } from '@patternfly/react-core';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { AboutButton } from './AboutButton';
 import { FeedbackButton } from './FeedbackButton';
 

--- a/apps/assisted-ui/src/components/Header.tsx
+++ b/apps/assisted-ui/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import type React from 'react';
 import { Brand, Masthead, MastheadLogo, MastheadMain, MastheadBrand } from '@patternfly/react-core';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router-dom';
 import { Config } from '@openshift-assisted/ui-lib/ocm';
 import { AboutButton } from './AboutButton';
 import { FeedbackButton } from './FeedbackButton';

--- a/apps/assisted-ui/src/components/Header.tsx
+++ b/apps/assisted-ui/src/components/Header.tsx
@@ -1,16 +1,13 @@
 import type React from 'react';
 import { Brand, Masthead, MastheadLogo, MastheadMain, MastheadBrand } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
-import { Config } from '@openshift-assisted/ui-lib/ocm';
 import { AboutButton } from './AboutButton';
 import { FeedbackButton } from './FeedbackButton';
-
-const clustersListPath = `${Config.routeBasePath}/clusters`;
 
 export const Header: React.FC = () => (
   <Masthead style={{ display: 'flex', justifyContent: 'space-between' }}>
     <MastheadBrand>
-      <MastheadLogo component={(props) => <Link {...props} to={clustersListPath} />}>
+      <MastheadLogo component={(props) => <Link {...props} to={'..'} />}>
         <Brand
           src="/logo.svg"
           alt="OpenShift Container Platform Assisted Installer"

--- a/libs/ui-lib-tests/cypress/@types/Cypress.d.ts
+++ b/libs/ui-lib-tests/cypress/@types/Cypress.d.ts
@@ -9,7 +9,7 @@ declare namespace Cypress {
     pasteText(selector: string, text: string): Chainable<Element>;
     newByDataTestId(selector: string, timeout?: number): Chainable<JQuery<HTMLElement>>;
     hostDetailSelector(i: number, label: string, timeout?: number): Chainable<Element>;
-    getClusterNameLinkSelector(clusterName?: string): Chainable<Element>;
+    getClusterLink(clusterId?: string): Chainable<Element>;
     setTestEnvironment(conf: AIInterceptsConfig);
   }
 }

--- a/libs/ui-lib-tests/cypress/integration/ui-behaviour/navigation.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/ui-behaviour/navigation.cy.ts
@@ -1,0 +1,122 @@
+import { commonActions } from '../../views/common';
+import { clusterListPage } from '../../views/clusterList';
+
+describe('Navigation Tests', () => {
+  const setTestStartSignal = (activeSignal: string) => {
+    cy.setTestEnvironment({
+      activeSignal,
+      activeScenario: 'AI_CREATE_MULTINODE',
+    });
+  };
+
+  before(() => setTestStartSignal('CLUSTER_CREATED'));
+
+  beforeEach(() => {
+    setTestStartSignal('CLUSTER_CREATED');
+  });
+
+  describe('Direct Route Navigation', () => {
+    it('Should navigate to clusters list route', () => {
+      cy.visit('/assisted-installer/clusters');
+      cy.url().should('include', '/assisted-installer/clusters');
+      clusterListPage.getCreateNewClusterButton().should('be.visible');
+    });
+
+    it('Should navigate to new cluster creation route', () => {
+      cy.visit('/assisted-installer/clusters/~new');
+      cy.url().should('include', '/assisted-installer/clusters/~new');
+      commonActions.verifyIsAtStep('Cluster details');
+    });
+
+    it('Should navigate to cluster details route', () => {
+      cy.visit(`/assisted-installer/clusters/${Cypress.env('clusterId')}`);
+      cy.url().should('include', `/assisted-installer/clusters/${Cypress.env('clusterId')}`);
+      commonActions.verifyIsAtStep('Host discovery');
+    });
+  });
+
+  describe('Header Navigation', () => {
+    it('Should navigate to clusters list when clicking masthead logo from new cluster page', () => {
+      cy.visit('/assisted-installer/clusters/~new');
+      cy.get('.pf-v6-c-masthead__brand a').click();
+      cy.url().should('include', '/clusters');
+      clusterListPage.getCreateNewClusterButton().should('be.visible');
+    });
+
+    it('Should navigate to clusters list when clicking masthead logo from cluster details page', () => {
+      cy.visit(`/assisted-installer/clusters/${Cypress.env('clusterId')}`);
+      cy.get('.pf-v6-c-masthead__brand a').click();
+      cy.url().should('include', '/clusters');
+      clusterListPage.getCreateNewClusterButton().should('be.visible');
+    });
+  });
+
+  describe('Clusters List Navigation', () => {
+    beforeEach(() => {
+      cy.visit('/assisted-installer/clusters');
+    });
+
+    it('Should navigate to new cluster page when clicking Create Cluster button', () => {
+      clusterListPage.getCreateNewClusterButton().click();
+      cy.url().should('include', '/assisted-installer/clusters/~new');
+      commonActions.verifyIsAtStep('Cluster details');
+    });
+
+    it('Should navigate to cluster details when clicking cluster name link', () => {
+      cy.getClusterLink().click();
+      cy.url().should('include', `/assisted-installer/clusters/${Cypress.env('clusterId')}`);
+      commonActions.verifyIsAtStep('Host discovery');
+    });
+  });
+
+  describe('Cluster Wizard Navigation', () => {
+    beforeEach(() => {
+      cy.visit('/assisted-installer/clusters/~new');
+    });
+
+    it('Should navigate to clusters list when clicking Cancel button in wizard footer', () => {
+      cy.get('button[name="cancel"]').click();
+      cy.url().should('include', '/assisted-installer/clusters');
+      cy.url().should('not.include', '~new');
+      clusterListPage.getCreateNewClusterButton().should('be.visible');
+    });
+  });
+
+  describe('Cluster Details Navigation', () => {
+    beforeEach(() => {
+      cy.visit(`/assisted-installer/clusters/${Cypress.env('clusterId')}`);
+    });
+
+    it('Should navigate to clusters list when clicking breadcrumb link', () => {
+      cy.get('.pf-v6-c-breadcrumb__item').contains('Assisted Clusters').click();
+      cy.url().should('include', '/assisted-installer/clusters');
+      cy.url().should('not.include', Cypress.env('clusterId'));
+      clusterListPage.getCreateNewClusterButton().should('be.visible');
+    });
+  });
+
+  describe('Error Handling & Redirects', () => {
+    it('Should redirect to clusters list when navigating to invalid route', () => {
+      cy.visit('/this-url/is/total-nonsense');
+      cy.url().should('include', '/assisted-installer/clusters');
+      cy.url().should('not.include', 'total-nonsense');
+    });
+
+    it('Should show error state with BackButton and navigate when clicked', () => {
+      cy.intercept('GET', '/api/assisted-install/v2/clusters/default-config', {
+        statusCode: 500,
+        body: { code: 500, message: 'Internal server error' },
+      }).as('get-default-config-error');
+
+      cy.visit(`/assisted-installer/clusters/${Cypress.env('clusterId')}`);
+      cy.wait('@get-default-config-error');
+
+      cy.contains('Failed to retrieve the default configuration').should('be.visible');
+      cy.get('.pf-v6-c-button').contains('Back').should('be.visible').click();
+
+      cy.url().should('include', '/assisted-installer/clusters');
+      cy.url().should('not.include', Cypress.env('clusterId'));
+      clusterListPage.getCreateNewClusterButton().should('be.visible');
+    });
+  });
+});

--- a/libs/ui-lib-tests/cypress/support/selectors.ts
+++ b/libs/ui-lib-tests/cypress/support/selectors.ts
@@ -17,6 +17,6 @@ Cypress.Commands.add(
     ),
 );
 
-Cypress.Commands.add('getClusterNameLinkSelector', (clusterName = Cypress.env('CLUSTER_NAME')) =>
-  cy.get(`#cluster-link-${clusterName}`),
+Cypress.Commands.add('getClusterLink', (clusterId = Cypress.env('clusterId')) =>
+  cy.get(`#cluster-link-${clusterId}`),
 );

--- a/libs/ui-lib-tests/cypress/views/clusterList.ts
+++ b/libs/ui-lib-tests/cypress/views/clusterList.ts
@@ -11,11 +11,7 @@ export const clusterListPage = {
   getCreateNewClusterButton: () => {
     return cy.get(Cypress.env('createNewClusterId')).scrollIntoView();
   },
-  openCluster: (clusterName = Cypress.env('CLUSTER_NAME')) => {
-    cy.getClusterNameLinkSelector(clusterName).click();
-    cy.get('.pf-v6-c-breadcrumb__list > :nth-child(3)').should('contain', clusterName);
-    cy.get(Cypress.env('clusterNameFieldId')).should('have.value', clusterName);
-  },
+
   deleteCluster: (clusterName = Cypress.env('CLUSTER_NAME')) => {
     cy.get(`${Cypress.env('clusterRowIdPrefix')}${clusterName}`)
       .scrollIntoView()

--- a/libs/ui-lib/lib/cim/components/Agent/NoAgentsAlert.tsx
+++ b/libs/ui-lib/lib/cim/components/Agent/NoAgentsAlert.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Alert, AlertVariant, List, ListComponent, ListItem } from '@patternfly/react-core';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
 import { Trans } from 'react-i18next';
 import { architectureData, CpuArchitecture, SupportedCpuArchitecture } from '../../../common';

--- a/libs/ui-lib/lib/cim/components/Agent/NoAgentsAlert.tsx
+++ b/libs/ui-lib/lib/cim/components/Agent/NoAgentsAlert.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Alert, AlertVariant, List, ListComponent, ListItem } from '@patternfly/react-core';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router-dom';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
 import { Trans } from 'react-i18next';
 import { architectureData, CpuArchitecture, SupportedCpuArchitecture } from '../../../common';

--- a/libs/ui-lib/lib/cim/components/Agent/tableColumns.tsx
+++ b/libs/ui-lib/lib/cim/components/Agent/tableColumns.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { TFunction } from 'i18next';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Host } from '@openshift-assisted/types/assisted-installer-service';
 import { HostsTableActions, getInventory, getHostname, Hostname } from '../../../common';
 import { TableRow } from '../../../common/components/hosts/AITable';

--- a/libs/ui-lib/lib/cim/components/Agent/tableColumns.tsx
+++ b/libs/ui-lib/lib/cim/components/Agent/tableColumns.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { TFunction } from 'i18next';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router-dom';
 import { Host } from '@openshift-assisted/types/assisted-installer-service';
 import { HostsTableActions, getInventory, getHostname, Hostname } from '../../../common';
 import { TableRow } from '../../../common/components/hosts/AITable';

--- a/libs/ui-lib/lib/cim/components/Hypershift/DetailsPage/NodePoolsTable.tsx
+++ b/libs/ui-lib/lib/cim/components/Hypershift/DetailsPage/NodePoolsTable.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router-dom';
 import { Button, Label, Popover, Stack, StackItem } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons/dist/js/icons/plus-circle-icon';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';

--- a/libs/ui-lib/lib/cim/components/Hypershift/DetailsPage/NodePoolsTable.tsx
+++ b/libs/ui-lib/lib/cim/components/Hypershift/DetailsPage/NodePoolsTable.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { Button, Label, Popover, Stack, StackItem } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons/dist/js/icons/plus-circle-icon';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';

--- a/libs/ui-lib/lib/cim/components/InfraEnv/AddHostDropdown.tsx
+++ b/libs/ui-lib/lib/cim/components/InfraEnv/AddHostDropdown.tsx
@@ -18,7 +18,7 @@ import { AddBmcHostModal, AddBmcHostYamlModal, AddHostModal } from '../modals';
 import { AddHostDropdownProps } from './types';
 import './AddHostDropdown.css';
 import { Trans } from 'react-i18next';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router-dom';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons/dist/js/icons/outlined-question-circle-icon';
 
 type ModalType = 'iso' | 'bmc' | 'yaml' | 'ipxe' | undefined;

--- a/libs/ui-lib/lib/cim/components/InfraEnv/AddHostDropdown.tsx
+++ b/libs/ui-lib/lib/cim/components/InfraEnv/AddHostDropdown.tsx
@@ -18,7 +18,7 @@ import { AddBmcHostModal, AddBmcHostYamlModal, AddHostModal } from '../modals';
 import { AddHostDropdownProps } from './types';
 import './AddHostDropdown.css';
 import { Trans } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons/dist/js/icons/outlined-question-circle-icon';
 
 type ModalType = 'iso' | 'bmc' | 'yaml' | 'ipxe' | undefined;

--- a/libs/ui-lib/lib/cim/components/modals/CimConfiguration/CimConfigProgressAlert.tsx
+++ b/libs/ui-lib/lib/cim/components/modals/CimConfiguration/CimConfigProgressAlert.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import {
   Alert,
   AlertVariant,
@@ -69,7 +69,7 @@ export const CimConfigProgressAlert: React.FC<CimConfigProgressAlertProps> = ({
       variant={ButtonVariant.link}
       isInline
       key="assisted-service-deployment"
-      onClick={() => navigate(assistedServiceDeploymentUrl)}
+      onClick={() => void navigate(assistedServiceDeploymentUrl)}
     >
       {t('ai:Troubleshoot in the assisted service deployment')}
     </Button>

--- a/libs/ui-lib/lib/cim/components/modals/CimConfiguration/CimConfigProgressAlert.tsx
+++ b/libs/ui-lib/lib/cim/components/modals/CimConfiguration/CimConfigProgressAlert.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router-dom';
 import {
   Alert,
   AlertVariant,

--- a/libs/ui-lib/lib/cim/components/modals/CimConfiguration/CimStorageMissingAlert.tsx
+++ b/libs/ui-lib/lib/cim/components/modals/CimConfiguration/CimStorageMissingAlert.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router-dom';
 import { Alert, AlertActionLink, AlertVariant } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 

--- a/libs/ui-lib/lib/cim/components/modals/CimConfiguration/CimStorageMissingAlert.tsx
+++ b/libs/ui-lib/lib/cim/components/modals/CimConfiguration/CimStorageMissingAlert.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Alert, AlertActionLink, AlertVariant } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 
@@ -20,7 +20,10 @@ export const CimStorageMissingAlert: React.FC<{
   );
 
   const actionLinks: React.ReactNode[] = [
-    <AlertActionLink key="install-storage-operator" onClick={() => navigate(storageOperatorUrl)}>
+    <AlertActionLink
+      key="install-storage-operator"
+      onClick={() => void navigate(storageOperatorUrl)}
+    >
       {t('ai:Install storage operator')}
     </AlertActionLink>,
     <AlertActionLink key="storage-class" onClick={() => window.open(docStorageUrl, '_blank')}>

--- a/libs/ui-lib/lib/cim/components/modals/MassDeleteAgentModal.tsx
+++ b/libs/ui-lib/lib/cim/components/modals/MassDeleteAgentModal.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { TFunction } from 'i18next';
 import { Button, Flex, FlexItem, Icon, Popover } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons/dist/js/icons/info-circle-icon';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import { Host } from '@openshift-assisted/types/assisted-installer-service';
 import {

--- a/libs/ui-lib/lib/cim/components/modals/MassDeleteAgentModal.tsx
+++ b/libs/ui-lib/lib/cim/components/modals/MassDeleteAgentModal.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { TFunction } from 'i18next';
 import { Button, Flex, FlexItem, Icon, Popover } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons/dist/js/icons/info-circle-icon';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router-dom';
 
 import { Host } from '@openshift-assisted/types/assisted-installer-service';
 import {

--- a/libs/ui-lib/lib/ocm/components/Routes.tsx
+++ b/libs/ui-lib/lib/ocm/components/Routes.tsx
@@ -7,7 +7,7 @@ import {
   Outlet,
   unstable_HistoryRouter as HistoryRouter,
   HistoryRouterProps,
-} from 'react-router-dom-v5-compat';
+} from 'react-router-dom';
 import { Clusters, ClusterPage, NewClusterPage } from './clusters';
 import type { FeatureListType } from '../../common/features/featureGate';
 import { AssistedUILibVersion } from './ui';

--- a/libs/ui-lib/lib/ocm/components/Routes.tsx
+++ b/libs/ui-lib/lib/ocm/components/Routes.tsx
@@ -7,7 +7,7 @@ import {
   Outlet,
   unstable_HistoryRouter as HistoryRouter,
   HistoryRouterProps,
-} from 'react-router-dom';
+} from 'react-router';
 import { Clusters, ClusterPage, NewClusterPage } from './clusters';
 import type { FeatureListType } from '../../common/features/featureGate';
 import { AssistedUILibVersion } from './ui';

--- a/libs/ui-lib/lib/ocm/components/Routes.tsx
+++ b/libs/ui-lib/lib/ocm/components/Routes.tsx
@@ -39,7 +39,7 @@ export const UILibRoutes = ({
           <Route index element={<Clusters />} />
         </Route>
         {children}
-        <Route path="*" element={<Navigate to="assisted-installer/clusters" />} />
+        <Route path="*" element={<Navigate to="/assisted-installer/clusters" />} />
       </Routes>
     </>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterDetail/AssistedInstallerDetailCard.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterDetail/AssistedInstallerDetailCard.tsx
@@ -33,7 +33,7 @@ import {
   unstable_HistoryRouter as HistoryRouter,
   HistoryRouterProps,
   BrowserRouter,
-} from 'react-router-dom-v5-compat';
+} from 'react-router-dom';
 
 type AssistedInstallerDetailCardProps = {
   aiClusterId: string;

--- a/libs/ui-lib/lib/ocm/components/clusterDetail/AssistedInstallerDetailCard.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterDetail/AssistedInstallerDetailCard.tsx
@@ -66,7 +66,9 @@ const ClusterLoadFailed = ({ clusterId, error }: { clusterId: Cluster['id']; err
         </Title>
       </CardHeader>
       <CardBody>
-        <BrowserRouter>
+        <BrowserRouter
+          future={{ v7_relativeSplatPath: true, v7_startTransition: true, v7_fetcherPersist: true }}
+        >
           <ErrorState
             title="Failed to fetch the cluster"
             fetchData={fetchCluster}
@@ -87,7 +89,9 @@ const LoadingDefaultConfigFailedCard = () => (
       </Title>
     </CardHeader>
     <CardBody>
-      <BrowserRouter>
+      <BrowserRouter
+        future={{ v7_relativeSplatPath: true, v7_startTransition: true, v7_fetcherPersist: true }}
+      >
         <ErrorState
           title="Failed to retrieve the default configuration"
           actions={[<BackButton key={'cancel'} to={'/cluster-list'} />]}
@@ -181,7 +185,11 @@ const AssistedInstallerDetailCard = ({
           {clusterDetailCard}
         </HistoryRouter>
       ) : (
-        <BrowserRouter>{clusterDetailCard}</BrowserRouter>
+        <BrowserRouter
+          future={{ v7_relativeSplatPath: true, v7_startTransition: true, v7_fetcherPersist: true }}
+        >
+          {clusterDetailCard}
+        </BrowserRouter>
       )}
     </>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterDetail/AssistedInstallerDetailCard.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterDetail/AssistedInstallerDetailCard.tsx
@@ -33,7 +33,7 @@ import {
   unstable_HistoryRouter as HistoryRouter,
   HistoryRouterProps,
   BrowserRouter,
-} from 'react-router-dom';
+} from 'react-router';
 
 type AssistedInstallerDetailCardProps = {
   aiClusterId: string;
@@ -66,9 +66,7 @@ const ClusterLoadFailed = ({ clusterId, error }: { clusterId: Cluster['id']; err
         </Title>
       </CardHeader>
       <CardBody>
-        <BrowserRouter
-          future={{ v7_relativeSplatPath: true, v7_startTransition: true, v7_fetcherPersist: true }}
-        >
+        <BrowserRouter>
           <ErrorState
             title="Failed to fetch the cluster"
             fetchData={fetchCluster}
@@ -89,9 +87,7 @@ const LoadingDefaultConfigFailedCard = () => (
       </Title>
     </CardHeader>
     <CardBody>
-      <BrowserRouter
-        future={{ v7_relativeSplatPath: true, v7_startTransition: true, v7_fetcherPersist: true }}
-      >
+      <BrowserRouter>
         <ErrorState
           title="Failed to retrieve the default configuration"
           actions={[<BackButton key={'cancel'} to={'/cluster-list'} />]}
@@ -185,11 +181,7 @@ const AssistedInstallerDetailCard = ({
           {clusterDetailCard}
         </HistoryRouter>
       ) : (
-        <BrowserRouter
-          future={{ v7_relativeSplatPath: true, v7_startTransition: true, v7_fetcherPersist: true }}
-        >
-          {clusterDetailCard}
-        </BrowserRouter>
+        <BrowserRouter>{clusterDetailCard}</BrowserRouter>
       )}
     </>
   );

--- a/libs/ui-lib/lib/ocm/components/clusterDetail/ClusterDetail.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterDetail/ClusterDetail.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router-dom';
 import { Stack, StackItem, Content, ButtonVariant, GridItem, Grid } from '@patternfly/react-core';
 import { ToolbarButton, Alerts, getEnabledHosts, selectOlmOperators, isSNO } from '../../../common';
 import { Cluster } from '@openshift-assisted/types/assisted-installer-service';

--- a/libs/ui-lib/lib/ocm/components/clusterDetail/ClusterDetail.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterDetail/ClusterDetail.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Stack, StackItem, Content, ButtonVariant, GridItem, Grid } from '@patternfly/react-core';
 import { ToolbarButton, Alerts, getEnabledHosts, selectOlmOperators, isSNO } from '../../../common';
 import { Cluster } from '@openshift-assisted/types/assisted-installer-service';
@@ -41,7 +41,7 @@ const ClusterDetail: React.FC<ClusterDetailProps> = ({ cluster }) => {
       try {
         const { data } = await ClustersAPI.allowAddHosts(cluster.id);
         updateCluster(data);
-        navigate(`${routeBasePath}/clusters/${cluster.id}`);
+        void navigate(`${routeBasePath}/clusters/${cluster.id}`);
       } catch (e) {
         handleApiError(e);
       }
@@ -102,7 +102,7 @@ const ClusterDetail: React.FC<ClusterDetailProps> = ({ cluster }) => {
           {!isSingleClusterFeatureEnabled && (
             <ToolbarButton
               variant={ButtonVariant.link}
-              onClick={() => navigate('..')}
+              onClick={() => void navigate('..')}
               id={getClusterDetailId('button-back-to-all-clusters')}
             >
               Back to all clusters

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterDetails.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterDetails.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import {
   useAlerts,

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterDetails.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterDetails.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import { useDispatch } from 'react-redux';
 import {
   useAlerts,
@@ -89,7 +89,7 @@ const ClusterDetails = ({ cluster, infraEnv }: ClusterDetailsProps) => {
           isAssistedMigration,
           isSingleClusterFeatureEnabled,
         );
-        navigate(`../${cluster.id}`, { state: ClusterWizardFlowStateNew });
+        void navigate(`../${cluster.id}`, { state: ClusterWizardFlowStateNew });
 
         if (isAssistedMigration) {
           try {

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterDetailsForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterDetailsForm.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { Flex, Grid, GridItem } from '@patternfly/react-core';
 import isUndefined from 'lodash-es/isUndefined.js';
 import { Formik, FormikHelpers } from 'formik';

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterDetailsForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterDetailsForm.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { useLocation } from 'react-router-dom-v5-compat';
+import { useLocation } from 'react-router-dom';
 import { Flex, Grid, GridItem } from '@patternfly/react-core';
 import isUndefined from 'lodash-es/isUndefined.js';
 import { Formik, FormikHelpers } from 'formik';

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
@@ -1,5 +1,5 @@
 import React, { PropsWithChildren } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 import { ClusterWizardContextType, ClusterWizardContext } from './ClusterWizardContext';
 import {
   ClusterWizardFlowStateType,

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
@@ -1,5 +1,5 @@
 import React, { PropsWithChildren } from 'react';
-import { useLocation } from 'react-router-dom-v5-compat';
+import { useLocation } from 'react-router-dom';
 import { ClusterWizardContextType, ClusterWizardContext } from './ClusterWizardContext';
 import {
   ClusterWizardFlowStateType,

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardFooter.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardFooter.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router-dom';
 import { Alert, AlertGroup, AlertVariant } from '@patternfly/react-core';
 import {
   WizardFooter,

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardFooter.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardFooter.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Alert, AlertGroup, AlertVariant } from '@patternfly/react-core';
 import {
   WizardFooter,

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/Operators.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/Operators.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
-import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { Formik, FormikConfig, useFormikContext } from 'formik';
 import { Cluster } from '@openshift-assisted/types/assisted-installer-service';
 import {

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/Operators.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/Operators.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import { Formik, FormikConfig, useFormikContext } from 'formik';
 import { Cluster } from '@openshift-assisted/types/assisted-installer-service';
 import {
@@ -74,7 +74,7 @@ const OperatorsForm = ({ cluster }: { cluster: Cluster }) => {
 
   const handleNext = () => {
     if (window.location.pathname.indexOf('assisted-installer') > -1) {
-      navigate(pathname, { state: undefined, replace: true });
+      void navigate(pathname, { state: undefined, replace: true });
     }
     clusterWizardContext.moveNext();
   };

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/disconnected/ReviewStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/disconnected/ReviewStep.tsx
@@ -26,7 +26,7 @@ import {
 } from '@patternfly/react-core';
 import { Formik } from 'formik';
 import { saveAs } from 'file-saver';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router-dom';
 
 import { getOperatorSpecs } from '../../../../common/components/operators/operatorSpecs';
 

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/disconnected/ReviewStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/disconnected/ReviewStep.tsx
@@ -26,7 +26,7 @@ import {
 } from '@patternfly/react-core';
 import { Formik } from 'formik';
 import { saveAs } from 'file-saver';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 
 import { getOperatorSpecs } from '../../../../common/components/operators/operatorSpecs';
 
@@ -51,7 +51,7 @@ const ReviewStep = () => {
           <ClusterWizardFooter
             onNext={() => {
               downloadUrl && saveAs(downloadUrl);
-              navigate('/cluster-list');
+              void navigate('/cluster-list');
             }}
             onBack={moveBack}
             nextButtonText="Download ISO"

--- a/libs/ui-lib/lib/ocm/components/clusters/ClusterBreadcrumbs.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusters/ClusterBreadcrumbs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Breadcrumb, BreadcrumbItem, PageSection } from '@patternfly/react-core';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router-dom';
 import { isInOcm } from '../../../common/api';
 
 const ClusterBreadcrumbs = ({ clusterName }: { clusterName?: string }) => {

--- a/libs/ui-lib/lib/ocm/components/clusters/ClusterBreadcrumbs.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusters/ClusterBreadcrumbs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Breadcrumb, BreadcrumbItem, PageSection } from '@patternfly/react-core';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { isInOcm } from '../../../common/api';
 
 const ClusterBreadcrumbs = ({ clusterName }: { clusterName?: string }) => {

--- a/libs/ui-lib/lib/ocm/components/clusters/ClusterPage.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusters/ClusterPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useParams, Navigate } from 'react-router-dom';
+import { useParams, Navigate } from 'react-router';
 import { useDispatch } from 'react-redux';
 import { PageSection, Content } from '@patternfly/react-core';
 import {

--- a/libs/ui-lib/lib/ocm/components/clusters/ClusterPage.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusters/ClusterPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useParams, Navigate } from 'react-router-dom-v5-compat';
+import { useParams, Navigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import { PageSection, Content } from '@patternfly/react-core';
 import {

--- a/libs/ui-lib/lib/ocm/components/clusters/Clusters.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusters/Clusters.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router-dom';
 import { Button, ButtonVariant, Content, PageSection } from '@patternfly/react-core';
 import { AddCircleOIcon } from '@patternfly/react-icons/dist/js/icons/add-circle-o-icon';
 import {

--- a/libs/ui-lib/lib/ocm/components/clusters/Clusters.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusters/Clusters.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Button, ButtonVariant, Content, PageSection } from '@patternfly/react-core';
 import { AddCircleOIcon } from '@patternfly/react-icons/dist/js/icons/add-circle-o-icon';
 import {
@@ -85,7 +85,7 @@ const Clusters = () => {
             primaryAction={
               <Button
                 variant={ButtonVariant.primary}
-                onClick={() => navigate(`~new`)}
+                onClick={() => void navigate(`~new`)}
                 id="empty-state-new-cluster-button"
                 data-ouia-id="button-create-new-cluster"
               >

--- a/libs/ui-lib/lib/ocm/components/clusters/ClustersListToolbar.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusters/ClustersListToolbar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import {
   Toolbar,
   ToolbarItem,
@@ -172,7 +172,7 @@ const ClustersListToolbar: React.FC<ClustersListToolbarProps> = ({
         </CustomToolbarFilter>
         <ToolbarButton
           variant={ButtonVariant.primary}
-          onClick={() => navigate(`~new`)}
+          onClick={() => void navigate(`~new`)}
           id="button-create-new-cluster"
           data-ouia-id="button-create-new-cluster"
         >

--- a/libs/ui-lib/lib/ocm/components/clusters/ClustersListToolbar.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusters/ClustersListToolbar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router-dom';
 import {
   Toolbar,
   ToolbarItem,

--- a/libs/ui-lib/lib/ocm/components/ui/Buttons/BackButton.tsx
+++ b/libs/ui-lib/lib/ocm/components/ui/Buttons/BackButton.tsx
@@ -1,4 +1,4 @@
-import { Link, LinkProps } from 'react-router-dom';
+import { Link, LinkProps } from 'react-router';
 import type { ButtonProps } from '@patternfly/react-core';
 import { Button } from '@patternfly/react-core';
 import React from 'react';

--- a/libs/ui-lib/lib/ocm/components/ui/Buttons/BackButton.tsx
+++ b/libs/ui-lib/lib/ocm/components/ui/Buttons/BackButton.tsx
@@ -1,4 +1,4 @@
-import { Link, LinkProps } from 'react-router-dom-v5-compat';
+import { Link, LinkProps } from 'react-router-dom';
 import type { ButtonProps } from '@patternfly/react-core';
 import { Button } from '@patternfly/react-core';
 import React from 'react';

--- a/libs/ui-lib/lib/ocm/store/slices/clusters/selectors.tsx
+++ b/libs/ui-lib/lib/ocm/store/slices/clusters/selectors.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { createSelector } from '@reduxjs/toolkit';
 import type { Selector } from 'reselect';
 import type { IRow, IRowData } from '@patternfly/react-table';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router-dom';
 import type { TFunction } from 'i18next';
 import {
   DASH,
@@ -103,6 +103,7 @@ export const selectClusterTableRows = (t: TFunction): Selector<RootStateDay1, Cl
   );
 };
 
-export const selectClusterNames = createSelector(selectClusters, (clusters) =>
-  clusters.map((c) => c.name),
+export const selectClusterNames: Selector<RootStateDay1, (string | undefined)[]> = createSelector(
+  selectClusters,
+  (clusters) => clusters.map((c) => c.name),
 );

--- a/libs/ui-lib/lib/ocm/store/slices/clusters/selectors.tsx
+++ b/libs/ui-lib/lib/ocm/store/slices/clusters/selectors.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { createSelector } from '@reduxjs/toolkit';
 import type { Selector } from 'reselect';
 import type { IRow, IRowData } from '@patternfly/react-table';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import type { TFunction } from 'i18next';
 import {
   DASH,

--- a/libs/ui-lib/lib/ocm/store/slices/clusters/selectors.tsx
+++ b/libs/ui-lib/lib/ocm/store/slices/clusters/selectors.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { createSelector } from '@reduxjs/toolkit';
+import type { Selector } from 'reselect';
 import type { IRow, IRowData } from '@patternfly/react-table';
 import { Link } from 'react-router-dom-v5-compat';
 import type { TFunction } from 'i18next';
@@ -22,7 +23,7 @@ const selectClusters = (state: RootStateDay1) =>
   state.clusters.data.filter((c) => c.kind !== 'DisconnectedCluster');
 const clustersUIState = (state: RootStateDay1) => state.clusters.uiState;
 
-export const selectClustersUIState = createSelector(
+export const selectClustersUIState: (state: RootStateDay1) => ResourceUIState = createSelector(
   [selectClusters, clustersUIState],
   (clusters, uiState): ResourceUIState => {
     const { LOADED, EMPTY } = ResourceUIState;
@@ -95,7 +96,7 @@ const clusterToClusterTableRow = (cluster: Cluster, t: TFunction): IRow => {
 export const getClusterTableStatusCell = (rowData: IRowData) =>
   rowData?.cells?.[3] as HumanizedSortable;
 
-export const selectClusterTableRows = (t: TFunction) => {
+export const selectClusterTableRows = (t: TFunction): Selector<RootStateDay1, ClusterTableRows> => {
   return createSelector(
     selectClusters,
     (clusters): ClusterTableRows => clusters.map((c) => clusterToClusterTableRow(c, t)),

--- a/libs/ui-lib/lib/ocm/store/slices/feature-flags/selectors.ts
+++ b/libs/ui-lib/lib/ocm/store/slices/feature-flags/selectors.ts
@@ -1,12 +1,15 @@
 import type { FeatureListType } from '../../../../common/features/featureGate';
 import type { RootStateDay1 } from '../../store-day1';
 import { createSelector } from '@reduxjs/toolkit';
+import type { Selector } from 'reselect';
 
 export const selectFeatureFlagsSlice = (state: RootStateDay1) => state.featureFlags;
 
-export const isFeatureEnabled = (featureId: keyof FeatureListType) =>
+export const isFeatureEnabled = (
+  featureId: keyof FeatureListType,
+): Selector<RootStateDay1, boolean> =>
   createSelector(
     selectFeatureFlagsSlice,
-    (featureFlags: ReturnType<typeof selectFeatureFlagsSlice>) =>
+    (featureFlags: ReturnType<typeof selectFeatureFlagsSlice>): boolean =>
       featureFlags.data[featureId] ?? false,
   );

--- a/libs/ui-lib/lib/ocm/store/slices/infra-envs/selectors.ts
+++ b/libs/ui-lib/lib/ocm/store/slices/infra-envs/selectors.ts
@@ -1,10 +1,12 @@
 import { createSelector } from '@reduxjs/toolkit';
+import type { Selector } from 'reselect';
 import type { RootStateDay1 } from '../../store-day1';
 import type { CpuArchitecture } from '../../../../common';
+import type { InfraEnv } from '@openshift-assisted/types/assisted-installer-service';
 
 export const selectInfraEnvsSlice = (state: RootStateDay1) => state.infraEnvs;
 export const selectInfraEnvByCpuArchitecture = createSelector(
   [selectInfraEnvsSlice, (_: RootStateDay1, cpuArchitecture: CpuArchitecture) => cpuArchitecture],
-  (infraEnvs, cpuArchitecture) =>
+  (infraEnvs, cpuArchitecture): InfraEnv | undefined =>
     infraEnvs.find((infraEnv) => infraEnv.cpuArchitecture === cpuArchitecture),
-);
+) as Selector<RootStateDay1, InfraEnv | undefined, [CpuArchitecture]>;

--- a/libs/ui-lib/package.json
+++ b/libs/ui-lib/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "@openshift-assisted/locales": "workspace:*",
     "@openshift-assisted/types": "workspace:*",
-    "@openshift-console/dynamic-plugin-sdk": "^4.19.1",
+    "@openshift-console/dynamic-plugin-sdk": "^4.22.0",
     "@patternfly/patternfly": "6.4.0",
     "@patternfly/react-code-editor": "6.4.1",
     "@patternfly/react-core": "6.4.1",

--- a/libs/ui-lib/package.json
+++ b/libs/ui-lib/package.json
@@ -99,7 +99,7 @@
     "react-i18next": ">11.7.3",
     "react-monaco-editor": "^0.55.0 || ^0.59.0",
     "react-redux": "^8.0.5",
-    "react-router-dom": "^6.0.0",
+    "react-router": "^7.17.0",
     "redux": "^4.2.1",
     "uuid": "^8.1",
     "yup": "^1.4.0"

--- a/libs/ui-lib/package.json
+++ b/libs/ui-lib/package.json
@@ -99,7 +99,7 @@
     "react-i18next": ">11.7.3",
     "react-monaco-editor": "^0.55.0 || ^0.59.0",
     "react-redux": "^8.0.5",
-    "react-router-dom-v5-compat": "^6.30.3",
+    "react-router-dom": "^6.0.0",
     "redux": "^4.2.1",
     "uuid": "^8.1",
     "yup": "^1.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1656,7 +1656,7 @@ __metadata:
     react-i18next: ^11.11.4
     react-monaco-editor: ^0.59.0
     react-redux: ^8.0.5
-    react-router-dom: ^6.0.0
+    react-router: ^7.17.0
     redux: ^4
     uuid: ^14.0
     vite: ^8.0.16
@@ -1691,7 +1691,7 @@ __metadata:
     react: ^18.2.0
     react-dom: ^18.2.0
     react-i18next: ^11.11.4
-    react-router-dom: ^6.0.0
+    react-router: ^7.17.0
     rimraf: ^6.0.0
     ts-patch: ^3.0.2
     typescript: ^5.9.3
@@ -1729,7 +1729,7 @@ __metadata:
     react-i18next: ^11.11.4
     react-monaco-editor: ^0.59.0
     react-redux: ^8.0.5
-    react-router-dom: ^6.0.0
+    react-router: ^7.17.0
     redux: ^4
     uuid: ^14.0
     vite: ^8.0.16
@@ -1894,7 +1894,7 @@ __metadata:
     react-i18next: ">11.7.3"
     react-monaco-editor: ^0.55.0 || ^0.59.0
     react-redux: ^8.0.5
-    react-router-dom: ^6.0.0
+    react-router: ^7.17.0
     redux: ^4.2.1
     uuid: ^8.1
     yup: ^1.4.0
@@ -2807,13 +2807,6 @@ __metadata:
     react-redux:
       optional: true
   checksum: ac25dec73a5d2df9fc7fbe98c14ccc73919e5ee1d6f251db0d2ec8f90273f92ef39c26716704bf56b5a40189f72d94b4526dc3a8c7ac3986f5daf44442bcc364
-  languageName: node
-  linkType: hard
-
-"@remix-run/router@npm:1.23.3":
-  version: 1.23.3
-  resolution: "@remix-run/router@npm:1.23.3"
-  checksum: 95bfe4c8ef1f1f7e614ceacfcc7ae42a66325284fa1397fe5358197cfba1618bc0832979a42a0fdeca292f015baeacfd82a5395b1f13f86f8ea0f236420bcb3d
   languageName: node
   linkType: hard
 
@@ -6705,7 +6698,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie@npm:^1.1.1":
+"cookie@npm:^1.0.1, cookie@npm:^1.1.1":
   version: 1.1.1
   resolution: "cookie@npm:1.1.1"
   checksum: e40c4ff817a73ec0a41413654ca9a71e6207bd6e511151bb1d307aef2903eb59771127a85474afe0e12a8982804f7b03cce0bda798b55c306aca9608b4b9acab
@@ -14655,27 +14648,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:^6.0.0":
-  version: 6.30.4
-  resolution: "react-router-dom@npm:6.30.4"
+"react-router@npm:^7.17.0":
+  version: 7.18.0
+  resolution: "react-router@npm:7.18.0"
   dependencies:
-    "@remix-run/router": 1.23.3
-    react-router: 6.30.4
+    cookie: ^1.0.1
+    set-cookie-parser: ^2.6.0
   peerDependencies:
-    react: ">=16.8"
-    react-dom: ">=16.8"
-  checksum: 98f58ee14a71c392fa7c05b3e2dc7cdc54928b6d679c2cce891e26a51fe42c64d67af4ba0721dff51debd9bfbd03d738d3079e9c19533585f8c2b7cf653a437f
-  languageName: node
-  linkType: hard
-
-"react-router@npm:6.30.4":
-  version: 6.30.4
-  resolution: "react-router@npm:6.30.4"
-  dependencies:
-    "@remix-run/router": 1.23.3
-  peerDependencies:
-    react: ">=16.8"
-  checksum: a9c1d03dd22cc824515dd603eae5dc49f8ed973496eabf404771ad3cfacfd239ccdc7d8cb7e2c6adab6889501cafdcc8abefdf6a061676bfa02a9247cf9d6c50
+    react: ">=18"
+    react-dom: ">=18"
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+  checksum: 247b9747ff5eb07d2d262fe9dfd74cb90fc2b0ecabe242456bb37d204ccd7fdcbaa571e608bb93363b8185a2a372cb102ff0aa2cac54bc26737bbf7981127977
   languageName: node
   linkType: hard
 
@@ -15667,6 +15652,13 @@ __metadata:
     parseurl: ~1.3.3
     send: ~0.19.1
   checksum: ec7599540215e6676b223ea768bf7c256819180bf14f89d0b5d249a61bbb8f10b05b2a53048a153cb2cc7f3b367f1227d2fb715fe4b09d07299a9233eda1a453
+  languageName: node
+  linkType: hard
+
+"set-cookie-parser@npm:^2.6.0":
+  version: 2.7.2
+  resolution: "set-cookie-parser@npm:2.7.2"
+  checksum: 9e1b09e7184079c81f9ba4d2db3222854adf4e6e4fe73982388367649386a93e7f9b979333ddeba22610706def93c2478f34c3324fe223528cb2c4c879a2c2d3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -370,7 +370,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.5, @babel/runtime@npm:^7.14.6, @babel/runtime@npm:^7.19.0, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.5, @babel/runtime@npm:^7.14.6, @babel/runtime@npm:^7.19.0, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.9.2":
   version: 7.26.10
   resolution: "@babel/runtime@npm:7.26.10"
   dependencies:
@@ -512,22 +512,6 @@ __metadata:
     debug: ^3.1.0
     lodash.once: ^4.1.1
   checksum: 7bdcdaeb1bb692ec9d9bf8ec52538aa0bead6764753f4a067a171a511807a43fab016f7285a56bef6a606c2467ff3f1365e1ad2d2d583b81beed849ee1573fd1
-  languageName: node
-  linkType: hard
-
-"@dagrejs/dagre@npm:1.1.2":
-  version: 1.1.2
-  resolution: "@dagrejs/dagre@npm:1.1.2"
-  dependencies:
-    "@dagrejs/graphlib": 2.2.2
-  checksum: 70d0d746be64efe7f09d18c123f0a9a83339e46b3817d56effd76530795b78838ea5ed862a92897c90643403c9181723a79768bb8b8f3e0f65139393e95027cf
-  languageName: node
-  linkType: hard
-
-"@dagrejs/graphlib@npm:2.2.2":
-  version: 2.2.2
-  resolution: "@dagrejs/graphlib@npm:2.2.2"
-  checksum: ceb833f350a9b984dc8557bd9f4a4304e3fe7a9293295313e63f8b94a2808c8dac51cfd6bd3a17c26260507440d0c6025bfa7eb24eb8ce7eda211119929f5216
   languageName: node
   linkType: hard
 
@@ -1646,7 +1630,7 @@ __metadata:
   resolution: "@openshift-assisted/assisted-disconnected-ui@workspace:apps/assisted-disconnected-ui"
   dependencies:
     "@openshift-assisted/ui-lib": "workspace:*"
-    "@openshift-console/dynamic-plugin-sdk": ^4.19.1
+    "@openshift-console/dynamic-plugin-sdk": ^4.22.0
     "@patternfly/patternfly": 6.4.0
     "@patternfly/react-code-editor": 6.4.1
     "@patternfly/react-core": 6.4.1
@@ -1720,7 +1704,7 @@ __metadata:
   resolution: "@openshift-assisted/assisted-ui@workspace:apps/assisted-ui"
   dependencies:
     "@openshift-assisted/ui-lib": "workspace:*"
-    "@openshift-console/dynamic-plugin-sdk": ^4.19.1
+    "@openshift-console/dynamic-plugin-sdk": ^4.22.0
     "@patternfly/patternfly": 6.4.0
     "@patternfly/react-code-editor": 6.4.1
     "@patternfly/react-core": 6.4.1
@@ -1859,7 +1843,7 @@ __metadata:
   dependencies:
     "@openshift-assisted/locales": "workspace:*"
     "@openshift-assisted/types": "workspace:*"
-    "@openshift-console/dynamic-plugin-sdk": ^4.19.1
+    "@openshift-console/dynamic-plugin-sdk": ^4.22.0
     "@patternfly/patternfly": 6.4.0
     "@patternfly/react-code-editor": 6.4.1
     "@patternfly/react-core": 6.4.1
@@ -1919,25 +1903,39 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openshift-console/dynamic-plugin-sdk@npm:^4.19.1":
-  version: 4.21.0
-  resolution: "@openshift-console/dynamic-plugin-sdk@npm:4.21.0"
+"@openshift-console/dynamic-plugin-sdk@npm:^4.22.0":
+  version: 4.22.0
+  resolution: "@openshift-console/dynamic-plugin-sdk@npm:4.22.0"
   dependencies:
-    "@openshift/dynamic-plugin-sdk": ^5.0.1
-    "@patternfly/react-topology": ^6.2.0
-    immutable: 3.x
-    lodash: ^4.17.23
-    react: ^17.0.1
-    react-i18next: ^11.12.0
-    react-redux: 7.2.9
-    react-router: 5.3.x
-    react-router-dom: 5.3.x
-    react-router-dom-v5-compat: ^6.11.2
-    redux: ^4.0.4
-    redux-thunk: 2.4.0
-    reselect: 4.x
-    typesafe-actions: ^4.2.1
-  checksum: dcdac70f3f9d893092b0407b4bc499b63450169b5eddfba4c634c84d5baeaa0ca13f3748a3d25fb8893ff882794f84ce764674d42519a2c34c4724cb423d1233
+    "@openshift/dynamic-plugin-sdk": ^8.0.0
+    immutable: ^3.8.3
+    lodash: ^4.17.21
+    reselect: ^5.1.1
+    typesafe-actions: ^5.1.0
+  peerDependencies:
+    "@patternfly/react-topology": ~6.4.0
+    react: ^18.3.1
+    react-i18next: ~16.5.8
+    react-redux: ~9.2.0
+    react-router: ~7.13.1
+    redux: ~5.0.1
+    redux-thunk: ~3.1.0
+  peerDependenciesMeta:
+    "@patternfly/react-topology":
+      optional: true
+    react:
+      optional: true
+    react-i18next:
+      optional: true
+    react-redux:
+      optional: true
+    react-router:
+      optional: true
+    redux:
+      optional: true
+    redux-thunk:
+      optional: true
+  checksum: 1731439e264ca8dc60a3ea093a241f562b3f971069990fe22e88a9815969f0f85fc5455e146e3474269d483598fbed37ded3337219c32bc4b4ca6274c1d19220
   languageName: node
   linkType: hard
 
@@ -1965,6 +1963,20 @@ __metadata:
   peerDependencies:
     react: ^17 || ^18
   checksum: 66e54691ac257cee70b83e627d8fa13c1b0951cc322da0b7c0e2511b9467a9adcf59290ce9250a8ed1de9f98870d6100195afe5dce49ad9b88cf4fc3c991ad4e
+  languageName: node
+  linkType: hard
+
+"@openshift/dynamic-plugin-sdk@npm:^8.0.0":
+  version: 8.2.0
+  resolution: "@openshift/dynamic-plugin-sdk@npm:8.2.0"
+  dependencies:
+    lodash: ^4.17.23
+    semver: ^7.7.3
+    uuid: ^8.3.2
+    yup: ^1.7.1
+  peerDependencies:
+    react: ^18 || ^19
+  checksum: 12430967efe2e03c4ccdcf9e952dc2a0309a580d2f13b4d41f0b41785c55cb74353ce3454db1e8b7a90cb607364ebe866536e754c7d16fadbfdfa0347c1ff1ce
   languageName: node
   linkType: hard
 
@@ -2349,30 +2361,6 @@ __metadata:
   version: 6.2.2
   resolution: "@patternfly/react-tokens@npm:6.2.2"
   checksum: 27183f771e400c8fcf611545dd46ade39c6459506bcb9aa020346de69dda9717e75665c8aad92609dab93de4c2f0472e7958d1c127b0f722beb552dda3a1fbca
-  languageName: node
-  linkType: hard
-
-"@patternfly/react-topology@npm:^6.2.0":
-  version: 6.4.0
-  resolution: "@patternfly/react-topology@npm:6.4.0"
-  dependencies:
-    "@dagrejs/dagre": 1.1.2
-    "@patternfly/react-core": ^6.0.0
-    "@patternfly/react-icons": ^6.0.0
-    "@patternfly/react-styles": ^6.0.0
-    "@types/d3": ^7.4.0
-    "@types/d3-force": ^1.2.1
-    d3: ^7.8.0
-    mobx: ^6.9.0
-    mobx-react: ^7.6.0
-    point-in-svg-path: ^1.0.1
-    popper.js: ^1.16.1
-    tslib: ^2.0.0
-    webcola: 3.4.0
-  peerDependencies:
-    react: ^17 || ^18 || ^19
-    react-dom: ^17 || ^18 || ^19
-  checksum: 2893d8328a7d75cc5cea37fd164f807877b396920a9100f597d0c6adf84bfaa46754d97b0e60b5352f5dd65ee90591f86d2e65c751703316064cbb2459a27d5e
   languageName: node
   linkType: hard
 
@@ -3922,285 +3910,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/d3-array@npm:*":
-  version: 3.2.2
-  resolution: "@types/d3-array@npm:3.2.2"
-  checksum: 72e8e2abe0911cb431d6f3fe0a1f71b915356b679d4d9c826f52941bb30210c0fe8299dde066b08d9986754c620f031b13b13ab6dfc60d404eceab66a075dd5d
-  languageName: node
-  linkType: hard
-
-"@types/d3-axis@npm:*":
-  version: 3.0.6
-  resolution: "@types/d3-axis@npm:3.0.6"
-  dependencies:
-    "@types/d3-selection": "*"
-  checksum: ea1065d9e6d134c04427763603cbe9d549b8b5785b8ae0d002b5b14a362619d5b8f5ee3c2fda8b36b7e5a413cbcd387e1a2d89898b919a9f0cc91ad4e67b5ab5
-  languageName: node
-  linkType: hard
-
-"@types/d3-brush@npm:*":
-  version: 3.0.6
-  resolution: "@types/d3-brush@npm:3.0.6"
-  dependencies:
-    "@types/d3-selection": "*"
-  checksum: e5166bc53e5c914b1fed0a6ce55ca14d76ae11c5afd16b724b8ae47989e977c4af02bb07496d1ccd0a77f4ccd9a2ca7345e1d289bcfce16490fe4b39a9e0d170
-  languageName: node
-  linkType: hard
-
-"@types/d3-chord@npm:*":
-  version: 3.0.6
-  resolution: "@types/d3-chord@npm:3.0.6"
-  checksum: b511cf372ed8a0086d37a715c0d4aca811b614454e1f7c1561fbcd46863beaccdb115d274a7a992a30a8218393fbc3e1fdd7ca6e9d572e729a4570002c327083
-  languageName: node
-  linkType: hard
-
-"@types/d3-color@npm:*":
-  version: 3.1.3
-  resolution: "@types/d3-color@npm:3.1.3"
-  checksum: 8a0e79a709929502ec4effcee2c786465b9aec51b653ba0b5d05dbfec3e84f418270dd603002d94021885061ff592f614979193bd7a02ad76317f5608560e357
-  languageName: node
-  linkType: hard
-
-"@types/d3-contour@npm:*":
-  version: 3.0.6
-  resolution: "@types/d3-contour@npm:3.0.6"
-  dependencies:
-    "@types/d3-array": "*"
-    "@types/geojson": "*"
-  checksum: 83c13eb0567e95d6675d6d81cbeab38d0899c5af70a7c69354e23e0860ddb2f3e911d2cacd33a8baa60ce7846b38785a337b2d7c8d2763a1340bfb999b4bd2ab
-  languageName: node
-  linkType: hard
-
-"@types/d3-delaunay@npm:*":
-  version: 6.0.4
-  resolution: "@types/d3-delaunay@npm:6.0.4"
-  checksum: 502fe0eb91f7d05b0f57904d68028c24348a54b1e5458009caf662de995d0e59bd82cd701b4af0087d614ee9e456d415fe32d63c25272ca753bf12b3f27b2d77
-  languageName: node
-  linkType: hard
-
-"@types/d3-dispatch@npm:*":
-  version: 3.0.7
-  resolution: "@types/d3-dispatch@npm:3.0.7"
-  checksum: ce7ab5a7d5c64aacf563797c0c61f3862b9ff687cb35470fe462219f09e402185646f51707339beede616586d92ded6974c3958dbeb15e35a85b1ecfafdf13a8
-  languageName: node
-  linkType: hard
-
-"@types/d3-drag@npm:*":
-  version: 3.0.7
-  resolution: "@types/d3-drag@npm:3.0.7"
-  dependencies:
-    "@types/d3-selection": "*"
-  checksum: 1107cb1667ead79073741c06ea4a9e8e4551698f6c9c60821e327a6aa30ca2ba0b31a6fe767af85a2e38a22d2305f6c45b714df15c2bba68adf58978223a5fc5
-  languageName: node
-  linkType: hard
-
-"@types/d3-dsv@npm:*":
-  version: 3.0.7
-  resolution: "@types/d3-dsv@npm:3.0.7"
-  checksum: 5025e01459827d09d14e0d00281995a04042ce9e3e76444c5a65466c1d29649d82cbfaa9251e33837bf576f5c587525d8d8ff5aacc6bd3b831824d54449261b9
-  languageName: node
-  linkType: hard
-
-"@types/d3-ease@npm:*":
-  version: 3.0.2
-  resolution: "@types/d3-ease@npm:3.0.2"
-  checksum: 0885219966294bfc99548f37297e1c75e75da812a5f3ec941977ebb57dcab0a25acec5b2bbd82d09a49d387daafca08521ca269b7e4c27ddca7768189e987b54
-  languageName: node
-  linkType: hard
-
-"@types/d3-fetch@npm:*":
-  version: 3.0.7
-  resolution: "@types/d3-fetch@npm:3.0.7"
-  dependencies:
-    "@types/d3-dsv": "*"
-  checksum: e60cf60b25cbc49b2066ac2a3638f610c7379000562b0f499dd90fd57a8cb9740c24667a70496c2a66456d42867afeffb1722a75b26d95e7d7ee8667d96b0b36
-  languageName: node
-  linkType: hard
-
-"@types/d3-force@npm:*":
-  version: 3.0.10
-  resolution: "@types/d3-force@npm:3.0.10"
-  checksum: 0faf1321ddd85f7bf25769ee97513b380a897791ad1cd6c4282f09e0108e566132fad80f4c73cdb592a352139b22388d3c77458298a00f92ef72e27019fb33c7
-  languageName: node
-  linkType: hard
-
-"@types/d3-force@npm:^1.2.1":
-  version: 1.2.7
-  resolution: "@types/d3-force@npm:1.2.7"
-  checksum: 9290f55beebcb4826b9b92dab2bb5204ca76a546ef5d84ded789f915605196da52d548f0a7b23c6e4327a1361096a20b096a9918148d1e0f3a10945a332b1844
-  languageName: node
-  linkType: hard
-
-"@types/d3-format@npm:*":
-  version: 3.0.4
-  resolution: "@types/d3-format@npm:3.0.4"
-  checksum: e69421cd93861a0c080084b0b23d4a5d6a427497559e46898189002fb756dae2c7c858b465308f6bcede7272b90e39ce8adab810bded2309035a5d9556c59134
-  languageName: node
-  linkType: hard
-
-"@types/d3-geo@npm:*":
-  version: 3.1.0
-  resolution: "@types/d3-geo@npm:3.1.0"
-  dependencies:
-    "@types/geojson": "*"
-  checksum: a4b2daa8a64012912ce7186891e8554af123925dca344c111b771e168a37477e02d504c6c94ee698440380e8c4f3f373d6755be97935da30eae0904f6745ce40
-  languageName: node
-  linkType: hard
-
-"@types/d3-hierarchy@npm:*":
-  version: 3.1.7
-  resolution: "@types/d3-hierarchy@npm:3.1.7"
-  checksum: 69746b3a65e0fe0ceb3ffcb1a8840a61e271eadb32eccb5034f0fce036d24801aef924ee45b99246580c9f7c81839ab0555f776a11773d82e860d522a2ff1c0e
-  languageName: node
-  linkType: hard
-
-"@types/d3-interpolate@npm:*":
-  version: 3.0.4
-  resolution: "@types/d3-interpolate@npm:3.0.4"
-  dependencies:
-    "@types/d3-color": "*"
-  checksum: efd2770e174e84fc7316fdafe03cf3688451f767dde1fa6211610137f495be7f3923db7e1723a6961a0e0e9ae0ed969f4f47c038189fa0beb1d556b447922622
-  languageName: node
-  linkType: hard
-
-"@types/d3-path@npm:*":
-  version: 3.1.1
-  resolution: "@types/d3-path@npm:3.1.1"
-  checksum: fee8f6b0d3b28a3611c7d7fda3bf2f79392ded266f54b03a220f205c42117644bdcd33dcbf4853da3cca02229f1c669d2a60d5d297a24ce459ba8271ccb26c03
-  languageName: node
-  linkType: hard
-
-"@types/d3-polygon@npm:*":
-  version: 3.0.2
-  resolution: "@types/d3-polygon@npm:3.0.2"
-  checksum: 7cf1eadb54f02dd3617512b558f4c0f3811f8a6a8c887d9886981c3cc251db28b68329b2b0707d9f517231a72060adbb08855227f89bef6ef30caedc0a67cab2
-  languageName: node
-  linkType: hard
-
-"@types/d3-quadtree@npm:*":
-  version: 3.0.6
-  resolution: "@types/d3-quadtree@npm:3.0.6"
-  checksum: 631fb1a50dbe4fb0c97574891b180ec3d6a0f524bbd8aee8dfd44eda405e7ed1ca2b03d5568a35f697d09e5e4b598117e149236874b0c8764979a3d6242bb0bc
-  languageName: node
-  linkType: hard
-
-"@types/d3-random@npm:*":
-  version: 3.0.3
-  resolution: "@types/d3-random@npm:3.0.3"
-  checksum: 33285b57768a724d2466ac1deec002432805c9df3e475ffb7f7fec66681cfe3e18d2f68b7f8ba45f400b274907bbebfe8adff14c9a97ef1987e476135e784925
-  languageName: node
-  linkType: hard
-
-"@types/d3-scale-chromatic@npm:*":
-  version: 3.1.0
-  resolution: "@types/d3-scale-chromatic@npm:3.1.0"
-  checksum: cb7b86deac077c7c217a52a3f658cdfb812cff8708404fbfe54918c03ead545e1df87df377e9c4eab21c9d6c1aeee6471320e02a5b6b27e2e3f786a12a82ab02
-  languageName: node
-  linkType: hard
-
-"@types/d3-scale@npm:*":
-  version: 4.0.9
-  resolution: "@types/d3-scale@npm:4.0.9"
-  dependencies:
-    "@types/d3-time": "*"
-  checksum: c44265a38e538983686b1b8d159abfb4e81c09b33316f3a68f0f372d38400fa950ad531644d25230cc7b48ea5adb50270fc54823f088979ade62dcd0225f7aa3
-  languageName: node
-  linkType: hard
-
-"@types/d3-selection@npm:*":
-  version: 3.0.11
-  resolution: "@types/d3-selection@npm:3.0.11"
-  checksum: 4b76630f76dffdafc73cdc786d73e7b4c96f40546483074b3da0e7fe83fd7f5ed9bc6c50f79bcef83595f943dcc9ed6986953350f39371047af644cc39c41b43
-  languageName: node
-  linkType: hard
-
-"@types/d3-shape@npm:*":
-  version: 3.1.8
-  resolution: "@types/d3-shape@npm:3.1.8"
-  dependencies:
-    "@types/d3-path": "*"
-  checksum: 659d51882dccc85d24817bdbcd50589212d12e24eb2aad19bae073665ed25443026e120966faa8523f0412f8a30f7c16002499cea3eb87d25b3011e0ee42e6a2
-  languageName: node
-  linkType: hard
-
-"@types/d3-time-format@npm:*":
-  version: 4.0.3
-  resolution: "@types/d3-time-format@npm:4.0.3"
-  checksum: e981fc9780697a9d8c5d1ddf1167d9c6bc28e4e610afddff1384fe55e6eb52cb65309b2a0a1d4cf817413b0a80b9f1a652fe0b2cb8054ace4eafff80a6093aa5
-  languageName: node
-  linkType: hard
-
-"@types/d3-time@npm:*":
-  version: 3.0.4
-  resolution: "@types/d3-time@npm:3.0.4"
-  checksum: 0c296884571ce70c4bbd4ea9cd1c93c0c8aee602c6c806b056187dd4ee49daf70c2f41da94b25ba0d796edf8ca83cbb87fe6d1cdda7ca669ab800170ece1c12b
-  languageName: node
-  linkType: hard
-
-"@types/d3-timer@npm:*":
-  version: 3.0.2
-  resolution: "@types/d3-timer@npm:3.0.2"
-  checksum: 1643eebfa5f4ae3eb00b556bbc509444d88078208ec2589ddd8e4a24f230dd4cf2301e9365947e70b1bee33f63aaefab84cd907822aae812b9bc4871b98ab0e1
-  languageName: node
-  linkType: hard
-
-"@types/d3-transition@npm:*":
-  version: 3.0.9
-  resolution: "@types/d3-transition@npm:3.0.9"
-  dependencies:
-    "@types/d3-selection": "*"
-  checksum: c8608b1ac7cf09acfe387f3d41074631adcdfd7f2c8ca2efb378309adf0e9fc8469dbcf0d7a8c40fd1f03f2d2bf05fcda0cde7aa356ae8533a141dcab4dff221
-  languageName: node
-  linkType: hard
-
-"@types/d3-zoom@npm:*":
-  version: 3.0.8
-  resolution: "@types/d3-zoom@npm:3.0.8"
-  dependencies:
-    "@types/d3-interpolate": "*"
-    "@types/d3-selection": "*"
-  checksum: a1685728949ed39faf8ce162cc13338639c57bc2fd4d55fc7902b2632cad2bc2a808941263e57ce6685647e8a6a0a556e173386a52d6bb74c9ed6195b68be3de
-  languageName: node
-  linkType: hard
-
-"@types/d3@npm:^7.4.0":
-  version: 7.4.3
-  resolution: "@types/d3@npm:7.4.3"
-  dependencies:
-    "@types/d3-array": "*"
-    "@types/d3-axis": "*"
-    "@types/d3-brush": "*"
-    "@types/d3-chord": "*"
-    "@types/d3-color": "*"
-    "@types/d3-contour": "*"
-    "@types/d3-delaunay": "*"
-    "@types/d3-dispatch": "*"
-    "@types/d3-drag": "*"
-    "@types/d3-dsv": "*"
-    "@types/d3-ease": "*"
-    "@types/d3-fetch": "*"
-    "@types/d3-force": "*"
-    "@types/d3-format": "*"
-    "@types/d3-geo": "*"
-    "@types/d3-hierarchy": "*"
-    "@types/d3-interpolate": "*"
-    "@types/d3-path": "*"
-    "@types/d3-polygon": "*"
-    "@types/d3-quadtree": "*"
-    "@types/d3-random": "*"
-    "@types/d3-scale": "*"
-    "@types/d3-scale-chromatic": "*"
-    "@types/d3-selection": "*"
-    "@types/d3-shape": "*"
-    "@types/d3-time": "*"
-    "@types/d3-time-format": "*"
-    "@types/d3-timer": "*"
-    "@types/d3-transition": "*"
-    "@types/d3-zoom": "*"
-  checksum: 12234aa093c8661546168becdd8956e892b276f525d96f65a7b32fed886fc6a569fe5a1171bff26fef2a5663960635f460c9504a6f2d242ba281a2b6c8c6465c
-  languageName: node
-  linkType: hard
-
 "@types/debounce-promise@npm:^3.1.1":
   version: 3.1.9
   resolution: "@types/debounce-promise@npm:3.1.9"
@@ -4337,13 +4046,6 @@ __metadata:
   version: 2.0.7
   resolution: "@types/file-saver@npm:2.0.7"
   checksum: c3d1cd80eab1214767922cabac97681f3fb688e82b74890450d70deaca49537949bbc96d80d363d91e8f0a4752c7164909cc8902d9721c5c4809baafc42a3801
-  languageName: node
-  linkType: hard
-
-"@types/geojson@npm:*":
-  version: 7946.0.16
-  resolution: "@types/geojson@npm:7946.0.16"
-  checksum: d66e5e023f43b3e7121448117af1930af7d06410a32a585a8bc9c6bb5d97e0d656cd93d99e31fa432976c32e98d4b780f82bf1fd1acd20ccf952eb6b8e39edf2
   languageName: node
   linkType: hard
 
@@ -4577,7 +4279,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-redux@npm:^7.1.20, @types/react-redux@npm:^7.1.7":
+"@types/react-redux@npm:^7.1.7":
   version: 7.1.34
   resolution: "@types/react-redux@npm:7.1.34"
   dependencies:
@@ -6828,13 +6530,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:7":
-  version: 7.2.0
-  resolution: "commander@npm:7.2.0"
-  checksum: 53501cbeee61d5157546c0bef0fedb6cdfc763a882136284bed9a07225f09a14b82d2a84e7637edfd1a679fb35ed9502fd58ef1d091e6287f60d790147f68ddc
-  languageName: node
-  linkType: hard
-
 "commander@npm:8.3.0, commander@npm:^8.3.0":
   version: 8.3.0
   resolution: "commander@npm:8.3.0"
@@ -7272,371 +6967,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-array@npm:2 - 3, d3-array@npm:2.10.0 - 3, d3-array@npm:2.5.0 - 3, d3-array@npm:3, d3-array@npm:^3.2.0":
-  version: 3.2.4
-  resolution: "d3-array@npm:3.2.4"
-  dependencies:
-    internmap: 1 - 2
-  checksum: a5976a6d6205f69208478bb44920dd7ce3e788c9dceb86b304dbe401a4bfb42ecc8b04c20facde486e9adcb488b5d1800d49393a3f81a23902b68158e12cddd0
-  languageName: node
-  linkType: hard
-
-"d3-axis@npm:3":
-  version: 3.0.0
-  resolution: "d3-axis@npm:3.0.0"
-  checksum: 227ddaa6d4bad083539c1ec245e2228b4620cca941997a8a650cb0af239375dc20271993127eedac66f0543f331027aca09385e1e16eed023f93eac937cddf0b
-  languageName: node
-  linkType: hard
-
-"d3-brush@npm:3":
-  version: 3.0.0
-  resolution: "d3-brush@npm:3.0.0"
-  dependencies:
-    d3-dispatch: 1 - 3
-    d3-drag: 2 - 3
-    d3-interpolate: 1 - 3
-    d3-selection: 3
-    d3-transition: 3
-  checksum: 1d042167769a02ac76271c71e90376d7184206e489552b7022a8ec2860209fe269db55e0a3430f3dcbe13b6fec2ff65b1adeaccba3218991b38e022390df72e3
-  languageName: node
-  linkType: hard
-
-"d3-chord@npm:3":
-  version: 3.0.1
-  resolution: "d3-chord@npm:3.0.1"
-  dependencies:
-    d3-path: 1 - 3
-  checksum: ddf35d41675e0f8738600a8a2f05bf0858def413438c12cba357c5802ecc1014c80a658acbbee63cbad2a8c747912efb2358455d93e59906fe37469f1dc6b78b
-  languageName: node
-  linkType: hard
-
-"d3-color@npm:1 - 3, d3-color@npm:3":
-  version: 3.1.0
-  resolution: "d3-color@npm:3.1.0"
-  checksum: 4931fbfda5d7c4b5cfa283a13c91a954f86e3b69d75ce588d06cde6c3628cebfc3af2069ccf225e982e8987c612aa7948b3932163ce15eb3c11cd7c003f3ee3b
-  languageName: node
-  linkType: hard
-
-"d3-contour@npm:4":
-  version: 4.0.2
-  resolution: "d3-contour@npm:4.0.2"
-  dependencies:
-    d3-array: ^3.2.0
-  checksum: 56aa082c1acf62a45b61c8d29fdd307041785aa17d9a07de7d1d848633769887a33fb6823888afa383f31c460d0f21d24756593e84e334ddb92d774214d32f1b
-  languageName: node
-  linkType: hard
-
-"d3-delaunay@npm:6":
-  version: 6.0.4
-  resolution: "d3-delaunay@npm:6.0.4"
-  dependencies:
-    delaunator: 5
-  checksum: ce6d267d5ef21a8aeadfe4606329fc80a22ab6e7748d47bc220bcc396ee8be84b77a5473033954c5ac4aa522d265ddc45d4165d30fe4787dd60a15ea66b9bbb4
-  languageName: node
-  linkType: hard
-
-"d3-dispatch@npm:1 - 3, d3-dispatch@npm:3":
-  version: 3.0.1
-  resolution: "d3-dispatch@npm:3.0.1"
-  checksum: fdfd4a230f46463e28e5b22a45dd76d03be9345b605e1b5dc7d18bd7ebf504e6c00ae123fd6d03e23d9e2711e01f0e14ea89cd0632545b9f0c00b924ba4be223
-  languageName: node
-  linkType: hard
-
-"d3-dispatch@npm:1, d3-dispatch@npm:^1.0.3":
-  version: 1.0.6
-  resolution: "d3-dispatch@npm:1.0.6"
-  checksum: b4ecb016b6dda8b99aa4263b2d0a0c7b12e7dea93e4b0ce3013c94dca4d360d9ba00f5bdc15dc944cc4543af8e341067bd628f061f7b8deb642257e2ac90d06c
-  languageName: node
-  linkType: hard
-
-"d3-drag@npm:2 - 3, d3-drag@npm:3":
-  version: 3.0.0
-  resolution: "d3-drag@npm:3.0.0"
-  dependencies:
-    d3-dispatch: 1 - 3
-    d3-selection: 3
-  checksum: d297231e60ecd633b0d076a63b4052b436ddeb48b5a3a11ff68c7e41a6774565473a6b064c5e9256e88eca6439a917ab9cea76032c52d944ddbf4fd289e31111
-  languageName: node
-  linkType: hard
-
-"d3-drag@npm:^1.0.4":
-  version: 1.2.5
-  resolution: "d3-drag@npm:1.2.5"
-  dependencies:
-    d3-dispatch: 1
-    d3-selection: 1
-  checksum: 6e86e89aa8d511979eea1b5326709c05c2a3c2d43a93a82ed6b6f98528b2ab03b2f58f5e4f66582f2f1c0ae44f9c19f6f4f857249eb66aabc46e4942295fa0a7
-  languageName: node
-  linkType: hard
-
-"d3-dsv@npm:1 - 3, d3-dsv@npm:3":
-  version: 3.0.1
-  resolution: "d3-dsv@npm:3.0.1"
-  dependencies:
-    commander: 7
-    iconv-lite: 0.6
-    rw: 1
-  bin:
-    csv2json: bin/dsv2json.js
-    csv2tsv: bin/dsv2dsv.js
-    dsv2dsv: bin/dsv2dsv.js
-    dsv2json: bin/dsv2json.js
-    json2csv: bin/json2dsv.js
-    json2dsv: bin/json2dsv.js
-    json2tsv: bin/json2dsv.js
-    tsv2csv: bin/dsv2dsv.js
-    tsv2json: bin/dsv2json.js
-  checksum: 5fc0723647269d5dccd181d74f2265920ab368a2868b0b4f55ffa2fecdfb7814390ea28622cd61ee5d9594ab262879509059544e9f815c54fe76fbfb4ffa4c8a
-  languageName: node
-  linkType: hard
-
-"d3-ease@npm:1 - 3, d3-ease@npm:3":
-  version: 3.0.1
-  resolution: "d3-ease@npm:3.0.1"
-  checksum: 06e2ee5326d1e3545eab4e2c0f84046a123dcd3b612e68858219aa034da1160333d9ce3da20a1d3486d98cb5c2a06f7d233eee1bc19ce42d1533458bd85dedcd
-  languageName: node
-  linkType: hard
-
-"d3-fetch@npm:3":
-  version: 3.0.1
-  resolution: "d3-fetch@npm:3.0.1"
-  dependencies:
-    d3-dsv: 1 - 3
-  checksum: 382dcea06549ef82c8d0b719e5dc1d96286352579e3b51b20f71437f5800323315b09cf7dcfd4e1f60a41e1204deb01758470cea257d2285a7abd9dcec806984
-  languageName: node
-  linkType: hard
-
-"d3-force@npm:3":
-  version: 3.0.0
-  resolution: "d3-force@npm:3.0.0"
-  dependencies:
-    d3-dispatch: 1 - 3
-    d3-quadtree: 1 - 3
-    d3-timer: 1 - 3
-  checksum: 6c7e96438cab62fa32aeadb0ade3297b62b51f81b1b38b0a60a5ec9fd627d74090c1189654d92df2250775f31b06812342f089f1d5947de9960a635ee3581def
-  languageName: node
-  linkType: hard
-
-"d3-format@npm:1 - 3, d3-format@npm:3":
-  version: 3.1.2
-  resolution: "d3-format@npm:3.1.2"
-  checksum: 2ce13417b3186311df3fd924028cd516ec3e96d7c3eb6df9c83f6c2ed43de1717e6c5119a385b7744ef84e2b8a4c678ad95a2b2998391803ceb0d809e235cff4
-  languageName: node
-  linkType: hard
-
-"d3-geo@npm:3":
-  version: 3.1.1
-  resolution: "d3-geo@npm:3.1.1"
-  dependencies:
-    d3-array: 2.5.0 - 3
-  checksum: 3cc4bb50af5d2d4858d2df1729a1777b7fd361854079d9faab1166186c988d2cba0d11911da0c4598d5e22fae91d79113ed262a9f98cabdbc6dbf7c30e5c0363
-  languageName: node
-  linkType: hard
-
-"d3-hierarchy@npm:3":
-  version: 3.1.2
-  resolution: "d3-hierarchy@npm:3.1.2"
-  checksum: 0fd946a8c5fd4686d43d3e11bbfc2037a145fda29d2261ccd0e36f70b66af6d7638e2c0c7112124d63fc3d3127197a00a6aecf676bd5bd392a94d7235a214263
-  languageName: node
-  linkType: hard
-
-"d3-interpolate@npm:1 - 3, d3-interpolate@npm:1.2.0 - 3, d3-interpolate@npm:3":
-  version: 3.0.1
-  resolution: "d3-interpolate@npm:3.0.1"
-  dependencies:
-    d3-color: 1 - 3
-  checksum: a42ba314e295e95e5365eff0f604834e67e4a3b3c7102458781c477bd67e9b24b6bb9d8e41ff5521050a3f2c7c0c4bbbb6e187fd586daa3980943095b267e78b
-  languageName: node
-  linkType: hard
-
-"d3-path@npm:1":
-  version: 1.0.9
-  resolution: "d3-path@npm:1.0.9"
-  checksum: d4382573baf9509a143f40944baeff9fead136926aed6872f7ead5b3555d68925f8a37935841dd51f1d70b65a294fe35c065b0906fb6e42109295f6598fc16d0
-  languageName: node
-  linkType: hard
-
-"d3-path@npm:1 - 3, d3-path@npm:3, d3-path@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "d3-path@npm:3.1.0"
-  checksum: 2306f1bd9191e1eac895ec13e3064f732a85f243d6e627d242a313f9777756838a2215ea11562f0c7630c7c3b16a19ec1fe0948b1c82f3317fac55882f6ee5d8
-  languageName: node
-  linkType: hard
-
-"d3-polygon@npm:3":
-  version: 3.0.1
-  resolution: "d3-polygon@npm:3.0.1"
-  checksum: 0b85c532517895544683849768a2c377cee3801ef8ccf3fa9693c8871dd21a0c1a2a0fc75ff54192f0ba2c562b0da2bc27f5bf959dfafc7fa23573b574865d2c
-  languageName: node
-  linkType: hard
-
-"d3-quadtree@npm:1 - 3, d3-quadtree@npm:3":
-  version: 3.0.1
-  resolution: "d3-quadtree@npm:3.0.1"
-  checksum: 5469d462763811475f34a7294d984f3eb100515b0585ca5b249656f6b1a6e99b20056a2d2e463cc9944b888896d2b1d07859c50f9c0cf23438df9cd2e3146066
-  languageName: node
-  linkType: hard
-
-"d3-random@npm:3":
-  version: 3.0.1
-  resolution: "d3-random@npm:3.0.1"
-  checksum: a70ad8d1cabe399ebeb2e482703121ac8946a3b336830b518da6848b9fdd48a111990fc041dc716f16885a72176ffa2898f2a250ca3d363ecdba5ef92b18e131
-  languageName: node
-  linkType: hard
-
-"d3-scale-chromatic@npm:3":
-  version: 3.1.0
-  resolution: "d3-scale-chromatic@npm:3.1.0"
-  dependencies:
-    d3-color: 1 - 3
-    d3-interpolate: 1 - 3
-  checksum: ab6324bd8e1f708e731e02ab44e09741efda2b174cea1d8ca21e4a87546295e99856bc44e2fd3890f228849c96bccfbcf922328f95be6a7df117453eb5cf22c9
-  languageName: node
-  linkType: hard
-
-"d3-scale@npm:4":
-  version: 4.0.2
-  resolution: "d3-scale@npm:4.0.2"
-  dependencies:
-    d3-array: 2.10.0 - 3
-    d3-format: 1 - 3
-    d3-interpolate: 1.2.0 - 3
-    d3-time: 2.1.1 - 3
-    d3-time-format: 2 - 4
-  checksum: a9c770d283162c3bd11477c3d9d485d07f8db2071665f1a4ad23eec3e515e2cefbd369059ec677c9ac849877d1a765494e90e92051d4f21111aa56791c98729e
-  languageName: node
-  linkType: hard
-
-"d3-selection@npm:1":
-  version: 1.4.2
-  resolution: "d3-selection@npm:1.4.2"
-  checksum: 2484b392259b087a98f546f2610e6a11c90f38dae6b6b20a3fc85171038fcab4c72e702788b1960a4fece88bed2e36f268096358b5b48d3c7f0d35cfbe305da6
-  languageName: node
-  linkType: hard
-
-"d3-selection@npm:2 - 3, d3-selection@npm:3":
-  version: 3.0.0
-  resolution: "d3-selection@npm:3.0.0"
-  checksum: f4e60e133309115b99f5b36a79ae0a19d71ee6e2d5e3c7216ef3e75ebd2cb1e778c2ed2fa4c01bef35e0dcbd96c5428f5bd6ca2184fe2957ed582fde6841cbc5
-  languageName: node
-  linkType: hard
-
-"d3-shape@npm:3":
-  version: 3.2.0
-  resolution: "d3-shape@npm:3.2.0"
-  dependencies:
-    d3-path: ^3.1.0
-  checksum: de2af5fc9a93036a7b68581ca0bfc4aca2d5a328aa7ba7064c11aedd44d24f310c20c40157cb654359d4c15c3ef369f95ee53d71221017276e34172c7b719cfa
-  languageName: node
-  linkType: hard
-
-"d3-shape@npm:^1.3.5":
-  version: 1.3.7
-  resolution: "d3-shape@npm:1.3.7"
-  dependencies:
-    d3-path: 1
-  checksum: 46566a3ab64a25023653bf59d64e81e9e6c987e95be985d81c5cedabae5838bd55f4a201a6b69069ca862eb63594cd263cac9034afc2b0e5664dfe286c866129
-  languageName: node
-  linkType: hard
-
-"d3-time-format@npm:2 - 4, d3-time-format@npm:4":
-  version: 4.1.0
-  resolution: "d3-time-format@npm:4.1.0"
-  dependencies:
-    d3-time: 1 - 3
-  checksum: 7342bce28355378152bbd4db4e275405439cabba082d9cd01946d40581140481c8328456d91740b0fe513c51ec4a467f4471ffa390c7e0e30ea30e9ec98fcdf4
-  languageName: node
-  linkType: hard
-
-"d3-time@npm:1 - 3, d3-time@npm:2.1.1 - 3, d3-time@npm:3":
-  version: 3.1.0
-  resolution: "d3-time@npm:3.1.0"
-  dependencies:
-    d3-array: 2 - 3
-  checksum: 613b435352a78d9f31b7f68540788186d8c331b63feca60ad21c88e9db1989fe888f97f242322ebd6365e45ec3fb206a4324cd4ca0dfffa1d9b5feb856ba00a7
-  languageName: node
-  linkType: hard
-
-"d3-timer@npm:1 - 3, d3-timer@npm:3":
-  version: 3.0.1
-  resolution: "d3-timer@npm:3.0.1"
-  checksum: 1cfddf86d7bca22f73f2c427f52dfa35c49f50d64e187eb788dcad6e927625c636aa18ae4edd44d084eb9d1f81d8ca4ec305dae7f733c15846a824575b789d73
-  languageName: node
-  linkType: hard
-
-"d3-timer@npm:^1.0.5":
-  version: 1.0.10
-  resolution: "d3-timer@npm:1.0.10"
-  checksum: f7040953672deb2dfa03830ace80dbbcb212f80890218eba15dcca6f33f74102d943023ccc2a563295195cd8c63639bb2410ef1691c8fecff4a114fdf5c666f4
-  languageName: node
-  linkType: hard
-
-"d3-transition@npm:2 - 3, d3-transition@npm:3":
-  version: 3.0.1
-  resolution: "d3-transition@npm:3.0.1"
-  dependencies:
-    d3-color: 1 - 3
-    d3-dispatch: 1 - 3
-    d3-ease: 1 - 3
-    d3-interpolate: 1 - 3
-    d3-timer: 1 - 3
-  peerDependencies:
-    d3-selection: 2 - 3
-  checksum: cb1e6e018c3abf0502fe9ff7b631ad058efb197b5e14b973a410d3935aead6e3c07c67d726cfab258e4936ef2667c2c3d1cd2037feb0765f0b4e1d3b8788c0ea
-  languageName: node
-  linkType: hard
-
-"d3-zoom@npm:3":
-  version: 3.0.0
-  resolution: "d3-zoom@npm:3.0.0"
-  dependencies:
-    d3-dispatch: 1 - 3
-    d3-drag: 2 - 3
-    d3-interpolate: 1 - 3
-    d3-selection: 2 - 3
-    d3-transition: 2 - 3
-  checksum: 8056e3527281cfd1ccbcbc458408f86973b0583e9dac00e51204026d1d36803ca437f970b5736f02fafed9f2b78f145f72a5dbc66397e02d4d95d4c594b8ff54
-  languageName: node
-  linkType: hard
-
-"d3@npm:^7.8.0":
-  version: 7.9.0
-  resolution: "d3@npm:7.9.0"
-  dependencies:
-    d3-array: 3
-    d3-axis: 3
-    d3-brush: 3
-    d3-chord: 3
-    d3-color: 3
-    d3-contour: 4
-    d3-delaunay: 6
-    d3-dispatch: 3
-    d3-drag: 3
-    d3-dsv: 3
-    d3-ease: 3
-    d3-fetch: 3
-    d3-force: 3
-    d3-format: 3
-    d3-geo: 3
-    d3-hierarchy: 3
-    d3-interpolate: 3
-    d3-path: 3
-    d3-polygon: 3
-    d3-quadtree: 3
-    d3-random: 3
-    d3-scale: 4
-    d3-scale-chromatic: 3
-    d3-selection: 3
-    d3-shape: 3
-    d3-time: 3
-    d3-time-format: 4
-    d3-timer: 3
-    d3-transition: 3
-    d3-zoom: 3
-  checksum: 1c0e9135f1fb78aa32b187fafc8b56ae6346102bd0e4e5e5a5339611a51e6038adbaa293fae373994228100eddd87320e930b1be922baeadc07c9fd43d26d99b
-  languageName: node
-  linkType: hard
-
 "dashdash@npm:^1.12.0":
   version: 1.14.1
   resolution: "dashdash@npm:1.14.1"
@@ -7950,15 +7280,6 @@ __metadata:
     rimraf: ^3.0.2
     slash: ^3.0.0
   checksum: 563288b73b8b19a7261c47fd21a330eeab6e2acd7c6208c49790dfd369127120dd7836cdf0c1eca216b77c94782a81507eac6b4734252d3bef2795cb366996b6
-  languageName: node
-  linkType: hard
-
-"delaunator@npm:5":
-  version: 5.1.0
-  resolution: "delaunator@npm:5.1.0"
-  dependencies:
-    robust-predicates: ^3.0.2
-  checksum: ecefe0a6ad356466a1793fa7396e170e873b9b519ab28a0e2e025df1ce506d76df113f210d02f7131f906be3cf6493f07b2fd972bf972d726ac7cdd96c4de4cd
   languageName: node
   linkType: hard
 
@@ -10625,30 +9946,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"history@npm:^4.9.0":
-  version: 4.10.1
-  resolution: "history@npm:4.10.1"
-  dependencies:
-    "@babel/runtime": ^7.1.2
-    loose-envify: ^1.2.0
-    resolve-pathname: ^3.0.0
-    tiny-invariant: ^1.0.2
-    tiny-warning: ^1.0.0
-    value-equal: ^1.0.1
-  checksum: addd84bc4683929bae4400419b5af132ff4e4e9b311a0d4e224579ea8e184a6b80d7f72c55927e4fa117f69076a9e47ce082d8d0b422f1a9ddac7991490ca1d0
-  languageName: node
-  linkType: hard
-
-"history@npm:^5.3.0":
-  version: 5.3.0
-  resolution: "history@npm:5.3.0"
-  dependencies:
-    "@babel/runtime": ^7.7.6
-  checksum: d73c35df49d19ac172f9547d30a21a26793e83f16a78386d99583b5bf1429cc980799fcf1827eb215d31816a6600684fba9686ce78104e23bd89ec239e7c726f
-  languageName: node
-  linkType: hard
-
-"hoist-non-react-statics@npm:^3.1.0, hoist-non-react-statics@npm:^3.2.0, hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.2":
+"hoist-non-react-statics@npm:^3.2.0, hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.2":
   version: 3.3.2
   resolution: "hoist-non-react-statics@npm:3.3.2"
   dependencies:
@@ -11032,7 +10330,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:0.6, iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2, iconv-lite@npm:^0.6.3":
+"iconv-lite@npm:0.6.3, iconv-lite@npm:^0.6.2, iconv-lite@npm:^0.6.3":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
   dependencies:
@@ -11103,7 +10401,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:3.x":
+"immutable@npm:^3.8.3":
   version: 3.8.3
   resolution: "immutable@npm:3.8.3"
   checksum: 3c668e4e92d77876f95081ed695c594f802fc8f88dc888e562ce70d26eb92596c65fbd64caad8fef054358c21990d52c77b28e9dc7bd6c8f53cf44775cfb44f9
@@ -11240,13 +10538,6 @@ __metadata:
     hasown: ^2.0.2
     side-channel: ^1.1.0
   checksum: 8e0991c2d048cc08dab0a91f573c99f6a4215075887517ea4fa32203ce8aea60fa03f95b177977fa27eb502e5168366d0f3e02c762b799691411d49900611861
-  languageName: node
-  linkType: hard
-
-"internmap@npm:1 - 2":
-  version: 2.0.3
-  resolution: "internmap@npm:2.0.3"
-  checksum: 7ca41ec6aba8f0072fc32fa8a023450a9f44503e2d8e403583c55714b25efd6390c38a87161ec456bf42d7bc83aab62eb28f5aef34876b1ac4e60693d5e1d241
   languageName: node
   linkType: hard
 
@@ -11898,13 +11189,6 @@ __metadata:
   dependencies:
     is-inside-container: ^1.0.0
   checksum: f9734c81f2f9cf9877c5db8356bfe1ff61680f1f4c1011e91278a9c0564b395ae796addb4bf33956871041476ec82c3e5260ed57b22ac91794d4ae70a1d2f0a9
-  languageName: node
-  linkType: hard
-
-"isarray@npm:0.0.1":
-  version: 0.0.1
-  resolution: "isarray@npm:0.0.1"
-  checksum: 49191f1425681df4a18c2f0f93db3adb85573bcdd6a4482539d98eac9e705d8961317b01175627e860516a2fc45f8f9302db26e5a380a97a520e272e2a40a8d4
   languageName: node
   linkType: hard
 
@@ -12724,7 +12008,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.1.0, loose-envify@npm:^1.2.0, loose-envify@npm:^1.3.1, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -13709,45 +12993,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mobx-react-lite@npm:^3.4.0":
-  version: 3.4.3
-  resolution: "mobx-react-lite@npm:3.4.3"
-  peerDependencies:
-    mobx: ^6.1.0
-    react: ^16.8.0 || ^17 || ^18
-  peerDependenciesMeta:
-    react-dom:
-      optional: true
-    react-native:
-      optional: true
-  checksum: 60a2580eb9a0b9988fc76959d7299f018733dc33cacaa73c45500953006d4d45e738d9ae39ccfc767ac19a75656dbc028d833282c848fbc67d8d18a2bcb5c262
-  languageName: node
-  linkType: hard
-
-"mobx-react@npm:^7.6.0":
-  version: 7.6.0
-  resolution: "mobx-react@npm:7.6.0"
-  dependencies:
-    mobx-react-lite: ^3.4.0
-  peerDependencies:
-    mobx: ^6.1.0
-    react: ^16.8.0 || ^17 || ^18
-  peerDependenciesMeta:
-    react-dom:
-      optional: true
-    react-native:
-      optional: true
-  checksum: 07ce6eb297ddab2cc693df7350a3e2f730194cc6eb56bd912f80e28f9427237569e0bda6b30167154faf094e7c5e5ff360abd52acd2860d9a0d0e53320617ee8
-  languageName: node
-  linkType: hard
-
-"mobx@npm:^6.9.0":
-  version: 6.15.0
-  resolution: "mobx@npm:6.15.0"
-  checksum: bdda12556b8dec650f30d0ae4dcd84459a2415dce2376174476730bb85e063d6171045717a2b8ddda6e584d524fad5b305e2ee65e8264a57c0cbcbb6bf2a83eb
-  languageName: node
-  linkType: hard
-
 "monaco-editor@npm:^0.55.0":
   version: 0.55.1
   resolution: "monaco-editor@npm:0.55.1"
@@ -14648,15 +13893,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:^1.7.0":
-  version: 1.8.0
-  resolution: "path-to-regexp@npm:1.8.0"
-  dependencies:
-    isarray: 0.0.1
-  checksum: 709f6f083c0552514ef4780cb2e7e4cf49b0cc89a97439f2b7cc69a608982b7690fb5d1720a7473a59806508fc2dae0be751ba49f495ecf89fd8fbc62abccbcd
-  languageName: node
-  linkType: hard
-
 "path-to-regexp@npm:^6.3.0":
   version: 6.3.0
   resolution: "path-to-regexp@npm:6.3.0"
@@ -14777,20 +14013,6 @@ __metadata:
     pvutils: ^1.1.3
     tslib: ^2.8.1
   checksum: 9e146816ff7d8c8cf98bf3f75f4fe06a206b0fbec992fd6a8d799a8e99d4c7647b10702e565ba1b48eac004f87098f989e941a119662e3a03133b012fc2705f7
-  languageName: node
-  linkType: hard
-
-"point-in-svg-path@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "point-in-svg-path@npm:1.0.2"
-  checksum: 0145eeb8c513fd4087ae569c6c7a4be5382854a251726d32e49cf0f08ff2663178f018ccc77c05609dd8fa73c087066ce8d6ab77b97350316e7b2e6a59174e12
-  languageName: node
-  linkType: hard
-
-"popper.js@npm:^1.16.1":
-  version: 1.16.1
-  resolution: "popper.js@npm:1.16.1"
-  checksum: c56ae5001ec50a77ee297a8061a0221d99d25c7348d2e6bcd3e45a0d0f32a1fd81bca29d46cb0d4bdf13efb77685bd6a0ce93f9eb3c608311a461f945fffedbe
   languageName: node
   linkType: hard
 
@@ -15048,7 +14270,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.5.8, prop-types@npm:^15.6.0, prop-types@npm:^15.6.2, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
+"prop-types@npm:^15.5.8, prop-types@npm:^15.6.0, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -15303,7 +14525,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-i18next@npm:^11.11.4, react-i18next@npm:^11.12.0":
+"react-i18next@npm:^11.11.4":
   version: 11.18.6
   resolution: "react-i18next@npm:11.18.6"
   dependencies:
@@ -15321,14 +14543,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.13.1, react-is@npm:^16.6.0, react-is@npm:^16.7.0":
+"react-is@npm:^16.13.1, react-is@npm:^16.7.0":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: f7a19ac3496de32ca9ae12aa030f00f14a3d45374f1ceca0af707c831b2a6098ef0d6bdae51bd437b0a306d7f01d4677fcc8de7c0d331eb47ad0f46130e53c5f
   languageName: node
   linkType: hard
 
-"react-is@npm:^17.0.1, react-is@npm:^17.0.2":
+"react-is@npm:^17.0.1":
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
   checksum: 9d6d111d8990dc98bc5402c1266a808b0459b5d54830bbea24c12d908b536df7883f268a7868cfaedde3dd9d4e0d574db456f84d2e6df9c4526f99bb4b5344d8
@@ -15396,27 +14618,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-redux@npm:7.2.9":
-  version: 7.2.9
-  resolution: "react-redux@npm:7.2.9"
-  dependencies:
-    "@babel/runtime": ^7.15.4
-    "@types/react-redux": ^7.1.20
-    hoist-non-react-statics: ^3.3.2
-    loose-envify: ^1.4.0
-    prop-types: ^15.7.2
-    react-is: ^17.0.2
-  peerDependencies:
-    react: ^16.8.3 || ^17 || ^18
-  peerDependenciesMeta:
-    react-dom:
-      optional: true
-    react-native:
-      optional: true
-  checksum: 369a2bdcf87915659af9e5c55abfd9f52a84e43e0d12dcc108ed17dbe6933558b7b7fc12caa9c10c1a10a8be7df89454b6c96989d8573fedec1a772c94a1f145
-  languageName: node
-  linkType: hard
-
 "react-redux@npm:^8.0.5":
   version: 8.1.3
   resolution: "react-redux@npm:8.1.3"
@@ -15456,75 +14657,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom-v5-compat@npm:^6.11.2, react-router-dom-v5-compat@npm:^6.30.3":
-  version: 6.30.3
-  resolution: "react-router-dom-v5-compat@npm:6.30.3"
+"react-router-dom@npm:^6.0.0":
+  version: 6.30.4
+  resolution: "react-router-dom@npm:6.30.4"
   dependencies:
-    "@remix-run/router": 1.23.2
-    history: ^5.3.0
-    react-router: 6.30.3
+    "@remix-run/router": 1.23.3
+    react-router: 6.30.4
   peerDependencies:
     react: ">=16.8"
     react-dom: ">=16.8"
-    react-router-dom: 4 || 5
-  checksum: 86947fa1887b47571ae653348dbd3f4d9db9c549b9cc6381a1d09e83c9de9e70f3e220ac52559b89d90c55a848a5caaffb9ce845e11f26c17b26917160ba37d1
+  checksum: 98f58ee14a71c392fa7c05b3e2dc7cdc54928b6d679c2cce891e26a51fe42c64d67af4ba0721dff51debd9bfbd03d738d3079e9c19533585f8c2b7cf653a437f
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:5.3.x":
-  version: 5.3.4
-  resolution: "react-router-dom@npm:5.3.4"
-  dependencies:
-    "@babel/runtime": ^7.12.13
-    history: ^4.9.0
-    loose-envify: ^1.3.1
-    prop-types: ^15.6.2
-    react-router: 5.3.4
-    tiny-invariant: ^1.0.2
-    tiny-warning: ^1.0.0
-  peerDependencies:
-    react: ">=15"
-  checksum: b86a6f2f5222f041e38adf4e4b32c7643d6735a1a915ef25855b2db285fd059d72ba8d62e5bcd5d822b8ef9520a80453209e55077f5a90d0f72e908979b8f535
-  languageName: node
-  linkType: hard
-
-"react-router@npm:5.3.4, react-router@npm:5.3.x":
-  version: 5.3.4
-  resolution: "react-router@npm:5.3.4"
-  dependencies:
-    "@babel/runtime": ^7.12.13
-    history: ^4.9.0
-    hoist-non-react-statics: ^3.1.0
-    loose-envify: ^1.3.1
-    path-to-regexp: ^1.7.0
-    prop-types: ^15.6.2
-    react-is: ^16.6.0
-    tiny-invariant: ^1.0.2
-    tiny-warning: ^1.0.0
-  peerDependencies:
-    react: ">=15"
-  checksum: 892d4e274a23bf4f39abc2efca54472fb646d3aed4b584020cf49654d2f50d09a2bacebe7c92b4ec7cb8925077376dfcd0664bad6442a73604397cefec9f01f9
-  languageName: node
-  linkType: hard
-
-"react-router@npm:6.30.3":
-  version: 6.30.3
-  resolution: "react-router@npm:6.30.3"
+"react-router@npm:6.30.4":
+  version: 6.30.4
+  resolution: "react-router@npm:6.30.4"
   dependencies:
     "@remix-run/router": 1.23.2
   peerDependencies:
     react: ">=16.8"
   checksum: b61e1a456b72ed35907dadc261d8572a65dd4caae008f7a85a6b09b437b1a4b90034fc7df0e418f1f01b73c2b8a8f6755d7fc0108b1ec3f2ed37f03a1e248513
-  languageName: node
-  linkType: hard
-
-"react@npm:^17.0.1":
-  version: 17.0.2
-  resolution: "react@npm:17.0.2"
-  dependencies:
-    loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-  checksum: b254cc17ce3011788330f7bbf383ab653c6848902d7936a87b09d835d091e3f295f7e9dd1597c6daac5dc80f90e778c8230218ba8ad599f74adcc11e33b9d61b
   languageName: node
   linkType: hard
 
@@ -15588,15 +14741,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"redux-thunk@npm:2.4.0":
-  version: 2.4.0
-  resolution: "redux-thunk@npm:2.4.0"
-  peerDependencies:
-    redux: ^4
-  checksum: 250cd88087bb4614052a5175fd6bd4c70b6a4479c357af8628b3a1d5f75d5b0a6c01645acc3257d3ed147a949708dd748a50b00402d548c3331038ed4f296edc
-  languageName: node
-  linkType: hard
-
 "redux-thunk@npm:^2.4.2":
   version: 2.4.2
   resolution: "redux-thunk@npm:2.4.2"
@@ -15606,7 +14750,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"redux@npm:^4, redux@npm:^4.0.0, redux@npm:^4.0.4, redux@npm:^4.2.1":
+"redux@npm:^4, redux@npm:^4.0.0, redux@npm:^4.2.1":
   version: 4.2.1
   resolution: "redux@npm:4.2.1"
   dependencies:
@@ -15821,10 +14965,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"reselect@npm:4.x, reselect@npm:^4.1.8":
+"reselect@npm:^4.1.8":
   version: 4.1.8
   resolution: "reselect@npm:4.1.8"
   checksum: a4ac87cedab198769a29be92bc221c32da76cfdad6911eda67b4d3e7136dca86208c3b210e31632eae31ebd2cded18596f0dd230d3ccc9e978df22f233b5583e
+  languageName: node
+  linkType: hard
+
+"reselect@npm:^5.1.1":
+  version: 5.2.0
+  resolution: "reselect@npm:5.2.0"
+  checksum: b274c69ba657cfe3531ae32ba332a6bae62050bb5addd7d42a66625fa85db0d82a93d69f0b6df1db345717fbcb8e9d311e843b09051afebd2b06da539f3510bb
   languageName: node
   linkType: hard
 
@@ -15857,13 +15008,6 @@ __metadata:
   dependencies:
     value-or-function: ^4.0.0
   checksum: b28584cc089099af42e36292c32bd9af8bc9e28e3ca73c172c0a172d7ed5afb01c75cc2275268c327dceba77a5555b33fbd55617be138874040279fe6ff02fbf
-  languageName: node
-  linkType: hard
-
-"resolve-pathname@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "resolve-pathname@npm:3.0.0"
-  checksum: 6147241ba42c423dbe83cb067a2b4af4f60908c3af57e1ea567729cc71416c089737fe2a73e9e79e7a60f00f66c91e4b45ad0d37cd4be2d43fec44963ef14368
   languageName: node
   linkType: hard
 
@@ -16031,13 +15175,6 @@ __metadata:
   bin:
     rimraf: dist/esm/bin.mjs
   checksum: 797dabd9b03a154a863c20e0bd0066214a3a7165d30a358852b63b96f9463d360f59d56db6ccbaebac6fe2ff5c93dea2cddd547855bba1a1e1d5361c31e7456a
-  languageName: node
-  linkType: hard
-
-"robust-predicates@npm:^3.0.2":
-  version: 3.0.3
-  resolution: "robust-predicates@npm:3.0.3"
-  checksum: 23692b9451e296bf8f98bdd681d4950a27045cdee5df3fadb9c150c7df0889b5fcf658ab2f82a41675bf14b1e32c4c6b7a4591f8adbee056b845f0eb9d3ad69c
   languageName: node
   linkType: hard
 
@@ -16230,13 +15367,6 @@ __metadata:
   dependencies:
     queue-microtask: ^1.2.2
   checksum: cb4f97ad25a75ebc11a8ef4e33bb962f8af8516bb2001082ceabd8902e15b98f4b84b4f8a9b222e5d57fc3bd1379c483886ed4619367a7680dad65316993021d
-  languageName: node
-  linkType: hard
-
-"rw@npm:1":
-  version: 1.3.3
-  resolution: "rw@npm:1.3.3"
-  checksum: c20d82421f5a71c86a13f76121b751553a99cd4a70ea27db86f9b23f33db941f3f06019c30f60d50c356d0bd674c8e74764ac146ea55e217c091bde6fba82aa3
   languageName: node
   linkType: hard
 
@@ -16475,6 +15605,15 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 7427f05b70786c696640edc29fdd4bc33b2acf3bbe1740b955029044f80575fc664e1a512e4113c3af21e767154a94b4aa214bf6cd6e42a1f6dba5914e0b208c
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.7.3":
+  version: 7.8.5
+  resolution: "semver@npm:7.8.5"
+  bin:
+    semver: bin/semver.js
+  checksum: 0c580f17e88e2b45806dc5cf3d824f719c946999d3554bf30307c2b68b3300ab3c8bfcd84d8f489b93b4cbb5362f5fc8de4d2858954f18d834253c4450fc9f6b
   languageName: node
   linkType: hard
 
@@ -17595,14 +16734,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-invariant@npm:^1.0.2":
-  version: 1.3.3
-  resolution: "tiny-invariant@npm:1.3.3"
-  checksum: 5e185c8cc2266967984ce3b352a4e57cb89dad5a8abb0dea21468a6ecaa67cd5bb47a3b7a85d08041008644af4f667fb8b6575ba38ba5fb00b3b5068306e59fe
-  languageName: node
-  linkType: hard
-
-"tiny-warning@npm:^1.0.0, tiny-warning@npm:^1.0.2":
+"tiny-warning@npm:^1.0.2":
   version: 1.0.3
   resolution: "tiny-warning@npm:1.0.3"
   checksum: da62c4acac565902f0624b123eed6dd3509bc9a8d30c06e017104bedcf5d35810da8ff72864400ad19c5c7806fc0a8323c68baf3e326af7cb7d969f846100d71
@@ -18062,10 +17194,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typesafe-actions@npm:^4.2.1":
-  version: 4.4.2
-  resolution: "typesafe-actions@npm:4.4.2"
-  checksum: 43b3a91af74172b42e27098150d84eaa9f02f74a8f9c81225e560d48872f6a3174482651d6e6278f380ed25870edb2b949b4776382cf0393b8299a3723c56d9b
+"typesafe-actions@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "typesafe-actions@npm:5.1.0"
+  checksum: 63f973ca93fcd2a037bf994ec6b173a5bf2fe2eba04ea64d8ddc49f3fcac5506d4209d61e020ab07dd39a21539d9f03fbf7c9ed7a22244c3c6c0758e438f6ef5
   languageName: node
   linkType: hard
 
@@ -18460,13 +17592,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"value-equal@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "value-equal@npm:1.0.1"
-  checksum: bb7ae1facc76b5cf8071aeb6c13d284d023fdb370478d10a5d64508e0e6e53bb459c4bbe34258df29d82e6f561f874f0105eba38de0e61fe9edd0bdce07a77a2
-  languageName: node
-  linkType: hard
-
 "value-or-function@npm:^4.0.0":
   version: 4.0.0
   resolution: "value-or-function@npm:4.0.0"
@@ -18843,18 +17968,6 @@ __metadata:
   version: 4.2.4
   resolution: "web-vitals@npm:4.2.4"
   checksum: 5b3ffe1db33f23aebf8cc8560ac574401a95939baafde5841835c1bb1c01f9a2478442f319f77aa0d7914739fc2f6b020c5d5b128c16c5c77ca6be2f9dfbbde6
-  languageName: node
-  linkType: hard
-
-"webcola@npm:3.4.0":
-  version: 3.4.0
-  resolution: "webcola@npm:3.4.0"
-  dependencies:
-    d3-dispatch: ^1.0.3
-    d3-drag: ^1.0.4
-    d3-shape: ^1.3.5
-    d3-timer: ^1.0.5
-  checksum: 046f7cc06ef077b42e2cdecba9b9407452008444629a95d1c921283b9dae7c874ef8b5d66d4e21d56f427662598ae12d11992fbe10ec29d8ec0bcc68f6c40b75
   languageName: node
   linkType: hard
 
@@ -19416,6 +18529,18 @@ __metadata:
     toposort: ^2.0.2
     type-fest: ^2.19.0
   checksum: 20a2ee0c1e891979ca16b34805b3a3be9ab4bea6ea3d2f9005b998b4dc992d0e4d7b53e5f4d8d9423420046630fb44fdf0ecf7e83bc34dd83392bca046c5229d
+  languageName: node
+  linkType: hard
+
+"yup@npm:^1.7.1":
+  version: 1.7.1
+  resolution: "yup@npm:1.7.1"
+  dependencies:
+    property-expr: ^2.0.5
+    tiny-case: ^1.0.3
+    toposort: ^2.0.2
+    type-fest: ^2.19.0
+  checksum: 80d0d6838da457d489a97ee0b9c26fa9f59355a553f86842ea114b049811a918a0e7221f9c22bb88314699ddfb3e24ded49f7ab10a0e74dd273d03430110d5af
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -370,6 +370,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.1.2":
+  version: 7.29.7
+  resolution: "@babel/runtime@npm:7.29.7"
+  checksum: bc311855c6dbf5356030979584ca0f8b6cee39fe058175b02e85a73e246fc76ae30248b0d40e70c2652101faeb43279468ed2d086a670673eb9783c1fee1df2b
+  languageName: node
+  linkType: hard
+
 "@babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.5, @babel/runtime@npm:^7.14.6, @babel/runtime@npm:^7.19.0, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.9.2":
   version: 7.26.10
   resolution: "@babel/runtime@npm:7.26.10"
@@ -1683,9 +1690,11 @@ __metadata:
     "@redhat-cloud-services/frontend-components-config": ^6.0.17
     "@redhat-cloud-services/tsc-transform-imports": ^1.0.4
     "@tsconfig/vite-react": ^7.0.2
+    "@types/history": ^4
     "@types/react": 18.2.37
     "@types/react-dom": ^18.2.0
     axios: ^1.17.0
+    history: ^4.10.1
     i18next: ^20.4 || ^21
     parse-url: ^9.2.0
     react: ^18.2.0
@@ -1716,8 +1725,6 @@ __metadata:
     "@tsconfig/vite-react": ^7.0.2
     "@types/react": 18.2.37
     "@types/react-dom": ^18.2.0
-    "@types/react-router": ^5.1.x
-    "@types/react-router-dom": 5.3.x
     "@vitejs/plugin-react-swc": ^4.3.0
     axios: ^1.17.0
     i18next: ^20.4 || ^21
@@ -4049,7 +4056,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/history@npm:^4.7.11":
+"@types/history@npm:^4":
   version: 4.7.11
   resolution: "@types/history@npm:4.7.11"
   checksum: c92e2ba407dcab0581a9afdf98f533aa41b61a71133420a6d92b1ca9839f741ab1f9395b17454ba5b88cb86020b70b22d74a1950ccfbdfd9beeaa5459fdc3464
@@ -4279,27 +4286,6 @@ __metadata:
     hoist-non-react-statics: ^3.3.0
     redux: ^4.0.0
   checksum: ba0cc5f54b91bff162cc97cf5d82d0077944e2d744c276c3c8eb896a293aba00923b513f5cd6ad717a46bf0c128a099ad697c98672202acb25143602042c8e6c
-  languageName: node
-  linkType: hard
-
-"@types/react-router-dom@npm:5.3.x":
-  version: 5.3.3
-  resolution: "@types/react-router-dom@npm:5.3.3"
-  dependencies:
-    "@types/history": ^4.7.11
-    "@types/react": "*"
-    "@types/react-router": "*"
-  checksum: 28c4ea48909803c414bf5a08502acbb8ba414669b4b43bb51297c05fe5addc4df0b8fd00e0a9d1e3535ec4073ef38aaafac2c4a2b95b787167d113bc059beff3
-  languageName: node
-  linkType: hard
-
-"@types/react-router@npm:*, @types/react-router@npm:^5.1.x":
-  version: 5.1.20
-  resolution: "@types/react-router@npm:5.1.20"
-  dependencies:
-    "@types/history": ^4.7.11
-    "@types/react": "*"
-  checksum: 128764143473a5e9457ddc715436b5d49814b1c214dde48939b9bef23f0e77f52ffcdfa97eb8d3cc27e2c229869c0cdd90f637d887b62f2c9f065a87d6425419
   languageName: node
   linkType: hard
 
@@ -9937,6 +9923,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"history@npm:^4.10.1":
+  version: 4.10.1
+  resolution: "history@npm:4.10.1"
+  dependencies:
+    "@babel/runtime": ^7.1.2
+    loose-envify: ^1.2.0
+    resolve-pathname: ^3.0.0
+    tiny-invariant: ^1.0.2
+    tiny-warning: ^1.0.0
+    value-equal: ^1.0.1
+  checksum: addd84bc4683929bae4400419b5af132ff4e4e9b311a0d4e224579ea8e184a6b80d7f72c55927e4fa117f69076a9e47ce082d8d0b422f1a9ddac7991490ca1d0
+  languageName: node
+  linkType: hard
+
 "hoist-non-react-statics@npm:^3.2.0, hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.2":
   version: 3.3.2
   resolution: "hoist-non-react-statics@npm:3.3.2"
@@ -11999,7 +11999,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.1.0, loose-envify@npm:^1.2.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -14994,6 +14994,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resolve-pathname@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "resolve-pathname@npm:3.0.0"
+  checksum: 6147241ba42c423dbe83cb067a2b4af4f60908c3af57e1ea567729cc71416c089737fe2a73e9e79e7a60f00f66c91e4b45ad0d37cd4be2d43fec44963ef14368
+  languageName: node
+  linkType: hard
+
 "resolve@npm:^1.20.0, resolve@npm:^1.22.2":
   version: 1.22.11
   resolution: "resolve@npm:1.22.11"
@@ -16724,7 +16731,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-warning@npm:^1.0.2":
+"tiny-invariant@npm:^1.0.2":
+  version: 1.3.3
+  resolution: "tiny-invariant@npm:1.3.3"
+  checksum: 5e185c8cc2266967984ce3b352a4e57cb89dad5a8abb0dea21468a6ecaa67cd5bb47a3b7a85d08041008644af4f667fb8b6575ba38ba5fb00b3b5068306e59fe
+  languageName: node
+  linkType: hard
+
+"tiny-warning@npm:^1.0.0, tiny-warning@npm:^1.0.2":
   version: 1.0.3
   resolution: "tiny-warning@npm:1.0.3"
   checksum: da62c4acac565902f0624b123eed6dd3509bc9a8d30c06e017104bedcf5d35810da8ff72864400ad19c5c7806fc0a8323c68baf3e326af7cb7d969f846100d71
@@ -17579,6 +17593,13 @@ __metadata:
   bin:
     uuid: dist/bin/uuid
   checksum: 39931f6da74e307f51c0fb463dc2462807531dc80760a9bff1e35af4316131b4fc3203d16da60ae33f07fdca5b56f3f1dd662da0c99fea9aaeab2004780cc5f4
+  languageName: node
+  linkType: hard
+
+"value-equal@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "value-equal@npm:1.0.1"
+  checksum: bb7ae1facc76b5cf8071aeb6c13d284d023fdb370478d10a5d64508e0e6e53bb459c4bbe34258df29d82e6f561f874f0105eba38de0e61fe9edd0bdce07a77a2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1656,8 +1656,7 @@ __metadata:
     react-i18next: ^11.11.4
     react-monaco-editor: ^0.59.0
     react-redux: ^8.0.5
-    react-router-dom: 5.3.x
-    react-router-dom-v5-compat: ^6.30.3
+    react-router-dom: ^6.0.0
     redux: ^4
     uuid: ^14.0
     vite: ^8.0.16
@@ -1692,7 +1691,7 @@ __metadata:
     react: ^18.2.0
     react-dom: ^18.2.0
     react-i18next: ^11.11.4
-    react-router-dom-v5-compat: ^6.30.3
+    react-router-dom: ^6.0.0
     rimraf: ^6.0.0
     ts-patch: ^3.0.2
     typescript: ^5.9.3
@@ -1730,8 +1729,7 @@ __metadata:
     react-i18next: ^11.11.4
     react-monaco-editor: ^0.59.0
     react-redux: ^8.0.5
-    react-router-dom: 5.3.x
-    react-router-dom-v5-compat: ^6.30.3
+    react-router-dom: ^6.0.0
     redux: ^4
     uuid: ^14.0
     vite: ^8.0.16
@@ -1896,7 +1894,7 @@ __metadata:
     react-i18next: ">11.7.3"
     react-monaco-editor: ^0.55.0 || ^0.59.0
     react-redux: ^8.0.5
-    react-router-dom-v5-compat: ^6.30.3
+    react-router-dom: ^6.0.0
     redux: ^4.2.1
     uuid: ^8.1
     yup: ^1.4.0
@@ -2812,10 +2810,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remix-run/router@npm:1.23.2":
-  version: 1.23.2
-  resolution: "@remix-run/router@npm:1.23.2"
-  checksum: 0f046e480372be17d14f88684435cd6af4c05ce842bd6094a549605dd5b8f0ab1e9a1e9d9e2faec9e4d5cd370d02179b456189192f06415e461bce44c28295d8
+"@remix-run/router@npm:1.23.3":
+  version: 1.23.3
+  resolution: "@remix-run/router@npm:1.23.3"
+  checksum: 95bfe4c8ef1f1f7e614ceacfcc7ae42a66325284fa1397fe5358197cfba1618bc0832979a42a0fdeca292f015baeacfd82a5395b1f13f86f8ea0f236420bcb3d
   languageName: node
   linkType: hard
 
@@ -14674,10 +14672,10 @@ __metadata:
   version: 6.30.4
   resolution: "react-router@npm:6.30.4"
   dependencies:
-    "@remix-run/router": 1.23.2
+    "@remix-run/router": 1.23.3
   peerDependencies:
     react: ">=16.8"
-  checksum: b61e1a456b72ed35907dadc261d8572a65dd4caae008f7a85a6b09b437b1a4b90034fc7df0e418f1f01b73c2b8a8f6755d7fc0108b1ec3f2ed37f03a1e248513
+  checksum: a9c1d03dd22cc824515dd603eae5dc49f8ed973496eabf404771ad3cfacfd239ccdc7d8cb7e2c6adab6889501cafdcc8abefdf6a061676bfa02a9247cf9d6c50
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://redhat.atlassian.net/browse/ACM-35000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved navigation across assisted installer screens, including cluster lists, cluster details, breadcrumbs, and wizard flows.

* **Bug Fixes**
  * Migrated routing to React Router v7 to improve link and redirect consistency.
  * Fixed fallback/invalid-route handling so users return to the clusters list reliably.

* **Tests**
  * Added end-to-end Cypress coverage for assisted installer navigation and error-handling, and updated related test helpers/selectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->