### PR TITLE
[release-4.22] MGMT-24753: Third-Party CNI stuck on Networking page in Validating status

### DIFF
--- a/libs/ui-lib/lib/cim/components/ClusterDeployment/wizardTransition.ts
+++ b/libs/ui-lib/lib/cim/components/ClusterDeployment/wizardTransition.ts
@@ -69,7 +69,11 @@ const networkingStepValidationsMap: WizardStepValidationMap = {
   // Alternatively we would have to whitelist network validations instead of using group
   // TODO(mlibra): remove that container-images-available from soft validations and let backend drive it via disabling it.
   //   Depends on: https://issues.redhat.com/browse/MGMT-5265
-  softValidationIds: ['ntp-synced', 'container-images-available'],
+  softValidationIds: [
+    'ntp-synced',
+    'container-images-available',
+    'custom-manifests-requirements-satisfied',
+  ],
   getPageURL: (host: Host, validationID: string) => {
     if (validationID === 'ntp-synced') {
       return {


### PR DESCRIPTION
## Summary

Cherry-pick of #3682 to `release-4.22`.

**Jira:** [MGMT-24301](https://redhat.atlassian.net/browse/MGMT-24301)
**Original PR:** https://github.com/openshift-assisted/assisted-installer-ui/pull/3682

## Changes

Third-Party CNI stuck on Networking page in Validating status

---
**Backport Jira:** [MGMT-24753](https://redhat.atlassian.net/browse/MGMT-24753)
**Original Jira:** [MGMT-24301](https://redhat.atlassian.net/browse/MGMT-24301)