### PR TITLE
Reflect selected operators correctly 

### DIFF
--- a/libs/ui-lib-tests/cypress/integration/use-cases/create-cluster/with-mtv-operator.cy.ts
+++ b/libs/ui-lib-tests/cypress/integration/use-cases/create-cluster/with-mtv-operator.cy.ts
@@ -2,6 +2,19 @@ import { commonActions } from '../../../views/common';
 import OperatorsForm from '../../../views/forms/Operators/OperatorsForm';
 import { operatorsPage } from '../../../views/operatorsPage';
 
+const mtvOperatorPreflightRequirements = {
+  operators: [
+    {
+      operatorName: 'mtv',
+      dependencies: ['cnv'],
+    },
+    {
+      operatorName: 'cnv',
+      dependencies: ['lso'],
+    },
+  ],
+};
+
 describe(`Create cluster with MTV operator enabled`, () => {
   const setTestStartSignal = (activeSignal: string) => {
     cy.setTestEnvironment({
@@ -14,25 +27,36 @@ describe(`Create cluster with MTV operator enabled`, () => {
 
   beforeEach(() => {
     setTestStartSignal('CLUSTER_CREATED');
+    cy.intercept(
+      'GET',
+      `/api/assisted-install/v2/clusters/${Cypress.env('clusterId')}/preflight-requirements`,
+      mtvOperatorPreflightRequirements,
+    ).as('cluster-req');
     commonActions.visitClusterDetailsPage();
     commonActions.startAtWizardStep('Operators');
     operatorsPage.singleOperatorsToggle().click();
+    cy.wait('@cluster-req');
+    cy.wait('@supported-operators');
   });
 
   describe('When the feature is enabled:', () => {
     it('There is a popover and helper text next to the checkbox label', () => {
       OperatorsForm.mtvOperatorControl.findHelperText();
     });
-    it('The user can select the MTV checkbox', () => {
+    it('Selecting MTV checks dependency operators and sends only MTV to the API', () => {
+      OperatorsForm.assertOperatorCheckbox('cnv', { checked: false, disabled: false });
+      OperatorsForm.assertOperatorCheckbox('lso', { checked: false, disabled: true });
+
       OperatorsForm.mtvOperatorControl.findLabel().click({ force: true });
+
+      OperatorsForm.assertOperatorCheckbox('mtv', { checked: true, disabled: false });
+      OperatorsForm.assertOperatorCheckbox('cnv', { checked: true, disabled: true });
+      OperatorsForm.assertOperatorCheckbox('lso', { checked: true, disabled: true });
+
       commonActions.toNextStepAfter('Operators');
 
       cy.wait('@update-cluster').then(({ request }) => {
-        expect(request.body.olm_operators).to.deep.equal([
-          { name: 'cnv' },
-          { name: 'lso' },
-          { name: 'mtv' },
-        ]);
+        expect(request.body.olm_operators).to.deep.equal([{ name: 'mtv' }]);
       });
     });
   });

--- a/libs/ui-lib-tests/cypress/views/forms/Operators/OperatorsForm.ts
+++ b/libs/ui-lib-tests/cypress/views/forms/Operators/OperatorsForm.ts
@@ -10,6 +10,19 @@ export default class OperatorsForm {
   static get mtvOperatorControl() {
     return MtvOperatorControl;
   }
+
+  static getOperatorCheckbox(operatorId: string) {
+    return OperatorsForm.body.find(`#form-input-${operatorId}-field`);
+  }
+
+  static assertOperatorCheckbox(
+    operatorId: string,
+    { checked, disabled }: { checked: boolean; disabled: boolean },
+  ) {
+    const checkbox = OperatorsForm.getOperatorCheckbox(operatorId);
+    checkbox.should(checked ? 'be.checked' : 'not.be.checked');
+    checkbox.should(disabled ? 'be.disabled' : 'not.be.disabled');
+  }
 }
 
 /** @private */

--- a/libs/ui-lib-tests/cypress/views/operatorsPage.ts
+++ b/libs/ui-lib-tests/cypress/views/operatorsPage.ts
@@ -3,6 +3,6 @@ export const operatorsPage = {
     return cy.get('#form-input-cnv-field');
   },
   singleOperatorsToggle: () => {
-    return cy.contains('Single Operators ');
+    return cy.contains('Single operators');
   },
 };

--- a/libs/ui-lib/lib/common/selectors/clusterSelectors.ts
+++ b/libs/ui-lib/lib/common/selectors/clusterSelectors.ts
@@ -44,6 +44,13 @@ export const selectOlmOperators = (cluster?: Pick<Cluster, 'monitoredOperators'>
   );
 };
 
+// Includes dependency-only operators
+export const selectAllOlmOperators = (cluster?: Pick<Cluster, 'monitoredOperators'>) => {
+  return selectMonitoredOperators(cluster?.monitoredOperators).filter(
+    (operator) => operator.operatorType === 'olm' && !!operator.name,
+  );
+};
+
 export const hasEnabledOperators = (
   monitoredOperators: Cluster['monitoredOperators'],
   searchOperator: string,

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OperatorCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OperatorCheckbox.tsx
@@ -24,7 +24,6 @@ import {
 import NewFeatureSupportLevelBadge from '../../../../common/components/newFeatureSupportLevels/NewFeatureSupportLevelBadge';
 import { getFieldId, OperatorsValues, PopoverIcon } from '../../../../common';
 import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
-import { getNewOperators } from './utils';
 import {
   highlightMatch,
   OperatorSpec,
@@ -112,6 +111,7 @@ const OperatorCheckbox = ({
   bundles,
   cluster,
   operatorId,
+  isChecked,
   title,
   featureId,
   notStandalone,
@@ -124,6 +124,7 @@ const OperatorCheckbox = ({
   bundles: Bundle[];
   cluster: Cluster;
   operatorId: string;
+  isChecked: boolean;
   openshiftVersion?: string;
   preflightRequirements: PreflightHardwareRequirements | undefined;
   searchTerm?: string;
@@ -143,8 +144,6 @@ const OperatorCheckbox = ({
   const isSelectedForBundle = values.selectedBundles.some((selectedBundle) =>
     selectedBundle.optionalOperators?.includes(operatorId),
   );
-  const isInBundle = isRequiredByBundle || isSelectedForBundle;
-
   const isOperatorActive = (opName: string) =>
     values.selectedOperators.includes(opName) ||
     values.selectedBundles.some((selectedBundle) => {
@@ -153,8 +152,6 @@ const OperatorCheckbox = ({
         bundle?.operators?.includes(opName) || selectedBundle.optionalOperators?.includes(opName)
       );
     });
-
-  const isChecked = values.selectedOperators.includes(operatorId) || isInBundle;
 
   const parentOperator = preflightRequirements?.operators?.find(
     (op) =>
@@ -203,16 +200,10 @@ const OperatorCheckbox = ({
         aria-describedby={`${fieldId}-helper`}
         isChecked={isChecked}
         onChange={(_, checked) => {
-          setFieldValue(
-            'selectedOperators',
-            getNewOperators(
-              values.selectedOperators,
-              operatorId,
-              preflightRequirements,
-              checked,
-              opSpecs,
-            ),
-          );
+          const next = checked
+            ? [...new Set([...values.selectedOperators, operatorId])]
+            : values.selectedOperators.filter((op) => op !== operatorId);
+          setFieldValue('selectedOperators', next);
         }}
         isDisabled={isViewerMode || !!disabledReason}
         description={

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OperatorCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OperatorCheckbox.tsx
@@ -109,6 +109,7 @@ const OperatorRequirements = ({
 
 const OperatorCheckbox = ({
   bundles,
+  dependencies,
   cluster,
   operatorId,
   isChecked,
@@ -122,6 +123,7 @@ const OperatorCheckbox = ({
   searchTerm,
 }: {
   bundles: Bundle[];
+  dependencies: Set<string>;
   cluster: Cluster;
   operatorId: string;
   isChecked: boolean;
@@ -136,48 +138,58 @@ const OperatorCheckbox = ({
   const { values, setFieldValue } = useFormikContext<OperatorsValues>();
   const fieldId = getFieldId(operatorId, 'input');
   const supportLevel = getFeatureSupportLevel(featureId);
+  const getDisabledReason = (): string | undefined => {
+    const featureDisabledReason = getFeatureDisabledReason(featureId);
+    if (featureDisabledReason) {
+      return featureDisabledReason;
+    }
 
-  const isRequiredByBundle = values.selectedBundles.some(
-    (selectedBundle) =>
-      !!bundles.find((bundle) => bundle.id === selectedBundle.id)?.operators?.includes(operatorId),
-  );
-  const isSelectedForBundle = values.selectedBundles.some((selectedBundle) =>
-    selectedBundle.optionalOperators?.includes(operatorId),
-  );
-  const isOperatorActive = (opName: string) =>
-    values.selectedOperators.includes(opName) ||
-    values.selectedBundles.some((selectedBundle) => {
-      const bundle = bundles.find(({ id }) => id === selectedBundle.id);
-      return (
-        bundle?.operators?.includes(opName) || selectedBundle.optionalOperators?.includes(opName)
-      );
-    });
+    const isRequiredByBundle = values.selectedBundles.some(
+      (selectedBundle) =>
+        !!bundles
+          .find((bundle) => bundle.id === selectedBundle.id)
+          ?.operators?.includes(operatorId),
+    );
+    if (isRequiredByBundle) {
+      return 'This operator is part of a selected bundle and cannot be deselected.';
+    }
 
-  const parentOperator = preflightRequirements?.operators?.find(
-    (op) =>
-      !!op.operatorName &&
-      op.dependencies?.includes(operatorId) &&
-      isOperatorActive(op.operatorName),
-  );
+    const isOptionallySelectedForBundle = values.selectedBundles.some((selectedBundle) =>
+      selectedBundle.optionalOperators?.includes(operatorId),
+    );
+    if (isOptionallySelectedForBundle) {
+      return 'This optional operator is selected through a bundle. Use the bundle card to change it.';
+    }
 
-  let requiredByOperatorName = '';
-  if (parentOperator?.operatorName) {
-    requiredByOperatorName =
-      opSpecs[parentOperator.operatorName]?.title || parentOperator.operatorName;
-  }
+    const parentOperator = preflightRequirements?.operators?.find(
+      ({ operatorName, dependencies }) =>
+        !!operatorName &&
+        dependencies?.includes(operatorId) &&
+        values.selectedOperators.includes(operatorName),
+    );
+    if (parentOperator?.operatorName) {
+      const parentName = opSpecs[parentOperator.operatorName]?.title || parentOperator.operatorName;
+      return `This operator is required by ${parentName}`;
+    }
 
-  let disabledReason = getFeatureDisabledReason(featureId);
+    if (dependencies.has(operatorId)) {
+      return 'This operator is a sub-dependency of a selected operator';
+    }
 
-  if (isRequiredByBundle) {
-    disabledReason = 'This operator is part of a selected bundle and cannot be deselected.';
-  } else if (isSelectedForBundle) {
-    disabledReason =
-      'This optional operator is selected through a bundle. Use the bundle card to change it.';
-  } else if (requiredByOperatorName) {
-    disabledReason = `This operator is required by ${requiredByOperatorName}`;
-  } else if (notStandalone && !values.selectedOperators.includes(operatorId)) {
-    disabledReason = 'This operator cannot be installed as a standalone';
-  }
+    if (notStandalone && !values.selectedOperators.includes(operatorId)) {
+      return 'This operator cannot be installed as a standalone';
+    }
+
+    return undefined;
+  };
+
+  const disabledReason = getDisabledReason();
+  const handleClick = (_: React.FormEvent, checked: boolean) => {
+    const next = checked
+      ? [...new Set([...values.selectedOperators, operatorId])]
+      : values.selectedOperators.filter((op) => op !== operatorId);
+    setFieldValue('selectedOperators', next);
+  };
 
   return (
     <FormGroup fieldId={fieldId} id={`form-control__${fieldId}`}>
@@ -199,12 +211,7 @@ const OperatorCheckbox = ({
         }
         aria-describedby={`${fieldId}-helper`}
         isChecked={isChecked}
-        onChange={(_, checked) => {
-          const next = checked
-            ? [...new Set([...values.selectedOperators, operatorId])]
-            : values.selectedOperators.filter((op) => op !== operatorId);
-          setFieldValue('selectedOperators', next);
-        }}
+        onChange={handleClick}
         isDisabled={isViewerMode || !!disabledReason}
         description={
           !!Description && (

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OperatorCheckbox.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/OperatorCheckbox.tsx
@@ -109,7 +109,7 @@ const OperatorRequirements = ({
 
 const OperatorCheckbox = ({
   bundles,
-  dependencies,
+  checkedOperatorIds,
   cluster,
   operatorId,
   isChecked,
@@ -123,7 +123,7 @@ const OperatorCheckbox = ({
   searchTerm,
 }: {
   bundles: Bundle[];
-  dependencies: Set<string>;
+  checkedOperatorIds: Set<string>;
   cluster: Cluster;
   operatorId: string;
   isChecked: boolean;
@@ -165,18 +165,14 @@ const OperatorCheckbox = ({
       ({ operatorName, dependencies }) =>
         !!operatorName &&
         dependencies?.includes(operatorId) &&
-        values.selectedOperators.includes(operatorName),
+        checkedOperatorIds.has(operatorName),
     );
     if (parentOperator?.operatorName) {
       const parentName = opSpecs[parentOperator.operatorName]?.title || parentOperator.operatorName;
       return `This operator is required by ${parentName}`;
     }
 
-    if (dependencies.has(operatorId)) {
-      return 'This operator is a sub-dependency of a selected operator';
-    }
-
-    if (notStandalone && !values.selectedOperators.includes(operatorId)) {
+    if (notStandalone && !checkedOperatorIds.has(operatorId)) {
       return 'This operator cannot be installed as a standalone';
     }
 
@@ -186,7 +182,7 @@ const OperatorCheckbox = ({
   const disabledReason = getDisabledReason();
   const handleClick = (_: React.FormEvent, checked: boolean) => {
     const next = checked
-      ? [...new Set([...values.selectedOperators, operatorId])]
+      ? [...values.selectedOperators, operatorId]
       : values.selectedOperators.filter((op) => op !== operatorId);
     setFieldValue('selectedOperators', next);
   };

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/utils.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/utils.tsx
@@ -3,8 +3,6 @@ import {
   Bundle,
   PreflightHardwareRequirements,
 } from '@openshift-assisted/types/assisted-installer-service';
-import { OperatorSpec } from '../../../../common/components/operators/operatorSpecs';
-
 const getOperatorDependencies = (
   operatorId: string,
   preflightRequirements: PreflightHardwareRequirements | undefined,
@@ -24,36 +22,6 @@ const getOperatorDependencies = (
     });
   }
   return [...dependencies];
-};
-
-export const getNewOperators = (
-  currentOperators: string[],
-  operatorId: string,
-  preflightRequirements: PreflightHardwareRequirements | undefined,
-  add: boolean,
-  opSpecs: { [key: string]: OperatorSpec },
-): string[] => {
-  const dependencies = getOperatorDependencies(operatorId, preflightRequirements);
-
-  if (add) {
-    const uniqueOps = new Set([...currentOperators, ...dependencies, operatorId]);
-    return Array.from(uniqueOps);
-  }
-
-  const newOperators = currentOperators.filter((op) => op !== operatorId);
-  const notStandaloneDeps = dependencies
-    .filter((dep) => opSpecs[dep]?.notStandalone)
-    .filter((dep) => {
-      const hasDependency = newOperators.some((op) =>
-        getOperatorDependencies(op, preflightRequirements).includes(dep),
-      );
-      if (!hasDependency) {
-        newOperators.splice(newOperators.indexOf(dep), 1);
-      }
-      return !hasDependency;
-    });
-
-  return currentOperators.filter((op) => op !== operatorId && !notStandaloneDeps.includes(op));
 };
 
 const getBundleOperators = (

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/utils.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/operators/utils.tsx
@@ -3,7 +3,7 @@ import {
   Bundle,
   PreflightHardwareRequirements,
 } from '@openshift-assisted/types/assisted-installer-service';
-const getOperatorDependencies = (
+export const getOperatorDependencies = (
   operatorId: string,
   preflightRequirements: PreflightHardwareRequirements | undefined,
   dependencies: Set<string> = new Set(),

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewOperatorsTable.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/review/ReviewOperatorsTable.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Title } from '@patternfly/react-core';
 import { Table, TableVariant, Tbody, Td, Tr } from '@patternfly/react-table';
-import { genericTableRowKey, selectOlmOperators } from '../../../../common';
+import { genericTableRowKey, selectAllOlmOperators } from '../../../../common';
 import { useStateSafely } from '../../../../common/hooks';
 import { Bundle, Cluster } from '@openshift-assisted/types/assisted-installer-service';
 import { TableSummaryExpandable } from './TableSummaryExpandable';
@@ -68,7 +68,7 @@ export const ReviewOperatorsTable = ({ cluster }: { cluster: Cluster }) => {
 
   const rows = React.useMemo(
     () =>
-      selectOlmOperators(cluster)
+      selectAllOlmOperators(cluster)
         .filter(({ name }) => !!name && !!opSpecs[name])
         .map((op) => {
           const opId = op.name as string;

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsSelect.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsSelect.tsx
@@ -91,7 +91,7 @@ const OperatorsSelect = ({
   return (
     <>
       <ExpandableSection
-        toggleText={`Single operators ( ${operatorsCount} selected)`}
+        toggleText={`Single operators (${operatorsCount} selected)`}
         onToggle={() => setIsExpanded(!isExpanded)}
         isExpanded={isExpanded}
         data-testid="single-operators-section"
@@ -128,7 +128,7 @@ const OperatorsSelect = ({
                     <OperatorCheckbox
                       bundles={bundles}
                       operatorId={spec.operatorKey}
-                      dependencies={dependencies}
+                      checkedOperatorIds={checkedOperatorIds}
                       isChecked={checkedOperatorIds.has(spec.operatorKey)}
                       cluster={cluster}
                       openshiftVersion={cluster.openshiftVersion}

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsSelect.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsSelect.tsx
@@ -36,7 +36,6 @@ const OperatorsSelect = ({
   const [isExpanded, setIsExpanded] = React.useState(false);
   const [supportedOperators, setSupportedOperators] = useStateSafely<string[]>([]);
   const isSingleClusterFeatureEnabled = useFeature('ASSISTED_INSTALLER_SINGLE_CLUSTER_FEATURE');
-  const { values } = useFormikContext<OperatorsValues>();
   React.useEffect(() => {
     const fetchSupportedOperators = async () => {
       try {
@@ -54,6 +53,7 @@ const OperatorsSelect = ({
     void fetchSupportedOperators();
   }, [addAlert, setSupportedOperators, setIsLoading]);
 
+  const { values } = useFormikContext<OperatorsValues>();
   const { byCategory, byKey: opSpecs } = useOperatorSpecs();
 
   const operators = React.useMemo(() => {
@@ -65,9 +65,34 @@ const OperatorsSelect = ({
     });
   }, [isSingleClusterFeatureEnabled, supportedOperators]);
 
-  const selectedOperators = values.selectedOperators.filter(
-    (opKey) => operators.includes(opKey) && !!opSpecs[opKey],
+  const isOperatorActive = React.useCallback(
+    (opName: string) =>
+      values.selectedOperators.includes(opName) ||
+      values.selectedBundles.some((selectedBundle) => {
+        const bundle = bundles.find(({ id }) => id === selectedBundle.id);
+        return (
+          bundle?.operators?.includes(opName) || selectedBundle.optionalOperators?.includes(opName)
+        );
+      }),
+    [values.selectedOperators, values.selectedBundles, bundles],
   );
+
+  // Computed once for all checkboxes — passed down as a prop to avoid per-checkbox recalculation.
+  const checkedOperatorIds = React.useMemo(
+    () =>
+      new Set(
+        operators.filter(
+          (op) =>
+            isOperatorActive(op) ||
+            preflightRequirements?.operators?.some(
+              (req) => req.dependencies?.includes(op) && isOperatorActive(req.operatorName ?? ''),
+            ),
+        ),
+      ),
+    [operators, isOperatorActive, preflightRequirements],
+  );
+
+  const operatorsCount = checkedOperatorIds.size;
 
   if (isLoading) {
     return <LoadingState />;
@@ -76,7 +101,7 @@ const OperatorsSelect = ({
   return (
     <>
       <ExpandableSection
-        toggleText={`Single Operators (${operators.length} | ${selectedOperators.length} selected)`}
+        toggleText={`Single operators ( ${operatorsCount} selected)`}
         onToggle={() => setIsExpanded(!isExpanded)}
         isExpanded={isExpanded}
         data-testid="single-operators-section"
@@ -113,6 +138,7 @@ const OperatorsSelect = ({
                     <OperatorCheckbox
                       bundles={bundles}
                       operatorId={spec.operatorKey}
+                      isChecked={checkedOperatorIds.has(spec.operatorKey)}
                       cluster={cluster}
                       openshiftVersion={cluster.openshiftVersion}
                       preflightRequirements={preflightRequirements}

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsSelect.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/OperatorsSelect.tsx
@@ -19,6 +19,7 @@ import { OperatorsService } from '../../services';
 import { useFeature } from '../../hooks/use-feature';
 import OperatorCheckbox from '../clusterConfiguration/operators/OperatorCheckbox';
 import { useOperatorSpecs } from '../../../common/components/operators/operatorSpecs';
+import { getOperatorDependencies } from '../clusterConfiguration/operators/utils';
 
 const OperatorsSelect = ({
   cluster,
@@ -65,34 +66,23 @@ const OperatorsSelect = ({
     });
   }, [isSingleClusterFeatureEnabled, supportedOperators]);
 
-  const isOperatorActive = React.useCallback(
-    (opName: string) =>
-      values.selectedOperators.includes(opName) ||
-      values.selectedBundles.some((selectedBundle) => {
-        const bundle = bundles.find(({ id }) => id === selectedBundle.id);
-        return (
-          bundle?.operators?.includes(opName) || selectedBundle.optionalOperators?.includes(opName)
-        );
-      }),
-    [values.selectedOperators, values.selectedBundles, bundles],
+  const bundleOperators = new Set<string>();
+  values.selectedBundles.forEach((b) => {
+    b.optionalOperators?.forEach((op) => bundleOperators.add(op));
+    bundles.find(({ id }) => id === b.id)?.operators?.forEach((op) => bundleOperators.add(op));
+  });
+
+  const dependencies = new Set<string>();
+  [...values.selectedOperators, ...bundleOperators].forEach((op) =>
+    getOperatorDependencies(op, preflightRequirements, dependencies),
   );
 
-  // Computed once for all checkboxes — passed down as a prop to avoid per-checkbox recalculation.
-  const checkedOperatorIds = React.useMemo(
-    () =>
-      new Set(
-        operators.filter(
-          (op) =>
-            isOperatorActive(op) ||
-            preflightRequirements?.operators?.some(
-              (req) => req.dependencies?.includes(op) && isOperatorActive(req.operatorName ?? ''),
-            ),
-        ),
-      ),
-    [operators, isOperatorActive, preflightRequirements],
-  );
-
-  const operatorsCount = checkedOperatorIds.size;
+  const checkedOperatorIds = new Set([
+    ...values.selectedOperators,
+    ...bundleOperators,
+    ...dependencies,
+  ]);
+  const operatorsCount = operators.filter((op) => checkedOperatorIds.has(op)).length;
 
   if (isLoading) {
     return <LoadingState />;
@@ -138,6 +128,7 @@ const OperatorsSelect = ({
                     <OperatorCheckbox
                       bundles={bundles}
                       operatorId={spec.operatorKey}
+                      dependencies={dependencies}
                       isChecked={checkedOperatorIds.has(spec.operatorKey)}
                       cluster={cluster}
                       openshiftVersion={cluster.openshiftVersion}


### PR DESCRIPTION
https://redhat.atlassian.net/browse/MGMT-24633
https://redhat.atlassian.net/browse/MGMT-24636

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operator selection now computes checkbox state and “selected” count consistently from directly selected, bundle-provided, and dependency-inferred operators.
  * Operators review table now shows all relevant OLM operators, including dependency-only operators.

* **Bug Fixes**
  * Checkbox state and enabled/disabled logic were refactored to avoid mismatches when selecting or deselecting operators.
  * Updated dependency checks so required operators reflect current selections.

* **Tests**
  * Extended Cypress MTV test to validate automatic dependency checkbox behavior and updated submitted `olm_operators`.
  * Updated Cypress selectors and added helper assertions for operator checkboxes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->