### PR TITLE
OCPBUGS-91623: Bump ws to 8.21.0 for CVE-2026-45736

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "shell-quote": "^1.8.4",
     "ip-address": "^10.1.1",
     "@cypress/request/form-data": "2.5.6",
-    "tar": "^7.5.19"
+    "tar": "^7.5.19",
+    "ws": "^8.21.0"
   },
   "scripts": {
     "_build:lib": "yarn workspace @openshift-assisted/ui-lib build && yarn workspace @openshift-assisted/chatbot build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12190,9 +12190,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.18.3":
-  version: 8.20.0
-  resolution: "ws@npm:8.20.0"
+"ws@npm:^8.21.0":
+  version: 8.21.1
+  resolution: "ws@npm:8.21.1"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -12201,7 +12201,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 2b31d24a53690770564a033c21ea48390f84d23fbc5abc14b2bbec4e112846f2f3ca66caee769a73fb8bc89ba16b452a6911a553e9742bbc75bccb79e203953e
+  checksum: 2e18c932d7bfeeb36fae32d874e5531f501e26dc932c48b699f9fcd2d7cc38f365e0265eddb47dec413ac6fb0effc0a8fa2cfa372d23f4f5b5ab214f394e1774
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

This PR fixes **CVE-2026-45736** by updating the ws (WebSocket) package from 8.20.0 to 8.21.1 via yarn resolutions.


**Dependency Chain:**
```
package.json (devDependencies)
  └─ happy-dom@20.8.9 (test DOM implementation)
      └─ ws@^8.18.3 (resolved to 8.20.0 → 8.21.1)
```

## Changes

### package.json
- Added `"ws": "^8.21.0"` to `resolutions` section

### yarn.lock
- ws version updated: `8.20.0` → `8.21.1`

