### PR TITLE
[release-4.22] MGMT-24749: Pull secret appears editable in draft cluster but changes are not applied

### DIFF
--- a/libs/ui-lib/lib/common/components/clusters/PullSecret.tsx
+++ b/libs/ui-lib/lib/common/components/clusters/PullSecret.tsx
@@ -18,8 +18,10 @@ const PullSecret: React.FC<PullSecretProps> = ({
   isPullSecretSet = false,
   isSingleClusterFeatureEnabled = false,
 }) => {
-  // Fetched pull secret will never change - see LoadingState in NewCluster
-  const [isExpanded, setExpanded] = React.useState(!defaultPullSecret);
+  // Existing cluster with a pull secret on the server: start collapsed so the secret text is not shown until the user chooses "Edit pull secret".
+  const [isExpanded, setExpanded] = React.useState(() =>
+    isPullSecretSet ? false : !defaultPullSecret,
+  );
   const { setFieldValue } = useFormikContext<ClusterCreateParams>();
   const { t } = useTranslation();
   const onCheckboxChange = () => {

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterDetails.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterDetails.tsx
@@ -46,7 +46,9 @@ const ClusterDetails = ({ cluster, infraEnv }: ClusterDetailsProps) => {
   } = useOpenShiftVersionsContext();
   const location = useLocation();
   const isSingleClusterFeatureEnabled = useFeature('ASSISTED_INSTALLER_SINGLE_CLUSTER_FEATURE');
-  const pullSecret = usePullSecret(isSingleClusterFeatureEnabled);
+  const fetchedPullSecret = usePullSecret(isSingleClusterFeatureEnabled);
+  /** With a cluster resource, never pre-fill the form with a pull secret (API does not return it); new-cluster flow uses the hook default. */
+  const pullSecretForForm = cluster ? '' : fetchedPullSecret ?? '';
 
   const handleClusterUpdate = React.useCallback(
     async (clusterId: Cluster['id'], params: ClusterDetailsUpdateParams) => {
@@ -59,7 +61,6 @@ const ClusterDetails = ({ cluster, infraEnv }: ClusterDetailsProps) => {
           params,
         );
         dispatch(updateCluster(updatedCluster));
-
         canNextClusterDetails({ cluster: updatedCluster }) && clusterWizardContext.moveNext();
       } catch (e) {
         handleApiError(e, () =>
@@ -140,7 +141,12 @@ const ClusterDetails = ({ cluster, infraEnv }: ClusterDetailsProps) => {
   );
 
   const navigation = <ClusterWizardNavigation cluster={cluster} />;
-  if (pullSecret === undefined || !managedDomains || loadingOCPVersions || !usedClusterNames) {
+  if (
+    (!cluster && fetchedPullSecret === undefined) ||
+    !managedDomains ||
+    loadingOCPVersions ||
+    !usedClusterNames
+  ) {
     return (
       <ClusterWizardStep navigation={navigation}>
         <LoadingState />
@@ -162,7 +168,7 @@ const ClusterDetails = ({ cluster, infraEnv }: ClusterDetailsProps) => {
   return (
     <ClusterDetailsForm
       cluster={cluster}
-      pullSecret={pullSecret}
+      pullSecret={pullSecretForForm}
       managedDomains={managedDomains}
       ocpVersions={versions}
       usedClusterNames={usedClusterNames}


### PR DESCRIPTION
## Summary

Cherry-pick of #3597 to `release-4.22`.

**Jira:** [MGMT-23916](https://redhat.atlassian.net/browse/MGMT-23916)
**Original PR:** https://github.com/openshift-assisted/assisted-installer-ui/pull/3597

## Changes

Pull secret appears editable in draft cluster but changes are not applied

---
**Backport Jira:** [MGMT-24749](https://redhat.atlassian.net/browse/MGMT-24749)
**Original Jira:** [MGMT-23916](https://redhat.atlassian.net/browse/MGMT-23916)