### PR TITLE
[ART-22057] move @types/react-dom to dependencies to fix Hermeto

### DIFF
--- a/libs/chatbot/package.json
+++ b/libs/chatbot/package.json
@@ -45,6 +45,7 @@
     "@patternfly/react-tokens": "6.3.1",
     "@redhat-cloud-services/ai-client-state": "^0.15.0",
     "@redhat-cloud-services/lightspeed-client": "^0.15.0",
+    "@types/react-dom": "^18.3.0",
     "file-saver": "^2.0.2",
     "lodash-es": "^4.17.21",
     "uuid": "^8.1"
@@ -52,8 +53,7 @@
   "devDependencies": {
     "@tsconfig/recommended": "^1.0.2",
     "@types/node": "^18.14.6",
-    "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.3.0"
+    "@types/react": "^18.0.0"
   },
   "peerDependencies": {
     "react": "^18",


### PR DESCRIPTION
## Summary
- Move `@types/react-dom` from devDependencies to dependencies to fix Hermeto build issues

## Test plan
- [ ] Verify Hermeto build succeeds with this change
- [ ] Verify no regressions in dev/build workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)