### PR TITLE
NO-ISSUE: Upgrade node version in Containerfile

### DIFF
--- a/apps/assisted-disconnected-ui/Containerfile
+++ b/apps/assisted-disconnected-ui/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/nodejs-18-minimal:latest as ui-build
+FROM registry.access.redhat.com/ubi9/nodejs-22-minimal:latest as ui-build
 USER root
 RUN microdnf install -y rsync git
 

--- a/apps/assisted-ui/Containerfile
+++ b/apps/assisted-ui/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/nodejs-18-minimal AS repo-builder
+FROM registry.access.redhat.com/ubi8/nodejs-22-minimal AS repo-builder
 USER root
 RUN INSTALL_PKGS="git rsync" && \
     microdnf --nodocs --setopt=install_weak_deps=0 install $INSTALL_PKGS && \


### PR DESCRIPTION
The version of `vite` we're using requires a higher version of Node.  
Node 22 appears to be sufficient.

You can test it with 

```
docker build -t assisted-ui:local -f apps/assisted-ui/Containerfile .
```
and
```
docker build -t assisted-ui:local -f apps/assisted-disconnected-ui/Containerfile .
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the frontend build environment to Node.js 22 for improved compatibility and support.
  * Applied the build environment update across both assisted UI variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->