### PR TITLE
NO-ISSUE: Upgrade path-to-regexp to ^8.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "brace-expansion": "^5.0.7",
     "terser-webpack-plugin": "^5.6.1",
     "sanitize-html": "^2.17.4",
+    "path-to-regexp": "^8.4.2",
     "ws": "^8.21.0",
     "qs": "^6.15.3",
     "shell-quote": "^1.8.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12682,24 +12682,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:8.4.2":
+"path-to-regexp@npm:^8.4.2":
   version: 8.4.2
   resolution: "path-to-regexp@npm:8.4.2"
   checksum: c30fba443e413cc736b7b28056a4b60b537ae1caa80152da21e8093bd41deba7c408a4ac6f11a1bf594e089d8fd8d87ed31476c55c50983719fb355826370ade
-  languageName: node
-  linkType: hard
-
-"path-to-regexp@npm:^6.3.0":
-  version: 6.3.0
-  resolution: "path-to-regexp@npm:6.3.0"
-  checksum: eca78602e6434a1b6799d511d375ec044e8d7e28f5a48aa5c28d57d8152fb52f3fc62fb1cfc5dfa2198e1f041c2a82ed14043d75740a2fe60e91b5089a153250
-  languageName: node
-  linkType: hard
-
-"path-to-regexp@npm:~0.1.12":
-  version: 0.1.12
-  resolution: "path-to-regexp@npm:0.1.12"
-  checksum: ab237858bee7b25ecd885189f175ab5b5161e7b712b360d44f5c4516b8d271da3e4bf7bf0a7b9153ecb04c7d90ce8ff5158614e1208819cf62bac2b08452722e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Resolves:

https://redhat.atlassian.net/browse/MGMT-23675
https://redhat.atlassian.net/browse/MGMT-23676

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolution to pin `path-to-regexp` to `^8.4.2`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->