### PR TITLE
[release-4.22] MGMT-24754: Standalone flow deployment status page never opened after install

### DIFF
--- a/libs/ui-lib/lib/cim/components/ClusterDeployment/review/ClusterDeploymentReviewStep.tsx
+++ b/libs/ui-lib/lib/cim/components/ClusterDeployment/review/ClusterDeploymentReviewStep.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import {
   Alert,
   AlertVariant,
@@ -7,7 +8,7 @@ import {
   useWizardFooter,
   WizardFooter,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import { PlatformType } from '@openshift-assisted/types/assisted-installer-service';
 import { canNextFromReviewStep } from '../wizardTransition';
 import {
   AgentClusterInstallK8sResource,
@@ -42,7 +43,6 @@ import { useTranslation } from '../../../../common/hooks/use-translation-wrapper
 import { ClusterDeploymentWizardContext } from '../ClusterDeploymentWizardContext';
 import { ReviewConfigMapsTable } from './ReviewConfigMapsTable';
 import { ValidationSection } from '../components/ValidationSection';
-import { PlatformType } from '@openshift-assisted/types/assisted-installer-service';
 
 type ClusterDeploymentReviewStepProps = {
   clusterDeployment: ClusterDeploymentK8sResource;
@@ -77,7 +77,8 @@ export const ClusterDeploymentReviewStep = ({
 
   const canContinue = canNextFromReviewStep(agentClusterInstall, clusterAgents);
   const { t } = useTranslation();
-  const onNext = async () => {
+
+  const onNext = React.useCallback(async () => {
     clearAlerts();
     setSubmitting(true);
     try {
@@ -88,18 +89,21 @@ export const ClusterDeploymentReviewStep = ({
     } finally {
       setSubmitting(false);
     }
-  };
+  }, [addAlert, clearAlerts, onFinish, t]);
 
-  const footer = (
-    <WizardFooter
-      activeStep={activeStep}
-      onNext={onNext}
-      isNextDisabled={isSubmitting || !canContinue || !!syncError}
-      nextButtonText={t('ai:Install cluster')}
-      nextButtonProps={{ isLoading: isSubmitting }}
-      onBack={goToPrevStep}
-      onClose={close}
-    />
+  const footer = React.useMemo(
+    () => (
+      <WizardFooter
+        activeStep={activeStep}
+        onNext={onNext}
+        isNextDisabled={isSubmitting || !canContinue || !!syncError}
+        nextButtonText={t('ai:Install cluster')}
+        nextButtonProps={{ isLoading: isSubmitting }}
+        onBack={goToPrevStep}
+        onClose={close}
+      />
+    ),
+    [activeStep, canContinue, close, goToPrevStep, isSubmitting, onNext, syncError, t],
   );
   useWizardFooter(footer);
 


### PR DESCRIPTION
## Summary

Cherry-pick of #3686 to `release-4.22`.

**Jira:** [MGMT-23951](https://redhat.atlassian.net/browse/MGMT-23951)
**Original PR:** https://github.com/openshift-assisted/assisted-installer-ui/pull/3686

## Changes

Standalone flow deployment status page never opened after install

---
**Backport Jira:** [MGMT-24754](https://redhat.atlassian.net/browse/MGMT-24754)
**Original Jira:** [MGMT-23951](https://redhat.atlassian.net/browse/MGMT-23951)