### PR TITLE
[release-4.22] MGMT-24756: TNA cluster creation no possibility to choose Arbiter

### DIFF
--- a/libs/ui-lib/lib/cim/components/ClusterDeployment/ClusterDeploymentWizard.tsx
+++ b/libs/ui-lib/lib/cim/components/ClusterDeployment/ClusterDeploymentWizard.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
 import { Grid, GridItem, Wizard, WizardStep } from '@patternfly/react-core';
-import { AlertsContextProvider, LoadingState } from '../../../common';
+import { AlertsContextProvider, ErrorState, LoadingState } from '../../../common';
 import { ClusterDeploymentWizardProps } from './types';
 import { ACMFeatureSupportLevelProvider } from '../featureSupportLevels';
 import { YamlPreview, useYamlPreview } from '../YamlPreview';
@@ -14,6 +14,7 @@ import { ClusterDeploymentHostsDiscoveryStep } from './hostDiscovery';
 import { ClusterDeploymentNetworkingStep } from './networking';
 import { ClusterDeploymentReviewStep } from './review';
 import { ClusterDeploymentCustomManifestsStep } from './customManifests';
+import { useAgents } from '../../hooks';
 
 export const ClusterDeploymentWizard = ({
   className,
@@ -27,7 +28,6 @@ export const ClusterDeploymentWizard = ({
   fetchSecret,
   clusterDeployment,
   agentClusterInstall,
-  agents,
   bareMetalHosts,
   clusterImages,
   aiConfigMap,
@@ -54,11 +54,19 @@ export const ClusterDeploymentWizard = ({
     fetchKlusterletAddonConfig,
   });
 
+  const [agents, loaded, error] = useAgents({ isList: true });
+
   // if initialStep is set, it is either 'host-selection' or 'host-discovery', both at index 4
   // if initialStep is not set, start at 'cluster-details' which is at index 2
   const startIndex = initialStep ? 4 : 2;
   const stepNames = wizardStepNames(t);
   const isAIFlow = !!infraEnv;
+
+  if (!loaded) {
+    return <LoadingState />;
+  } else if (error) {
+    return <ErrorState />;
+  }
 
   return (
     <Grid style={{ height: '100%' }}>

--- a/libs/ui-lib/lib/cim/components/ClusterDeployment/types.ts
+++ b/libs/ui-lib/lib/cim/components/ClusterDeployment/types.ts
@@ -141,7 +141,6 @@ export type ClusterDeploymentWizardProps = {
 
   clusterDeployment: ClusterDeploymentK8sResource;
   agentClusterInstall: AgentClusterInstallK8sResource;
-  agents: AgentK8sResource[];
   bareMetalHosts: BareMetalHostK8sResource[];
   aiConfigMap?: ConfigMapK8sResource;
   infraEnv?: InfraEnvK8sResource;

--- a/libs/ui-lib/lib/cim/hooks/index.tsx
+++ b/libs/ui-lib/lib/cim/hooks/index.tsx
@@ -1,3 +1,4 @@
 export * from './useConfigMaps';
 export * from './useAgentServiceConfig';
 export * from './useEvents';
+export * from './useAgents';

--- a/libs/ui-lib/lib/cim/hooks/useAgents.tsx
+++ b/libs/ui-lib/lib/cim/hooks/useAgents.tsx
@@ -1,0 +1,15 @@
+import { useK8sWatchResource } from './useK8sWatchResource';
+import { AgentK8sResource } from '../types';
+import { K8sWatchHookProps } from './types';
+
+export const useAgents = (props: K8sWatchHookProps) =>
+  useK8sWatchResource<AgentK8sResource[]>(
+    {
+      groupVersionKind: {
+        group: 'agent-install.openshift.io',
+        kind: 'Agent',
+        version: 'v1beta1',
+      },
+    },
+    props,
+  );


### PR DESCRIPTION
## Summary

Cherry-pick of #3711 to `release-4.22`.

**Jira:** [MGMT-24321](https://redhat.atlassian.net/browse/MGMT-24321)
**Original PR:** https://github.com/openshift-assisted/assisted-installer-ui/pull/3711

## Changes

TNA cluster creation no possibility to choose Arbiter

---
**Backport Jira:** [MGMT-24756](https://redhat.atlassian.net/browse/MGMT-24756)
**Original Jira:** [MGMT-24321](https://redhat.atlassian.net/browse/MGMT-24321)