### PR TITLE
[release-4.22] MGMT-24761: Add hosts modal huge space between inline alert and buttons

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/DiscoveryImageForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/DiscoveryImageForm.tsx
@@ -19,6 +19,7 @@ import { mapClusterCpuArchToInfraEnvCpuArch } from '../../services/CpuArchitectu
 import { usePullSecret } from '../../hooks';
 import { Cluster } from '@openshift-assisted/types/assisted-installer-service';
 import { isOciPlatformType } from '../utils';
+import { ModalBody } from '@patternfly/react-core';
 
 type DiscoveryImageFormProps = {
   cluster: Cluster;
@@ -93,10 +94,18 @@ const DiscoveryImageForm = ({
   };
 
   if (infraEnvError) {
-    return <ErrorState />;
+    return (
+      <ModalBody style={{ height: '696px' }}>
+        <ErrorState />
+      </ModalBody>
+    );
   }
   if (!infraEnv) {
-    return <LoadingState />;
+    return (
+      <ModalBody style={{ height: '696px' }}>
+        <LoadingState />
+      </ModalBody>
+    );
   }
   return (
     <OcmDiscoveryImageConfigForm

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/DiscoveryImageModal.css
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/DiscoveryImageModal.css
@@ -1,3 +1,0 @@
-#generate-discovery-iso-modal {
-  height: 791px;
-}

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/DiscoveryImageModal.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/DiscoveryImageModal.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { Button, ButtonVariant, Modal, ModalHeader, ModalVariant } from '@patternfly/react-core';
+import {
+  Button,
+  ButtonVariant,
+  Modal,
+  ModalBody,
+  ModalHeader,
+  ModalVariant,
+} from '@patternfly/react-core';
 import { pluralize } from 'humanize-plus';
 import {
   AI_CISCO_INTERSIGHT_TAG,
@@ -14,7 +21,6 @@ import { useModalDialogsContext } from '../hosts/ModalDialogsContext';
 import useInfraEnvImageUrl from '../../hooks/useInfraEnvImageUrl';
 import useInfraEnvIpxeImageUrl from '../../hooks/useInfraEnvIpxeImageUrl';
 import DownloadIpxeScript from '../../../common/components/clusterConfiguration/DownloadIpxeScript';
-import './DiscoveryImageModal.css';
 import { Cluster } from '@openshift-assisted/types/assisted-installer-service';
 import { ClustersService } from '../../services';
 import { useDispatch } from 'react-redux';
@@ -115,7 +121,11 @@ export const DiscoveryImageModal = () => {
         data-testid="discovery-modal-title"
         title={`Add ${pluralize(+isSNOCluster, 'host')}`}
       />
-      {(isoDownloadError || ipxeDownloadError) && <ErrorState />}
+      {(isoDownloadError || ipxeDownloadError) && (
+        <ModalBody>
+          <ErrorState />
+        </ModalBody>
+      )}
       {isoDownloadUrl ? (
         <DownloadIso
           fileName={`discovery_image_${cluster.name || ''}.iso`}

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmDiscoveryImageConfigForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmDiscoveryImageConfigForm.tsx
@@ -145,7 +145,7 @@ export const OcmDiscoveryImageConfigForm = ({
       {({ submitForm, isSubmitting, status, setStatus }) => {
         return (
           <>
-            <ModalBody>
+            <ModalBody style={{ maxHeight: '611px' }}>
               <Stack hasGutter>
                 <StackItem>
                   <Alert variant={AlertVariant.info} isInline title={alertDiscoveryText} />


### PR DESCRIPTION
## Summary

Cherry-pick of #3792 to `release-4.22`.

**Jira:** [MGMT-22058](https://redhat.atlassian.net/browse/MGMT-22058)
**Original PR:** https://github.com/openshift-assisted/assisted-installer-ui/pull/3792

## Changes

Add hosts modal huge space between inline alert and buttons

---
**Backport Jira:** [MGMT-24761](https://redhat.atlassian.net/browse/MGMT-24761)
**Original Jira:** [MGMT-22058](https://redhat.atlassian.net/browse/MGMT-22058)