### PR TITLE
MGMT-24910: Nmstateconfig Custom Resource seems to be missing a finaliser causing issues during BMH deletion

### DIFF
--- a/libs/ui-lib/lib/cim/components/ClusterDeployment/types.ts
+++ b/libs/ui-lib/lib/cim/components/ClusterDeployment/types.ts
@@ -188,7 +188,6 @@ export type InfraEnvAgentTableProps = Pick<
   agentMachines: AgentMachineK8sResource[];
   bareMetalHosts: BareMetalHostK8sResource[];
   infraEnv: InfraEnvK8sResource;
-  nmStates: NMStateK8sResource[];
   getClusterDeploymentLink: (cd: { name: string; namespace: string }) => string;
   onChangeHostname: (agent: AgentK8sResource, hostname: string) => Promise<AgentK8sResource>;
   onChangeBMHHostname: (

--- a/libs/ui-lib/lib/cim/components/InfraEnv/InfraEnvAgentTable.tsx
+++ b/libs/ui-lib/lib/cim/components/InfraEnv/InfraEnvAgentTable.tsx
@@ -66,7 +66,6 @@ const InfraEnvAgentTable: React.FC<InfraEnvAgentTableProps> = ({
   getClusterDeploymentLink,
   bareMetalHosts,
   infraEnv,
-  nmStates,
   onChangeHostname,
   onChangeBMHHostname,
   onMassDeleteHost,
@@ -287,7 +286,6 @@ const InfraEnvAgentTable: React.FC<InfraEnvAgentTableProps> = ({
           agents={selectedAgents}
           bmhs={selectedBMHs}
           infraEnv={infraEnv}
-          nmStates={nmStates}
           onDelete={onMassDeleteHost}
           onClose={() => setMassDeleteOpen(false)}
         />

--- a/libs/ui-lib/lib/cim/components/modals/MassDeleteAgentModal.tsx
+++ b/libs/ui-lib/lib/cim/components/modals/MassDeleteAgentModal.tsx
@@ -12,12 +12,7 @@ import {
 } from '../../../common';
 import { TableRow } from '../../../common/components/hosts/AITable';
 import HostsTable from '../../../common/components/hosts/HostsTable';
-import {
-  AgentK8sResource,
-  BareMetalHostK8sResource,
-  InfraEnvK8sResource,
-  NMStateK8sResource,
-} from '../../types';
+import { AgentK8sResource, BareMetalHostK8sResource, InfraEnvK8sResource } from '../../types';
 import { useAgentsTable } from '../Agent/tableUtils';
 import { AGENT_BMH_NAME_LABEL_KEY } from '../common/constants';
 import AgentStatus from '../Agent/AgentStatus';
@@ -142,13 +137,8 @@ type MassDeleteAgentModalProps = {
   onClose: VoidFunction;
   agents: AgentK8sResource[];
   bmhs: BareMetalHostK8sResource[];
-  nmStates: NMStateK8sResource[];
   // eslint-disable-next-line
-  onDelete: (
-    agent?: AgentK8sResource,
-    bmh?: BareMetalHostK8sResource,
-    nmStates?: NMStateK8sResource[],
-  ) => Promise<unknown>;
+  onDelete: (agent?: AgentK8sResource, bmh?: BareMetalHostK8sResource) => Promise<unknown>;
   infraEnv: InfraEnvK8sResource;
 };
 
@@ -159,7 +149,6 @@ const MassDeleteAgentModal: React.FC<MassDeleteAgentModalProps> = ({
   agents,
   bmhs,
   infraEnv,
-  nmStates,
 }) => {
   const [hosts] = useAgentsTable({ agents, bmhs, infraEnv });
   const onClick = async (host: Host) => {
@@ -175,7 +164,7 @@ const MassDeleteAgentModal: React.FC<MassDeleteAgentModalProps> = ({
       );
     }
     if (!agent?.spec?.clusterDeploymentName?.name) {
-      return onDelete(agent, bmh, nmStates);
+      return onDelete(agent, bmh);
     }
   };
   const { t } = useTranslation();


### PR DESCRIPTION
https://redhat.atlassian.net/browse/MGMT-24910

Needs https://github.com/stolostron/console/pull/6599

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified mass deletion of infrastructure hosts by removing unnecessary network state handling.
  * Updated the cluster deployment wizard to use agent, host, and infrastructure environment information directly during deletion.
  * Preserved existing deletion behavior while streamlining modal interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->