### PR TITLE
OCPBUGS-96890: Bump sanitize-html to 2.17.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "serialize-javascript": "^7.0.6",
     "ws": "^8.21.0",
     "qs": "^6.15.3",
-    "shell-quote": "^1.8.4"
+    "shell-quote": "^1.8.4",
+    "sanitize-html": "^2.17.4"
   },
   "workspaces": [
     "apps/*",


### PR DESCRIPTION
## Summary

This PR addresses **CVE-2026-44990** by forcing `sanitize-html` to version 2.17.4 via yarn resolutions. This fixes a critical stored XSS vulnerability in the sanitize-html library.

## CVE Details

**CVE-2026-44990**: Stored Cross-Site Scripting via xmp tag bypass in sanitize-html

- **Severity**: Critical (CVSS 9.3)
- **Affected**: sanitize-html < 2.17.4  
- **Fixed**: sanitize-html >= 2.17.4
- **Impact**: Attackers can execute arbitrary JavaScript by submitting content with malicious xmp tags



## References

- Jira: [OCPBUGS-96890](https://redhat.atlassian.net/browse/OCPBUGS-96890)
- GitHub Advisory: [GHSA-rpr9-rxv7-x643](https://github.com/advisories/GHSA-rpr9-rxv7-x643)
- sanitize-html Issue: [apostrophecms/sanitize-html#293](https://github.com/apostrophecms/sanitize-html/issues/293)
