### PR TITLE
[release-5.0] OCPBUGS-99039: Bump dompurify from 3.2.7 to 3.4.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "path-to-regexp": "^8.4.2",
     "ws": "^8.21.0",
     "qs": "^6.15.3",
-    "shell-quote": "^1.8.4"
+    "shell-quote": "^1.8.4",
+    "dompurify": "^3.4.7"
   },
   "workspaces": [
     "apps/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6763,15 +6763,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:3.2.7":
-  version: 3.2.7
-  resolution: "dompurify@npm:3.2.7"
+"dompurify@npm:^3.4.7":
+  version: 3.4.12
+  resolution: "dompurify@npm:3.4.12"
   dependencies:
     "@types/trusted-types": ^2.0.7
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 15958b76e0266f463303b81bc190ab78808c20640e5211dcf7e5071e4fe4396b904c04a8cb68e149e02ab44360defa13a00147e3f23721d41a81ca4bf6d7c983
+  checksum: 477e944e669bac9247c9ebfa55c7ea5c73f3cc6cd6b21ee72e306000e3e53d308e7bdaac89e655a0e2661de2ffbdd877e6a92537d07ba1d70c6c441fcef8c65c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes
- `package.json`: added `"dompurify": "^3.4.7"` to the `resolutions` block (resolves to `3.4.12`, the latest patch on the same major/minor-safe line).
- `yarn.lock`: regenerated via `node .yarn/releases/yarn-3.8.7.cjs install --mode=update-lockfile`. Only the `dompurify` locator changed; verified no other package's resolution shifted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a security-related dependency resolution to ensure the application uses the specified DOM sanitization library version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->