### PR TITLE
OCPBUGS-96710: Bump basic-ftp to 5.3.1 for CVE-2026-44240

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "follow-redirects": "^1.16.0",
     "shell-quote": "^1.8.4",
     "ip-address": "^10.1.1",
-    "tar": "^7.5.19"
+    "tar": "^7.5.19",
+    "basic-ftp": "^5.3.1"
   },
   "workspaces": [
     "apps/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5697,10 +5697,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"basic-ftp@npm:^5.0.2":
-  version: 5.2.1
-  resolution: "basic-ftp@npm:5.2.1"
-  checksum: f1d26251248255b25cfccde8b4bc1ef8ab7f8d6112b56d7de0fd1008fa6c5dbc3e5df680d445f5fbd14a00640dd33dabff4f2cbcf2be5bd9c1cde3c138eb9147
+"basic-ftp@npm:^5.3.1":
+  version: 5.3.1
+  resolution: "basic-ftp@npm:5.3.1"
+  checksum: a3b5ffbedb070f89636aaaa5f639b2b275cab3486f8e216902bd60529e51047b42c732059dc94869581e2f585937a76d183a09fc519b1ce909155c137a502953
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

This PR addresses CVE-2026-44240 by updating the basic-ftp dependency from version 5.2.1 to 5.3.1, which includes a fix for an unbounded multiline FTP response buffering vulnerability that could lead to denial of service (DoS).

## Changes

- Added `basic-ftp: ^5.3.1` to yarn resolutions in package.json
- Ran `yarn install` to update yarn.lock
- Updated lockfile shows basic-ftp@5.3.1

## CVE Details

**CVE-2026-44240**: basic-ftp unbounded multiline FTP response buffering DoS

- **Severity**: Medium
- **Affected versions**: < 5.3.1
- **Fixed version**: 5.3.1
- **Impact**: Client-side DoS via unbounded multiline FTP response buffering

## Dependency Chain

basic-ftp is a transitive devDependency:
```
@openapitools/openapi-generator-cli
  → proxy-agent
    → pac-proxy-agent
      → get-uri
        → basic-ftp@5.2.1 (vulnerable)
```

