### PR TITLE
[release-4.22] MGMT-24751: Cluster name missing in page header for draft clusters

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusters/AssistedInstallerHeader.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusters/AssistedInstallerHeader.tsx
@@ -8,12 +8,16 @@ import {
 } from '../../../common';
 import { useFeature } from '../../hooks/use-feature';
 
-export const AssistedInstallerHeader = () => {
+type AssistedInstallerHeaderProps = {
+  clusterName?: string;
+};
+
+export const AssistedInstallerHeader = ({ clusterName }: AssistedInstallerHeaderProps) => {
   const isSingleClusterFeatureEnabled = useFeature('ASSISTED_INSTALLER_SINGLE_CLUSTER_FEATURE');
   return (
     <>
       <Content component="h1" className="pf-v6-u-display-inline">
-        Install OpenShift with the Assisted Installer
+        {clusterName || 'Install OpenShift with the Assisted Installer'}
       </Content>
       {isSingleClusterFeatureEnabled && <TechnologyPreview />}
       <Split hasGutter>

--- a/libs/ui-lib/lib/ocm/components/clusters/ClusterPage.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusters/ClusterPage.tsx
@@ -104,7 +104,7 @@ const ClusterPageGeneric = ({
           {showBreadcrumbs && <ClusterBreadcrumbs clusterName={cluster.name} />}
           {showBreadcrumbs && (
             <PageSection hasBodyWrapper={false}>
-              <AssistedInstallerHeader />
+              <AssistedInstallerHeader clusterName={cluster.name} />
             </PageSection>
           )}
 


### PR DESCRIPTION
## Summary

Cherry-pick of #3669 to `release-4.22`.

**Jira:** [MGMT-23950](https://redhat.atlassian.net/browse/MGMT-23950)
**Original PR:** https://github.com/openshift-assisted/assisted-installer-ui/pull/3669

## Changes

Cluster name missing in page header for draft clusters

---
**Backport Jira:** [MGMT-24751](https://redhat.atlassian.net/browse/MGMT-24751)
**Original Jira:** [MGMT-23950](https://redhat.atlassian.net/browse/MGMT-23950)