### PR TITLE
no-jira: Bump axios to latest (1.18.1)

### DIFF
--- a/apps/assisted-chatbot/package.json
+++ b/apps/assisted-chatbot/package.json
@@ -30,7 +30,7 @@
     "@redhat-cloud-services/ai-client-common": "^0.13.0",
     "@redhat-cloud-services/ai-client-state": "^0.15.0",
     "@redhat-cloud-services/frontend-components": "^7.0.0",
-    "axios": "^1.17.0",
+    "axios": "^1.18.1",
     "i18next": "^20.4 || ^21",
     "parse-url": "^9.2.0",
     "react": "^18.2.0",

--- a/apps/assisted-disconnected-ui/package.json
+++ b/apps/assisted-disconnected-ui/package.json
@@ -11,7 +11,7 @@
     "@patternfly/react-tokens": "6.4.0",
     "@reduxjs/toolkit": "^1.9.1",
     "@sentry/browser": "^7.119",
-    "axios": "^1.17.0",
+    "axios": "^1.18.1",
     "i18next": "^20.4 || ^21",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.18.1",

--- a/apps/assisted-ui/package.json
+++ b/apps/assisted-ui/package.json
@@ -11,7 +11,7 @@
     "@patternfly/react-tokens": "6.4.0",
     "@reduxjs/toolkit": "^1.9.1",
     "@sentry/browser": "^7.119",
-    "axios": "^1.17.0",
+    "axios": "^1.18.1",
     "i18next": "^20.4 || ^21",
     "i18next-browser-languagedetector": "^6.1.2",
     "lodash": "^4.18.1",

--- a/libs/sdks/package.json
+++ b/libs/sdks/package.json
@@ -17,7 +17,7 @@
     }
   },
   "dependencies": {
-    "axios": "^1.17.0"
+    "axios": "^1.18.1"
   },
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "^2.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1651,7 +1651,7 @@ __metadata:
     "@types/react": 18.2.37
     "@types/react-dom": ^18.2.0
     "@vitejs/plugin-react-swc": ^4.3.0
-    axios: ^1.17.0
+    axios: ^1.18.1
     concurrently: ^9.0.0
     i18next: ^20.4 || ^21
     i18next-browser-languagedetector: ^6.1.2
@@ -1693,7 +1693,7 @@ __metadata:
     "@types/history": ^4
     "@types/react": 18.2.37
     "@types/react-dom": ^18.2.0
-    axios: ^1.17.0
+    axios: ^1.18.1
     history: ^4.10.1
     i18next: ^20.4 || ^21
     parse-url: ^9.2.0
@@ -1726,7 +1726,7 @@ __metadata:
     "@types/react": 18.2.37
     "@types/react-dom": ^18.2.0
     "@vitejs/plugin-react-swc": ^4.3.0
-    axios: ^1.17.0
+    axios: ^1.18.1
     i18next: ^20.4 || ^21
     i18next-browser-languagedetector: ^6.1.2
     lodash: ^4.18.1
@@ -1798,7 +1798,7 @@ __metadata:
   resolution: "@openshift-assisted/sdks@workspace:libs/sdks"
   dependencies:
     "@openapitools/openapi-generator-cli": ^2.7.0
-    axios: ^1.17.0
+    axios: ^1.18.1
     typescript: ^5.9.3
   languageName: unknown
   linkType: soft
@@ -5608,7 +5608,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.12.2, axios@npm:^1.13.5, axios@npm:^1.14.0, axios@npm:^1.17.0, axios@npm:^1.6.1":
+"axios@npm:^1.12.2, axios@npm:^1.13.5, axios@npm:^1.14.0, axios@npm:^1.6.1":
   version: 1.17.0
   resolution: "axios@npm:1.17.0"
   dependencies:
@@ -5617,6 +5617,18 @@ __metadata:
     https-proxy-agent: ^5.0.1
     proxy-from-env: ^2.1.0
   checksum: 4bf030d85fde8720ebd112115223f162844505e4e44687749ba36e7b37241ef2e875fb8a5406be82097f4bc907362dc74f3ae94ea2c9cffca4fd2b2c37cafc5c
+  languageName: node
+  linkType: hard
+
+"axios@npm:^1.18.1":
+  version: 1.18.1
+  resolution: "axios@npm:1.18.1"
+  dependencies:
+    follow-redirects: ^1.16.0
+    form-data: ^4.0.5
+    https-proxy-agent: ^5.0.1
+    proxy-from-env: ^2.1.0
+  checksum: e7a0c1f73f3d17ef5c5b09259b6aae0c1d841fe3b4ef76964ac5aca97b1cf30724cdedb9a514ccc435682dc690f4486580c5babfe897fbcbd500627bd2e86f6d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a core HTTP library dependency to a newer version across the assisted chat, disconnected UI, assisted UI, and SDK packages.
  * This keeps these apps and libraries aligned on the same dependency version for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->