### PR TITLE
[release-4.22] OCPBUGS-98431: Bump js-yaml from 4.1.1 to 4.3.0

### DIFF
--- a/libs/types/package.json
+++ b/libs/types/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.1",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.3.0",
     "sw2dts": "^2.6.3"
   },
   "version": "1.0.0"

--- a/libs/ui-lib/package.json
+++ b/libs/ui-lib/package.json
@@ -24,7 +24,7 @@
     "ip-address": "^7.1.0",
     "is-cidr": "^4.0.2",
     "is-in-subnet": "^4",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.3.0",
     "lodash-es": "^4.17.23",
     "parse-url": "^9.2.0",
     "prism-react-renderer": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1648,7 +1648,7 @@ __metadata:
   resolution: "@openshift-assisted/types@workspace:libs/types"
   dependencies:
     "@types/js-yaml": ^4.0.1
-    js-yaml: ^4.1.1
+    js-yaml: ^4.3.0
     sw2dts: ^2.6.3
   languageName: unknown
   linkType: soft
@@ -1708,7 +1708,7 @@ __metadata:
     ip-address: ^7.1.0
     is-cidr: ^4.0.2
     is-in-subnet: ^4
-    js-yaml: ^4.1.1
+    js-yaml: ^4.3.0
     lodash-es: ^4.17.23
     parse-url: ^9.2.0
     prism-react-renderer: ^1.1.1
@@ -11739,7 +11739,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.1.0, js-yaml@npm:^4.1.1":
+"js-yaml@npm:^4.1.0":
   version: 4.1.1
   resolution: "js-yaml@npm:4.1.1"
   dependencies:
@@ -11747,6 +11747,17 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: ea2339c6930fe048ec31b007b3c90be2714ab3e7defcc2c27ebf30c74fd940358f29070b4345af0019ef151875bf3bc3f8644bea1bab0372652b5044813ac02d
+  languageName: node
+  linkType: hard
+
+"js-yaml@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "js-yaml@npm:4.3.0"
+  dependencies:
+    argparse: ^2.0.1
+  bin:
+    js-yaml: bin/js-yaml.js
+  checksum: 1268fb22ae8504646cedc0823c18816d4af056029578e855b9a4d3e19bcafc3e9ba9e391f70dea4a29b023bb09f23639766071199cb89e853266b90a6ec25f9a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update js-yaml from 4.1.1 to 4.3.0 in libs/ui-lib (runtime dependency, bundled into the shipped assisted-disconnected-ui app) and libs/types (devDependency, build-time codegen only) to address CVE-2026-59869.

js-yaml < 4.3.0 can spend quadratic CPU time parsing a YAML document containing a chain of mappings that each merge (<<) the previous one. 4.3.0 adds a maxTotalMergeKeys limit to cap merge-key processing. 

Related: OCPBUGS-98431"