### PR TITLE
MGMT-24781: Installation bar filters dependency_only operators in installation and doesnt show them as installed in UI

### DIFF
--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmClusterProgressItems.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmClusterProgressItems.tsx
@@ -4,7 +4,7 @@ import {
   EventListFetchProps,
   getEnabledHosts,
   RenderIf,
-  selectOlmOperators,
+  selectAllOlmOperators,
 } from '../../../common';
 import { FinalizingProgress } from '../../../common/components/clusterDetail/FinalizingProgress';
 import { ProgressBarTexts } from '../../../common/components/clusterDetail/ProgressBarTexts';
@@ -26,7 +26,7 @@ const OcmClusterProgressItems = ({
   fallbackEventsURL,
 }: OcmClusterProgressItemsProps) => {
   const enabledHosts = getEnabledHosts(cluster.hosts);
-  const olmOperators = selectOlmOperators(cluster);
+  const olmOperators = selectAllOlmOperators(cluster);
 
   const masterHosts = enabledHosts.filter((host) => host.role && 'master' === host.role);
   const workerHosts = enabledHosts.filter((host) => host.role && 'worker' === host.role);


### PR DESCRIPTION
https://redhat.atlassian.net/browse/MGMT-24781

(Selected OpenShift AI bundle)

**Before:**

<img width="686" height="558" alt="image" src="https://github.com/user-attachments/assets/001c58c4-1ac5-4562-8e03-e48600393087" />


**After:**

<img width="686" height="558" alt="image" src="https://github.com/user-attachments/assets/25105224-1f6f-46ba-803c-385dba7b8c30" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the cluster progress display so operator status is now calculated more completely and shown more accurately.
  * The operator progress section will appear or stay hidden based on the full set of detected operators, reducing missing or inconsistent status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->