### PR TITLE
OCPBUGS-99025: Bump dompurify to 3.4.7+ in 4.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "ip-address": "^10.1.1",
     "tar": "^7.5.19",
     "basic-ftp": "^5.3.1",
-    "ws": "^8.21.0"
+    "ws": "^8.21.0",
+    "dompurify": "^3.4.7"
   },
   "workspaces": [
     "apps/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7809,15 +7809,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:3.2.7":
-  version: 3.2.7
-  resolution: "dompurify@npm:3.2.7"
+"dompurify@npm:^3.4.7":
+  version: 3.4.12
+  resolution: "dompurify@npm:3.4.12"
   dependencies:
     "@types/trusted-types": ^2.0.7
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 15958b76e0266f463303b81bc190ab78808c20640e5211dcf7e5071e4fe4396b904c04a8cb68e149e02ab44360defa13a00147e3f23721d41a81ca4bf6d7c983
+  checksum: 477e944e669bac9247c9ebfa55c7ea5c73f3cc6cd6b21ee72e306000e3e53d308e7bdaac89e655a0e2661de2ffbdd877e6a92537d07ba1d70c6c441fcef8c65c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes
- `package.json`: added `"dompurify": "^3.4.7"` to the `resolutions` block (resolves to `3.4.12`, the latest patch on the same major/minor-safe line).
- `yarn.lock`: regenerated via `node .yarn/releases/yarn-3.4.1.cjs install --mode=update-lockfile`. Only the `dompurify` locator changed; verified no other package's resolution shifted.