### PR TITLE
MGMT-24973: Fix missing padding on InfraEnv error alerts in the Add h…

### DIFF
--- a/libs/ui-lib/lib/cim/components/InfraEnv/EnvironmentErrors.tsx
+++ b/libs/ui-lib/lib/cim/components/InfraEnv/EnvironmentErrors.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
+import { Alert, AlertVariant, ModalBody } from '@patternfly/react-core';
 import { getFailingResourceConditions } from '../helpers';
 import { InfraEnvK8sResource } from '../../types';
 import { SingleResourceAlerts } from '../common/ResourceAlerts';
-import { Alert, AlertVariant } from '@patternfly/react-core';
 import { getInfraEnvDocs } from '../common/constants';
 import { useTranslation } from '../../../common/hooks/use-translation-wrapper';
 
@@ -25,8 +25,8 @@ export const EnvironmentErrors: React.FC<EnvironmentErrorsProps> = ({
   }
 
   return (
-    <>
-      {!infraEnv.status && (
+    <ModalBody>
+      {!infraEnv.status ? (
         <Alert
           title={t('ai:Central infrastructure management is not running')}
           variant={AlertVariant.warning}
@@ -42,11 +42,12 @@ export const EnvironmentErrors: React.FC<EnvironmentErrorsProps> = ({
             'ai:It seems the Central infrastructure management is not configured which will prevent its features to be used. Please refer to the documentation for the first time setup steps.',
           )}
         </Alert>
+      ) : (
+        <SingleResourceAlerts
+          title={t('ai:Failing infrastructure environment')}
+          conditions={infraEnvAlerts}
+        />
       )}
-      <SingleResourceAlerts
-        title={t('ai:Failing infrastructure environment')}
-        conditions={infraEnvAlerts}
-      />
-    </>
+    </ModalBody>
   );
 };


### PR DESCRIPTION
https://redhat.atlassian.net/browse/MGMT-24973


Before:
<img width="1920" height="1002" alt="image" src="https://github.com/user-attachments/assets/82ada2fd-2417-4b8b-ae58-3628ccf251a6" />

After:
<img width="1920" height="1002" alt="image" src="https://github.com/user-attachments/assets/b0814858-efde-4505-b107-ce56dfda8bf7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved infrastructure environment error messaging by showing resource alerts only when an environment has a status.
  * Displays an unconfigured-environment warning when no status is available.
  * Improved modal content layout for clearer presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->