### PR TITLE
AGENT-1575: Add Pullsecret and SSH Key to Disconnected Wizard

### DIFF
--- a/libs/types/assisted-installer-service.d.ts
+++ b/libs/types/assisted-installer-service.d.ts
@@ -1843,7 +1843,7 @@ export interface ImageInfo {
   staticNetworkConfig?: string;
   type?: ImageType;
 }
-export type ImageType = 'full-iso' | 'minimal-iso';
+export type ImageType = 'full-iso' | 'minimal-iso' | 'disconnected-iso';
 export interface ImportClusterParams {
   /**
    * OpenShift cluster name.

--- a/libs/ui-lib/lib/common/api/assisted-service/ClustersAPI.ts
+++ b/libs/ui-lib/lib/common/api/assisted-service/ClustersAPI.ts
@@ -3,6 +3,7 @@ import {
   Cluster,
   ClusterCreateParams,
   ClusterDefaultConfig,
+  DisconnectedClusterCreateParams,
   V2ClusterUpdateParams,
   Credentials,
   Host,
@@ -138,6 +139,13 @@ const ClustersAPI = {
   register(params: ClusterCreateParams) {
     return client.post<Cluster, AxiosResponse<Cluster>, ClusterCreateParams>(
       `${ClustersAPI.makeBaseURI()}`,
+      params,
+    );
+  },
+
+  registerDisconnected(params: DisconnectedClusterCreateParams) {
+    return client.post<Cluster, AxiosResponse<Cluster>, DisconnectedClusterCreateParams>(
+      `${ClustersAPI.makeBaseURI()}disconnected`,
       params,
     );
   },

--- a/libs/ui-lib/lib/common/components/ui/formik/PullSecretField.tsx
+++ b/libs/ui-lib/lib/common/components/ui/formik/PullSecretField.tsx
@@ -65,7 +65,10 @@ const GetPullSecretHelperText: React.FC<{ isOcm: boolean }> = ({ isOcm }) => {
   );
 };
 
-const PullSecretField: React.FC<{ isOcm: boolean }> = ({ isOcm }) => {
+const PullSecretField: React.FC<{ isOcm: boolean; isRequired?: boolean }> = ({
+  isOcm,
+  isRequired = true,
+}) => {
   const { t } = useTranslation();
   return (
     <TextAreaField
@@ -75,7 +78,7 @@ const PullSecretField: React.FC<{ isOcm: boolean }> = ({ isOcm }) => {
       getErrorText={(error) => error}
       helperText={<GetPullSecretHelperText isOcm={isOcm} />}
       rows={10}
-      isRequired
+      isRequired={isRequired}
     />
   );
 };

--- a/libs/ui-lib/lib/common/types/clusters.ts
+++ b/libs/ui-lib/lib/common/types/clusters.ts
@@ -73,4 +73,4 @@ export const SupportedPlatformIntegrations: SupportedPlatformType[] = [
 ];
 export const NonPlatformIntegrations: PlatformType[] = ['baremetal', 'none'];
 
-export type DiscoveryImageType = ImageType | 'discovery-image-ipxe';
+export type DiscoveryImageType = Exclude<ImageType, 'disconnected-iso'> | 'discovery-image-ipxe';

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmDiscoveryImageConfigForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/OcmDiscoveryImageConfigForm.tsx
@@ -106,7 +106,7 @@ export const OcmDiscoveryImageConfigForm = ({
     httpsProxy: httpsProxy || '',
     noProxy: noProxy || '',
     enableProxy: !!(httpProxy || httpsProxy || noProxy),
-    imageType: imageTypeValue as ImageType,
+    imageType: imageTypeValue as DiscoveryImageType,
     enableCertificate: enableCertificate || false,
     trustBundle: trustBundle || '',
   };
@@ -155,7 +155,7 @@ export const OcmDiscoveryImageConfigForm = ({
                   <Form>
                     <DiscoveryImageTypeDropdown
                       name="imageType"
-                      defaultValue={discoveryImageTypes[imageTypeValue]}
+                      defaultValue={discoveryImageTypes[imageTypeValue as DiscoveryImageType]}
                       onChange={updateDiscoveryButtonAndAlertText}
                       selectedCpuArchitecture={selectedCpuArchitecture}
                       isDisabled={isOracleCloudInfrastructure}

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContext.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContext.tsx
@@ -3,6 +3,7 @@ import { HostsNetworkConfigurationType } from '../../services';
 import { StaticIpView } from '../clusterConfiguration/staticIp/data/dataTypes';
 import { ClusterWizardStepsType } from './wizardTransition';
 import { UISettingsValues } from '../../../common';
+import { Cluster, InfraEnv } from '@openshift-assisted/types/assisted-installer-service';
 
 export type ClusterWizardContextType = {
   currentStepId: ClusterWizardStepsType;
@@ -18,6 +19,10 @@ export type ClusterWizardContextType = {
   uiSettings?: UISettingsValues;
   installDisconnected: boolean;
   setInstallDisconnected: (enabled: boolean) => void;
+  disconnectedCluster?: Cluster;
+  setDisconnectedCluster: (cluster: Cluster | undefined) => void;
+  disconnectedInfraEnv?: InfraEnv;
+  setDisconnectedInfraEnv: (infraEnv: InfraEnv | undefined) => void;
 };
 
 export const ClusterWizardContext = React.createContext<ClusterWizardContextType | null>(null);

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/ClusterWizardContextProvider.tsx
@@ -88,6 +88,8 @@ const ClusterWizardContextProvider = ({
   const [connectedWizardStepIds, setWizardStepIds] = React.useState<ClusterWizardStepsType[]>();
   const [wizardPerPage, setWizardPerPage] = React.useState(10);
   const [installDisconnected, setInstallDisconnected] = React.useState(false);
+  const [disconnectedCluster, setDisconnectedCluster] = React.useState<Cluster | undefined>();
+  const [disconnectedInfraEnv, setDisconnectedInfraEnv] = React.useState<InfraEnv | undefined>();
   const location = useLocation();
   const locationState = location.state as ClusterWizardFlowStateType | undefined;
   const {
@@ -228,6 +230,10 @@ const ClusterWizardContextProvider = ({
           connectedWizardStepIds?.length && onSetCurrentStepId(connectedWizardStepIds[0]);
         }
       },
+      disconnectedCluster,
+      setDisconnectedCluster,
+      disconnectedInfraEnv,
+      setDisconnectedInfraEnv,
     };
   }, [
     wizardStepIds,
@@ -240,6 +246,9 @@ const ClusterWizardContextProvider = ({
     updateUISettings,
     installDisconnected,
     connectedWizardStepIds,
+    disconnectedCluster,
+    disconnectedInfraEnv,
+    setDisconnectedInfraEnv,
   ]);
 
   if (!contextValue) {

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/NewClusterWizard.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/NewClusterWizard.tsx
@@ -4,6 +4,7 @@ import ClusterDetails from './ClusterDetails';
 import { useClusterWizardContext } from './ClusterWizardContext';
 import ReviewStep from './disconnected/ReviewStep';
 import BasicStep from './disconnected/BasicStep';
+import OptionalConfigurationsStep from './disconnected/OptionalConfigurationsStep';
 import { ClusterWizardStepsType } from './wizardTransition';
 import { useInfraEnv } from '../../hooks';
 import { CpuArchitecture } from '../../../common/types';
@@ -13,6 +14,8 @@ const getCurrentStep = (currentStepId: ClusterWizardStepsType, infraEnv?: InfraE
   switch (currentStepId) {
     case 'disconnected-review':
       return <ReviewStep />;
+    case 'disconnected-optional-configurations':
+      return <OptionalConfigurationsStep />;
     case 'disconnected-basic':
       return <BasicStep />;
     default:

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/constants.ts
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/constants.ts
@@ -14,6 +14,7 @@ export const wizardStepNames: { [key in ClusterWizardStepsType]: string } = {
   'credentials-download': 'Download credentials',
   'disconnected-review': 'Review and download ISO',
   'disconnected-basic': 'Basic information',
+  'disconnected-optional-configurations': 'Optional configurations',
 };
 
 export const defaultWizardSteps: ClusterWizardStepsType[] = [

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/disconnected/BasicStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/disconnected/BasicStep.tsx
@@ -1,68 +1,47 @@
 import * as React from 'react';
-import {
-  ClusterWizardStep,
-  TechnologyPreview,
-  ExternalLink,
-  OCP_RELEASES_PAGE,
-  StaticTextField,
-  useTranslation,
-} from '../../../../common';
+import { ClusterWizardStep, TechnologyPreview, StaticTextField } from '../../../../common';
 import { Flex, Grid, GridItem, Form, Content } from '@patternfly/react-core';
-import OcmOpenShiftVersion from '../../clusterConfiguration/OcmOpenShiftVersion';
 import { useClusterWizardContext } from '../ClusterWizardContext';
 import ClusterWizardFooter from '../ClusterWizardFooter';
 import ClusterWizardNavigation from '../ClusterWizardNavigation';
 import { WithErrorBoundary } from '../../../../common/components/ErrorHandling/WithErrorBoundary';
 import InstallDisconnectedSwitch from './InstallDisconnectedSwitch';
-import { Formik } from 'formik';
+
+export const DISCONNECTED_OPENSHIFT_VERSION = '4.21';
 
 const BasicStep = () => {
-  const { t } = useTranslation();
   const { moveNext } = useClusterWizardContext();
 
   return (
-    <Formik
-      initialValues={{}}
-      onSubmit={() => {
-        // nothing to do
-      }}
+    <ClusterWizardStep
+      navigation={<ClusterWizardNavigation />}
+      footer={<ClusterWizardFooter onNext={moveNext} />}
     >
-      <ClusterWizardStep
-        navigation={<ClusterWizardNavigation />}
-        footer={<ClusterWizardFooter onNext={moveNext} />}
-      >
-        <WithErrorBoundary title="Failed to load Basic step">
-          <Grid hasGutter>
-            <GridItem>
-              <Content component="h2">Basic information</Content>
-            </GridItem>
-            <GridItem>
-              <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
-                <TechnologyPreview />
-                <InstallDisconnectedSwitch />
-                <span>
-                  {t("ai:I'm installing on a disconnected/air-gapped/secured environment")}
-                </span>
-              </Flex>
-            </GridItem>
-            <GridItem>
-              <Form id="wizard-cluster-basic-info__form">
-                <OcmOpenShiftVersion openshiftVersion="4.20" withPreviewText withMultiText>
-                  <ExternalLink href={`${window.location.origin}/${OCP_RELEASES_PAGE}`}>
-                    <span data-ouia-id="openshift-releases-link">
-                      {t('ai:Learn more about OpenShift releases')}
-                    </span>
-                  </ExternalLink>
-                </OcmOpenShiftVersion>
-                <StaticTextField name="cpuArchitecture" label="CPU architecture" isRequired>
-                  x86_64
-                </StaticTextField>
-              </Form>
-            </GridItem>
-          </Grid>
-        </WithErrorBoundary>
-      </ClusterWizardStep>
-    </Formik>
+      <WithErrorBoundary title="Failed to load Basic step">
+        <Grid hasGutter>
+          <GridItem>
+            <Content component="h2">Basic information</Content>
+          </GridItem>
+          <GridItem>
+            <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
+              <TechnologyPreview />
+              <InstallDisconnectedSwitch />
+              <span>I'm installing on a disconnected/air-gapped/secured environment</span>
+            </Flex>
+          </GridItem>
+          <GridItem>
+            <Form id="wizard-cluster-basic-info__form">
+              <StaticTextField name="openshiftVersion" label="OpenShift version">
+                {DISCONNECTED_OPENSHIFT_VERSION}
+              </StaticTextField>
+              <StaticTextField name="cpuArchitecture" label="CPU architecture">
+                x86_64
+              </StaticTextField>
+            </Form>
+          </GridItem>
+        </Grid>
+      </WithErrorBoundary>
+    </ClusterWizardStep>
   );
 };
 

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/disconnected/OptionalConfigurationsStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/disconnected/OptionalConfigurationsStep.tsx
@@ -1,0 +1,173 @@
+import * as React from 'react';
+import { Formik, useFormikContext } from 'formik';
+import * as Yup from 'yup';
+import { AlertVariant } from '@patternfly/react-core';
+import { Form, Grid, GridItem, Content } from '@patternfly/react-core';
+import {
+  ClusterWizardStep,
+  PullSecret,
+  UploadSSH,
+  handleApiError,
+  getApiErrorMessage,
+  isInOcm,
+  pullSecretValidationSchema,
+  sshPublicKeyValidationSchema,
+  useAlerts,
+  useTranslation,
+} from '../../../../common';
+import { WithErrorBoundary } from '../../../../common/components/ErrorHandling/WithErrorBoundary';
+import { useClusterWizardContext } from '../ClusterWizardContext';
+import ClusterWizardFooter from '../ClusterWizardFooter';
+import ClusterWizardNavigation from '../ClusterWizardNavigation';
+import { InfraEnvsAPI, ClustersAPI } from '../../../services/apis';
+import { ImageType } from '@openshift-assisted/types/assisted-installer-service';
+import usePullSecret from '../../../hooks/usePullSecret';
+import { DISCONNECTED_OPENSHIFT_VERSION } from './BasicStep';
+
+const DISCONNECTED_IMAGE_TYPE: ImageType = 'disconnected-iso';
+const DISCONNECTED_CLUSTER_NAME = 'disconnected-cluster';
+
+type OptionalConfigurationsValues = {
+  sshPublicKey: string;
+  pullSecret: string;
+};
+
+type OptionalConfigurationsFormProps = {
+  defaultPullSecret?: string;
+  isSubmitting: boolean;
+};
+
+const OptionalConfigurationsForm: React.FC<OptionalConfigurationsFormProps> = ({
+  defaultPullSecret,
+  isSubmitting,
+}) => {
+  const { moveBack } = useClusterWizardContext();
+  const { isValid, submitForm } = useFormikContext<OptionalConfigurationsValues>();
+
+  return (
+    <ClusterWizardStep
+      navigation={<ClusterWizardNavigation />}
+      footer={
+        <ClusterWizardFooter
+          onNext={() => void submitForm()}
+          onBack={moveBack}
+          isSubmitting={isSubmitting}
+          isNextDisabled={!isValid}
+        />
+      }
+    >
+      <WithErrorBoundary title="Failed to load Optional configurations step">
+        <Grid hasGutter>
+          <GridItem>
+            <Content component="h2">Optional configurations</Content>
+          </GridItem>
+          <GridItem>
+            <Form id="wizard-cluster-optional-config__form">
+              <UploadSSH />
+              {!isInOcm && <PullSecret isOcm={false} defaultPullSecret={defaultPullSecret} />}
+            </Form>
+          </GridItem>
+        </Grid>
+      </WithErrorBoundary>
+    </ClusterWizardStep>
+  );
+};
+
+const OptionalConfigurationsStep = () => {
+  const { t } = useTranslation();
+  const {
+    moveNext,
+    disconnectedCluster,
+    setDisconnectedCluster,
+    disconnectedInfraEnv,
+    setDisconnectedInfraEnv,
+  } = useClusterWizardContext();
+  const { addAlert, clearAlerts } = useAlerts();
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const defaultPullSecret = usePullSecret();
+
+  const validationSchema = React.useMemo(
+    () =>
+      Yup.object({
+        sshPublicKey: sshPublicKeyValidationSchema(t),
+        pullSecret: isInOcm ? Yup.string() : pullSecretValidationSchema(t),
+      }),
+    [t],
+  );
+
+  const initialValues: OptionalConfigurationsValues = {
+    sshPublicKey: disconnectedInfraEnv?.sshAuthorizedKey ?? '',
+    pullSecret: defaultPullSecret ?? '',
+  };
+
+  const handleNext = React.useCallback(
+    async (values: OptionalConfigurationsValues) => {
+      clearAlerts();
+      setIsSubmitting(true);
+      try {
+        const pullSecretToUse = isInOcm ? defaultPullSecret ?? '' : values.pullSecret;
+
+        if (disconnectedCluster?.id && disconnectedInfraEnv?.id) {
+          const { data: updatedInfraEnv } = await InfraEnvsAPI.update(disconnectedInfraEnv.id, {
+            sshAuthorizedKey: values.sshPublicKey,
+          });
+          setDisconnectedInfraEnv(updatedInfraEnv);
+        } else {
+          const { data: cluster } = await ClustersAPI.registerDisconnected({
+            name: DISCONNECTED_CLUSTER_NAME,
+            openshiftVersion: DISCONNECTED_OPENSHIFT_VERSION,
+          });
+          setDisconnectedCluster(cluster);
+
+          const { data: createdInfraEnv } = await InfraEnvsAPI.register({
+            name: 'disconnected-infra-env',
+            pullSecret: pullSecretToUse,
+            clusterId: cluster.id,
+            imageType: DISCONNECTED_IMAGE_TYPE,
+            openshiftVersion: DISCONNECTED_OPENSHIFT_VERSION,
+            sshAuthorizedKey: values.sshPublicKey || undefined,
+          });
+          setDisconnectedInfraEnv(createdInfraEnv);
+        }
+
+        moveNext();
+      } catch (error) {
+        handleApiError(error, () => {
+          addAlert({
+            title: 'Failed to save optional configurations',
+            message: getApiErrorMessage(error),
+            variant: AlertVariant.danger,
+          });
+        });
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [
+      clearAlerts,
+      defaultPullSecret,
+      disconnectedCluster,
+      disconnectedInfraEnv,
+      setDisconnectedCluster,
+      setDisconnectedInfraEnv,
+      addAlert,
+      moveNext,
+    ],
+  );
+
+  return (
+    <Formik<OptionalConfigurationsValues>
+      initialValues={initialValues}
+      enableReinitialize
+      validationSchema={validationSchema}
+      onSubmit={(values) => void handleNext(values)}
+    >
+      <OptionalConfigurationsForm
+        defaultPullSecret={defaultPullSecret}
+        isSubmitting={isSubmitting}
+      />
+    </Formik>
+  );
+};
+
+export default OptionalConfigurationsStep;

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/disconnected/ReviewStep.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/disconnected/ReviewStep.tsx
@@ -29,12 +29,10 @@ import { saveAs } from 'file-saver';
 import { useNavigate } from 'react-router';
 
 import { getOperatorSpecs } from '../../../../common/components/operators/operatorSpecs';
-
-const downloadUrl =
-  'https://mirror.openshift.com/pub/cgw/assisted-installer-disconnected/latest/agent-ove.x86_64.iso';
+import { DISCONNECTED_OPENSHIFT_VERSION } from './BasicStep';
 
 const ReviewStep = () => {
-  const { moveBack } = useClusterWizardContext();
+  const { moveBack, disconnectedInfraEnv } = useClusterWizardContext();
   const opSpecs = getOperatorSpecs(() => undefined);
   const navigate = useNavigate();
 
@@ -50,7 +48,7 @@ const ReviewStep = () => {
         footer={
           <ClusterWizardFooter
             onNext={() => {
-              downloadUrl && saveAs(downloadUrl);
+              saveAs(disconnectedInfraEnv?.downloadUrl ?? '');
               void navigate('/cluster-list');
             }}
             onBack={moveBack}
@@ -98,11 +96,15 @@ const ReviewStep = () => {
             <DescriptionList isHorizontal>
               <DescriptionListGroup>
                 <DescriptionListTerm>OpenShift version</DescriptionListTerm>
-                <DescriptionListDescription>4.20</DescriptionListDescription>
+                <DescriptionListDescription>
+                  {disconnectedInfraEnv?.openshiftVersion ?? DISCONNECTED_OPENSHIFT_VERSION}
+                </DescriptionListDescription>
               </DescriptionListGroup>
               <DescriptionListGroup>
                 <DescriptionListTerm>CPU architecture</DescriptionListTerm>
-                <DescriptionListDescription>x86_64</DescriptionListDescription>
+                <DescriptionListDescription>
+                  {disconnectedInfraEnv?.cpuArchitecture ?? 'x86_64'}
+                </DescriptionListDescription>
               </DescriptionListGroup>
               <DescriptionListGroup>
                 <DescriptionListTerm>ISO size</DescriptionListTerm>

--- a/libs/ui-lib/lib/ocm/components/clusterWizard/wizardTransition.ts
+++ b/libs/ui-lib/lib/ocm/components/clusterWizard/wizardTransition.ts
@@ -34,6 +34,7 @@ export type ClusterWizardStepsType =
   | 'custom-manifests'
   | 'credentials-download'
   | 'disconnected-basic'
+  | 'disconnected-optional-configurations'
   | 'disconnected-review';
 
 const wizardStepsOrder: ClusterWizardStepsType[] = [
@@ -52,6 +53,7 @@ const wizardStepsOrder: ClusterWizardStepsType[] = [
 
 export const disconnectedSteps: ClusterWizardStepsType[] = [
   'disconnected-basic',
+  'disconnected-optional-configurations',
   'disconnected-review',
 ];
 
@@ -323,6 +325,7 @@ const credentialsValidationMap = buildEmptyValidationsMap();
 
 const disconnectedReviewValidationsMap = buildEmptyValidationsMap();
 const disconnectedBasicValidationsMap = buildEmptyValidationsMap();
+const disconnectedOptionalConfigurationsValidationsMap = buildEmptyValidationsMap();
 
 export const wizardStepsValidationsMap: WizardStepsValidationMap<ClusterWizardStepsType> = {
   'cluster-details': clusterDetailsStepValidationsMap,
@@ -338,6 +341,7 @@ export const wizardStepsValidationsMap: WizardStepsValidationMap<ClusterWizardSt
   review: reviewStepValidationsMap,
   'disconnected-review': disconnectedReviewValidationsMap,
   'disconnected-basic': disconnectedBasicValidationsMap,
+  'disconnected-optional-configurations': disconnectedOptionalConfigurationsValidationsMap,
 };
 
 export const allClusterWizardSoftValidationIds =

--- a/libs/ui-lib/lib/ocm/services/ClustersService.ts
+++ b/libs/ui-lib/lib/ocm/services/ClustersService.ts
@@ -5,6 +5,7 @@ import type {
 } from '../components/clusterConfiguration/manifestsConfiguration/data/dataTypes';
 import type {
   Cluster,
+  DisconnectedClusterCreateParams,
   Host,
   InfraEnvCreateParams,
   UpdateManifestParams,
@@ -120,6 +121,10 @@ const ClustersService = {
   async get(clusterId: Cluster['id']) {
     const { data: cluster } = await ClustersAPI.get(clusterId);
     return cluster;
+  },
+
+  registerDisconnected(params: DisconnectedClusterCreateParams) {
+    return ClustersAPI.registerDisconnected(params);
   },
 
   transformFormViewManifest(manifest: CustomManifestValues) {


### PR DESCRIPTION
https://redhat.atlassian.net/browse/AGENT-1575

## Changes

### New wizard step: Optional Configurations

Added a new **"Optional Configurations"** step between "Basic information" and "Review and Download ISO" in the disconnected/air-gapped cluster wizard flow.

- Users can optionally provide an **SSH public key** and/or a **Pull Secret**
- Both fields are optional (no asterisk, no required validation)
- If neither field is filled, the wizard skips all backend calls and falls back to the static `FALLBACK_DOWNLOAD_URL` in the Review step
- If either field is provided, a Cluster and InfraEnv are created/updated via the backend API, and the Review step uses the returned dynamic download URL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Optional configurations step to the disconnected cluster setup wizard.
  * Added support for entering an SSH public key and pull secret.
  * Added disconnected ISO image support and disconnected cluster registration.
  * Reviews now display environment-specific download, version, and architecture details.

* **Improvements**
  * Pull secrets can now be marked as optional.
  * Disconnected setup now uses OpenShift 4.21 and no longer requires CPU architecture selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->