### PR TITLE
OCPBUGS-96781: Bump webpack-dev-server to 5.2.5

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -18047,8 +18047,8 @@ __metadata:
   linkType: hard
 
 "webpack-dev-server@npm:5.2.3":
-  version: 5.2.3
-  resolution: "webpack-dev-server@npm:5.2.3"
+  version: 5.2.5
+  resolution: "webpack-dev-server@npm:5.2.5"
   dependencies:
     "@types/bonjour": ^3.5.13
     "@types/connect-history-api-fallback": ^1.5.4
@@ -18087,7 +18087,7 @@ __metadata:
       optional: true
   bin:
     webpack-dev-server: bin/webpack-dev-server.js
-  checksum: 2b7f2096529945f578e86966d9a0994b0a87b82e3bb3a7cd1ccea2fb81aa95724473a88c9b2033ae3d2f799d13330342948ea77638029d10c8c0c746aac545f7
+  checksum: 349719d0487a5672f65a7427d54afc9f8ddc6b695042641ed9f468cb5a3c90866e16a236ecdb2ac62d2a922712f9c1296b8805b7ec0880f6a3f5c4280785f200
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

This PR addresses CVE-2026-9595 by updating webpack-dev-server from 5.2.3 to 5.2.5, which includes a fix for an information disclosure vulnerability via improper proxy configuration.

## CVE Details

**CVE-2026-9595**: webpack-dev-server information disclosure and denial of service via improper proxy configuration

- **Severity**: Medium
- **Affected**: webpack-dev-server < 5.2.5
- **Impact**: Information disclosure (cookies, Origin headers) when using permissive proxy configuration with `context: '/'` and `ws: true`
- **Vulnerable component**: HMR WebSocket proxy interception

