### PR TITLE
[release-4.22] MGMT-24752: UI form view missing autoconf field for ipv6

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/data/formDataToInfraEnvField.ts
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/data/formDataToInfraEnvField.ts
@@ -73,6 +73,7 @@ const getNmstateObject = (
       realProtocolConfigs[protocolVersion] = getNmstateProtocolConfig(
         hostIp,
         getPrefixLength(networkWide, protocolVersion),
+        protocolVersion,
       );
       if (networkWide.useVlan && networkWide.vlanId) {
         if (bondType && hasBondsConfigured) {
@@ -94,6 +95,7 @@ const getNmstateObject = (
         [protocolVersion]: getNmstateProtocolConfig(
           DUMMY_NMSTATE_ADDRESSES[protocolVersion].ip,
           DUMMY_NMSTATE_ADDRESSES[protocolVersion].prefixLength,
+          protocolVersion,
         ),
       };
       nicName = getDummyNicName(protocolVersion);

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/data/nmstateTypes.ts
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/data/nmstateTypes.ts
@@ -15,6 +15,7 @@ export type NmstateProtocolConfig = {
   address: NmstateAddress[];
   enabled: boolean;
   dhcp: boolean;
+  autoconf?: boolean;
 };
 
 export type NmstateProtocolConfigs = {

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/data/nmstateYaml.ts
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/staticIp/data/nmstateYaml.ts
@@ -80,6 +80,7 @@ export const getProtocolType = (comments: string[]): StaticProtocolType | null =
 export const getNmstateProtocolConfig = (
   ipAddress: string,
   prefixLength: number,
+  protocolVersion?: ProtocolVersion,
 ): NmstateProtocolConfig => {
   return {
     address: [
@@ -90,6 +91,7 @@ export const getNmstateProtocolConfig = (
     ],
     enabled: true,
     dhcp: false,
+    ...(protocolVersion === ProtocolVersion.ipv6 && { autoconf: false }),
   };
 };
 


### PR DESCRIPTION
## Summary

Cherry-pick of #3681 to `release-4.22`.

**Jira:** [MGMT-19002](https://redhat.atlassian.net/browse/MGMT-19002)
**Original PR:** https://github.com/openshift-assisted/assisted-installer-ui/pull/3681

## Changes

UI form view missing autoconf field for ipv6

---
**Backport Jira:** [MGMT-24752](https://redhat.atlassian.net/browse/MGMT-24752)
**Original Jira:** [MGMT-19002](https://redhat.atlassian.net/browse/MGMT-19002)