### PR TITLE
AGENT-1570: Remove CustomNoUpgrade featureSet and NoRegistryClusterInstall feature gate

### DIFF
--- a/libs/ui-lib/lib/common/api/assisted-service/ClustersAPI.ts
+++ b/libs/ui-lib/lib/common/api/assisted-service/ClustersAPI.ts
@@ -247,12 +247,6 @@ const ClustersAPI = {
       params,
     );
   },
-
-  updateInstallConfig(clusterId: Cluster['id'], config: string) {
-    return client.patch(`${ClustersAPI.makeBaseURI(clusterId)}/install-config`, config, {
-      headers: { 'Content-Type': 'application/json' },
-    });
-  },
 };
 
 export default ClustersAPI;

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
@@ -16,7 +16,6 @@ import {
   SecurityFields,
   useAlerts,
   useFormikAutoSave,
-  ClustersAPI,
   useTranslation,
 } from '../../../../common';
 import { useDefaultConfiguration } from '../ClusterDefaultConfigurationContext';
@@ -47,7 +46,6 @@ import {
   V2ClusterUpdateParams,
 } from '@openshift-assisted/types/assisted-installer-service';
 import { useNewFeatureSupportLevel } from '../../../../common/components/newFeatureSupportLevels';
-import { useFeature } from '../../../hooks/use-feature';
 
 const NetworkConfigurationForm: React.FC<{
   cluster: Cluster;
@@ -68,9 +66,6 @@ const NetworkConfigurationForm: React.FC<{
     useFormikContext<NetworkConfigurationValues>();
   const isAutoSaveRunning = useFormikAutoSave();
   const errorFields = getFormikErrorFields(errors, touched);
-  const isSingleClusterFeatureEnabled = useFeature('ASSISTED_INSTALLER_SINGLE_CLUSTER_FEATURE');
-  const { addAlert } = useAlerts();
-  const dispatch = useDispatch();
 
   // DHCP allocation is currently not supported for Nutanix hosts
   // https://issues.redhat.com/browse/MGMT-12382
@@ -85,33 +80,9 @@ const NetworkConfigurationForm: React.FC<{
     }
   }, [isHostsPlatformTypeNutanix, setFieldValue, values.vipDhcpAllocation]);
 
-  const onNext = React.useCallback(async () => {
-    if (isSingleClusterFeatureEnabled) {
-      try {
-        await ClustersAPI.updateInstallConfig(
-          cluster.id,
-          JSON.stringify(
-            JSON.stringify({
-              featureSet: 'CustomNoUpgrade',
-              featureGates: ['NoRegistryClusterInstall=true'],
-            }),
-          ),
-        );
-      } catch (e) {
-        handleApiError(e, () =>
-          addAlert({
-            title: 'Failed to update install-config',
-            message: getApiErrorMessage(e),
-          }),
-        );
-        if (isUnknownServerError(e as Error)) {
-          dispatch(setServerUpdateError());
-        }
-        return;
-      }
-    }
+  const onNext = React.useCallback(() => {
     clusterWizardContext.moveNext();
-  }, [addAlert, cluster.id, clusterWizardContext, dispatch, isSingleClusterFeatureEnabled]);
+  }, [clusterWizardContext]);
 
   const footer = (
     <ClusterWizardFooter
@@ -125,7 +96,7 @@ const NetworkConfigurationForm: React.FC<{
         !isValid ||
         !canNextNetwork({ cluster })
       }
-      onNext={() => void onNext()}
+      onNext={onNext}
       onBack={() => clusterWizardContext.moveBack()}
       isBackDisabled={isSubmitting || isAutoSaveRunning}
     />

--- a/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
+++ b/libs/ui-lib/lib/ocm/components/clusterConfiguration/networkConfiguration/NetworkConfigurationForm.tsx
@@ -80,10 +80,6 @@ const NetworkConfigurationForm: React.FC<{
     }
   }, [isHostsPlatformTypeNutanix, setFieldValue, values.vipDhcpAllocation]);
 
-  const onNext = React.useCallback(() => {
-    clusterWizardContext.moveNext();
-  }, [clusterWizardContext]);
-
   const footer = (
     <ClusterWizardFooter
       cluster={cluster}
@@ -96,7 +92,7 @@ const NetworkConfigurationForm: React.FC<{
         !isValid ||
         !canNextNetwork({ cluster })
       }
-      onNext={onNext}
+      onNext={() => clusterWizardContext.moveNext()}
       onBack={() => clusterWizardContext.moveBack()}
       isBackDisabled={isSubmitting || isAutoSaveRunning}
     />


### PR DESCRIPTION
NoRegistryClusterInstall has been promoted to default in 5.0 in the OpenShift API, so it no longer needs to be explicitly enabled via a feature gate. This also removes the CustomNoUpgrade featureSet which was only needed to allow setting that custom feature gate.

Related PRs:
- openshift/machine-config-operator#6396
- openshift/installer#10746

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- The network configuration wizard now advances directly to the next step when selecting **Next**.
- Removed the extra single-cluster configuration update during wizard navigation.
- Eliminated related error alerts and feature-specific behavior from the **Next** action, providing a simpler and more predictable progression through network configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->