### PR TITLE
ART-22057: Move @types/react-dom to dependencies in chatbot

### DIFF
--- a/libs/chatbot/package.json
+++ b/libs/chatbot/package.json
@@ -43,6 +43,7 @@
     "@patternfly/react-icons": "6.3.1",
     "@patternfly/react-styles": "6.3.1",
     "@patternfly/react-tokens": "6.3.1",
+    "@types/react-dom": "^18.3.0",
     "file-saver": "^2.0.2",
     "lodash-es": "^4.17.21",
     "uuid": "^8.1"
@@ -51,7 +52,6 @@
     "@tsconfig/recommended": "^1.0.2",
     "@types/node": "^18.14.6",
     "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.3.0"
   },
   "peerDependencies": {
     "react": "^18",


### PR DESCRIPTION
Move @types/react-dom from devDependencies to dependencies to ensure type definitions are available in production builds.



rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED