### PR TITLE
[release-4.20] OCPBUGS-98429: Bump  js-yaml from 4.1.0 to 4.3.0

### DIFF
--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.1",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^4.3.0",
     "sw2dts": "^2.6.3"
   },
   "version": "1.0.0"

--- a/libs/ui-lib/package.json
+++ b/libs/ui-lib/package.json
@@ -23,7 +23,7 @@
     "ip-address": "^7.1.0",
     "is-cidr": "^4.0.2",
     "is-in-subnet": "^4",
-    "js-yaml": "^4.1.0",
+    "js-yaml": "^4.3.0",
     "lodash-es": "^4.17.23",
     "parse-url": "^9.2.0",
     "prism-react-renderer": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,7 +981,7 @@ __metadata:
   resolution: "@openshift-assisted/types@workspace:libs/types"
   dependencies:
     "@types/js-yaml": ^4.0.1
-    js-yaml: ^4.1.0
+    js-yaml: ^4.3.0
     sw2dts: ^2.6.3
   languageName: unknown
   linkType: soft
@@ -1043,7 +1043,7 @@ __metadata:
     ip-address: ^7.1.0
     is-cidr: ^4.0.2
     is-in-subnet: ^4
-    js-yaml: ^4.1.0
+    js-yaml: ^4.3.0
     lodash-es: ^4.17.23
     parse-url: ^9.2.0
     prism-react-renderer: ^1.1.1
@@ -7198,6 +7198,17 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: bef146085f472d44dee30ec34e5cf36bf89164f5d585435a3d3da89e52622dff0b188a580e4ad091c3341889e14cb88cac6e4deb16dc5b1e9623bb0601fc255c
+  languageName: node
+  linkType: hard
+
+"js-yaml@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "js-yaml@npm:4.3.0"
+  dependencies:
+    argparse: ^2.0.1
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: 1268fb22ae8504646cedc0823c18816d4af056029578e855b9a4d3e19bcafc3e9ba9e391f70dea4a29b023bb09f23639766071199cb89e853266b90a6ec25f9a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Changes

- Updated js-yaml in libs/ui-lib/package.json: ^4.1.0 → ^4.3.0 (direct runtime dependency, bundled into assisted-disconnected-ui).
- Updated js-yaml in libs/types/package.json: ^4.1.0 → ^4.3.0 (devDependency, build-time codegen only).
- Regenerated yarn.lock (yarn install --mode=update-lockfile) — resolves js-yaml@4.3.0 with the correct checksum, no other dependency changes.